### PR TITLE
Update gsBinomial.R

### DIFF
--- a/R/gsBinomial.R
+++ b/R/gsBinomial.R
@@ -273,7 +273,7 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
   }
   else {
     OR <- exp(-delta0)
-    if (min(abs(p1 / (1 - p1) / p2 * (1 - p2) * OR) - 1) < 1e-07) {
+    if (min(abs(p1 / (1 - p1) / p2 * (1 - p2) * OR - 1)) < 1e-07) {
       stop("p1/(1-p1)/p2*(1-p2) may not equal exp(delta0) when scale=\"OR\"")
     }
     a <- OR - 1


### PR DESCRIPTION
fix typo reported by Dana

It is when the scale is ‘OR’ and the code is checking that the alternate OR or is not too close to the null OR. It is in these lines:
```
if (min(abs(p1 / (1 - p1) / p2 * (1 - p2) * OR) - 1) < 1e-07) {
      stop("p1/(1-p1)/p2*(1-p2) may not equal exp(delta0) when scale=\"OR\"")
    }
```
I believe the lines should rather be:
```
if (min(abs(p1 / (1 - p1) / p2 * (1 - p2) * OR - 1)) < 1e-07) {
      stop("p1/(1-p1)/p2*(1-p2) may not equal exp(delta0) when scale=\"OR\"")
    }
```
