### PR TITLE
Use inherits() to replace is()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,14 +1,10 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -22,64 +18,29 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest", http-user-agent: "R/4.1.0 (ubuntu-20.04) R (4.1.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
 
+      - uses: r-lib/actions/setup-pandoc@v1
+
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: rcmdcheck
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+      - uses: r-lib/actions/check-r-package@v1

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,42 +1,33 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: master
+    branches: [main, master]
+    tags: ['*']
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: macOS-r-4.0-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: macOS-r-4.0-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          install.packages("remotes")
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_dev("pkgdown")
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: pkgdown
+          needs: website
 
       - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,42 +1,29 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
+    branches: [main, master]
 
 name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: macOS-r-4.0-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: macOS-r-4.0-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: covr
 
       - name: Test coverage
         run: covr::codecov()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,21 +1,30 @@
 Package: gsDesign
 Version: 3.2.1.9000
 Title: Group Sequential Design
-Description: Derives group sequential clinical trial designs and describes their properties. Particular focus on time-to-event, binary and continuous outcomes. Largely based on methods described in Jennison, Christopher and Turnbull, Bruce W., 2000, "Group Sequential Methods with Applications to Clinical Trials" ISBN: 0-8493-0316-8. 
+Description: Derives group sequential clinical trial designs and describes
+    their properties. Particular focus on time-to-event, binary, and
+    continuous outcomes. Largely based on methods described in
+    Jennison, Christopher and Turnbull, Bruce W., 2000,
+    "Group Sequential Methods with Applications to Clinical Trials"
+    ISBN: 0-8493-0316-8.
 Authors@R: person(given = "Keaven", family = "Anderson", email =
           "keaven_anderson@merck.com", role = c('aut','cre'))
 Depends: R (>= 3.5.0), ggplot2 (>= 0.9.2)
 License: GPL (>= 3)
-Imports: stats,
-         magrittr,
-         rlang,
-         methods,
-         graphics,
-         tools,
-         dplyr,
-         tidyr,
-         xtable
-Suggests: 
+URL: https://keaven.github.io/gsDesign/, https://github.com/keaven/gsDesign
+BugReports: https://github.com/keaven/gsDesign/issues
+Encoding: UTF-8
+Imports:
+    stats,
+    magrittr,
+    rlang,
+    methods,
+    graphics,
+    tools,
+    dplyr,
+    tidyr,
+    xtable
+Suggests:
     knitr,
     scales,
     rmarkdown,
@@ -28,5 +37,4 @@ Suggests:
     mvtnorm
 VignetteBuilder: knitr
 Copyright: Copyright 2010, Merck Research Laboratories
-RoxygenNote: 7.1.1
-Encoding: UTF-8
+RoxygenNote: 7.1.2

--- a/R/gsCP.R
+++ b/R/gsCP.R
@@ -207,7 +207,7 @@ gsCP <- function(x, theta = NULL, i = 1, zi = 0, r = 18) {
   # as a gsProbability object
   # Inputs: interim theta value and which interim is considered
 
-  if (!(methods::is(x, "gsProbability") || methods::is(x, "gsDesign"))) {
+  if (!(inherits(x, "gsProbability") || inherits(x, "gsDesign"))) {
     stop("gsCP must be called with class of x either gsProbability or gsDesign")
   }
 
@@ -215,7 +215,7 @@ gsCP <- function(x, theta = NULL, i = 1, zi = 0, r = 18) {
     stop("gsCP must be called with i from 1 to x$k-1")
   }
 
-  test.type <- ifelse(methods::is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
 
   if (zi > x$upper$bound[i]) {
     stop("gsCP must have x$lower$bound[i] <= zi <= x$upper$bound[i]")
@@ -259,10 +259,10 @@ gsCP <- function(x, theta = NULL, i = 1, zi = 0, r = 18) {
 #' @rdname gsCP
 # gsPP function [sinew] ----
 gsPP <- function(x, i = 1, zi = 0, theta = c(0, 3), wgts = c(.5, .5), r = 18, total = TRUE) {
-  if (!(methods::is(x, "gsProbability") || methods::is(x, "gsDesign"))) {
+  if (!(inherits(x, "gsProbability") || inherits(x, "gsDesign"))) {
     stop("gsPP: class(x) must be gsProbability or gsDesign")
   }
-  test.type <- ifelse(methods::is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
   checkScalar(i, "integer", c(1, x$k - 1))
   checkScalar(zi, "numeric", c(-Inf, Inf), c(FALSE, FALSE))
   checkVector(wgts, "numeric", c(0, Inf), c(TRUE, FALSE))
@@ -284,7 +284,7 @@ gsPP <- function(x, i = 1, zi = 0, theta = c(0, 3), wgts = c(.5, .5), r = 18, to
 #' @rdname gsCP
 # gsPI function [sinew] ----
 gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c(.5, .5)) {
-  if (!(methods::is(x, "gsProbability") || methods::is(x, "gsDesign"))) {
+  if (!(inherits(x, "gsProbability") || inherits(x, "gsDesign"))) {
     stop("gsPI: class(x) must be gsProbability or gsDesign")
   }
   checkScalar(i, "integer", c(1, x$k - 1))
@@ -364,7 +364,7 @@ gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c
 #' @rdname gsBoundCP
 # gsBoundCP function [sinew] ----
 gsBoundCP <- function(x, theta = "thetahat", r = 18) {
-  if (!(methods::is(x, "gsProbability") || methods::is(x, "gsDesign"))) {
+  if (!(inherits(x, "gsProbability") || inherits(x, "gsDesign"))) {
     stop("gsPI: class(x) must be gsProbability or gsDesign")
   }
   checkScalar(r, "integer", c(1, 70))
@@ -373,7 +373,7 @@ gsBoundCP <- function(x, theta = "thetahat", r = 18) {
   }
 
   len <- x$k - 1
-  test.type <- ifelse(methods::is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
 
   if (theta != "thetahat") {
     thetahi <- rep(theta, len)
@@ -402,7 +402,6 @@ gsBoundCP <- function(x, theta = "thetahat", r = 18) {
 # gsPosterior roxy [sinew] ----
 #' @rdname gsCP
 #' @export
-#' @importFrom methods is
 # gsPosterior function [sinew] ----
 gsPosterior <- function(x = gsDesign(), i = 1, zi = NULL, prior = normalGrid(), r = 18) {
   if (is.null(prior$gridwgts)) prior$gridwgts <- rep(1, length(prior$z))
@@ -410,10 +409,10 @@ gsPosterior <- function(x = gsDesign(), i = 1, zi = NULL, prior = normalGrid(), 
   checkVector(prior$gridwgts, "numeric", c(0, Inf), c(TRUE, FALSE))
   checkVector(prior$density, "numeric", c(0, Inf), c(TRUE, FALSE))
   checkVector(prior$z, "numeric", c(-Inf, Inf), c(FALSE, FALSE))
-  if (!(methods::is(x, "gsProbability") || methods::is(x, "gsDesign"))) {
+  if (!(inherits(x, "gsProbability") || inherits(x, "gsDesign"))) {
     stop("gsPosterior: x must have class gsDesign or gsProbability")
   }
-  test.type <- ifelse(methods::is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
   checkScalar(i, "integer", c(1, x$k - 1))
   if (is.null(zi)) {
     zi <- c(x$lower$bound[i], x$upper$bound[i])
@@ -477,7 +476,7 @@ postfn <- function(x, PP, d, i, zi, j, theta, wgts) {
 #' @rdname gsCP
 # gsPOS function [sinew] ----
 gsPOS <- function(x, theta, wgts) {
-  if (!methods::is(x, c("gsProbability", "gsDesign"))) {
+  if (!inherits(x, c("gsProbability", "gsDesign"))) {
     stop("x must have class gsProbability or gsDesign")
   }
   checkVector(theta, "numeric")
@@ -493,7 +492,7 @@ gsPOS <- function(x, theta, wgts) {
 #' @rdname gsCP
 # gsCPOS function [sinew] ----
 gsCPOS <- function(i, x, theta, wgts) {
-  if (!methods::is(x, c("gsProbability", "gsDesign"))) {
+  if (!inherits(x, c("gsProbability", "gsDesign"))) {
     stop("x must have class gsProbability or gsDesign")
   }
   checkScalar(i, "integer", c(1, x$k), c(TRUE, FALSE))

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -649,7 +649,6 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 #' @export
 #' @aliases print.gsProbability
 #' @rdname gsProbability
-#' @importFrom methods is
 #' @useDynLib gsDesign probrej
 # gsProbability function [sinew] ----
 gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0) {
@@ -660,7 +659,7 @@ gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0
   checkVector(theta, "numeric")
 
   if (k == 0) {
-    if (!methods::is(d, "gsDesign")) {
+    if (!inherits(d, "gsDesign")) {
       stop("d should be an object of class gsDesign")
     }
     return(gsDProb(theta = theta, d = d))

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -504,7 +504,7 @@ plotgsCP <- function(x, theta = "thetahat", main = "Conditional power at interim
     ntx <- "n="
     if (is.null(xlab)) xlab <- "N"
   }
-  test.type <- ifelse(is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
   if (is.null(legtext)) legtext <- gsLegendText(test.type)
   y <- gsBoundCP(x, theta = theta)
   ymax <- 1.05
@@ -668,7 +668,7 @@ plotsf <- function(x,
   if (length(lwd) == 1) lwd <- rep(lwd, 2)
 
   # K. Wills (GSD-31)
-  if (is(x, "gsProbability")) {
+  if (inherits(x, "gsProbability")) {
     stop("Spending function plot not available for gsProbability object")
   }
 
@@ -744,11 +744,11 @@ plotsf <- function(x,
 # plotASN function [sinew] ----
 plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval = NULL, type = "l",
                     base = FALSE, ...) {
-  if (is(x, "gsDesign") && x$n.fix == 1) {
+  if (inherits(x, "gsDesign") && x$n.fix == 1) {
     if (is.null(ylab)) ylab <- "E{N} relative to fixed design"
     if (is.null(main)) main <- "Expected sample size relative to fixed design"
   }
-  else if (is(x, "gsSurv")) {
+  else if (inherits(x, "gsSurv")) {
     if (is.null(ylab)) ylab <- "Expected number of events"
     if (is.null(main)) main <- "Expected number of events by underlying hazard ratio"
   }
@@ -758,7 +758,7 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
   }
 
   if (is.null(theta)) {
-    if (is(x, "gsDesign")) {
+    if (inherits(x, "gsDesign")) {
       theta <- seq(0, 2, .05) * x$delta
     } else {
       theta <- x$theta
@@ -766,9 +766,9 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
   }
 
   if (is.null(xval)) {
-    if (is(x, "gsDesign")) {
+    if (inherits(x, "gsDesign")) {
       xval <- x$delta0 + (x$delta1 - x$delta0) * theta / x$delta
-      if (is(x, "gsSurv")) {
+      if (inherits(x, "gsSurv")) {
         xval <- exp(xval)
         if (is.null(xlab)) xlab <- "Hazard ratio"
       } else if (is.null(xlab)) xlab <- expression(delta)
@@ -778,7 +778,7 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
     }
   }
 
-  x <- if (is(x, "gsDesign")) {
+  x <- if (inherits(x, "gsDesign")) {
     gsProbability(d = x, theta = theta)
   } else {
     gsProbability(k = x$k, a = x$lower$bound, b = x$upper$bound, n.I = x$n.I, theta = theta)
@@ -812,13 +812,13 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
 plotgsPower <- function(x, main = "Boundary crossing probabilities by effect size",
                         ylab = "Cumulative Boundary Crossing Probability",
                         xlab = NULL, lty = NULL, col = NULL, lwd = 1, cex = 1,
-                        theta = if (is(x, "gsDesign")) seq(0, 2, .05) * x$delta else x$theta,
+                        theta = if (inherits(x, "gsDesign")) seq(0, 2, .05) * x$delta else x$theta,
                         xval = NULL, base = FALSE, outtype = 1, ...) {
 
   if (is.null(xval)) {
-    if (is(x, "gsDesign")) {
+    if (inherits(x, "gsDesign")) {
       xval <- x$delta0 + (x$delta1 - x$delta0) * theta / x$delta
-      if (is(x, "gsSurv")) {
+      if (inherits(x, "gsSurv")) {
         xval <- exp(xval)
         if (is.null(xlab)) xlab <- "Hazard ratio"
       } else if (is.null(xlab)) xlab <- expression(delta)
@@ -828,12 +828,12 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     }
   }
   if (is.null(xlab)) xlab <- ""
-  x <- if (is(x, "gsDesign")) {
+  x <- if (inherits(x, "gsDesign")) {
     gsProbability(d = x, theta = theta)
   } else {
     gsProbability(k = x$k, a = x$lower$bound, b = x$upper$bound, n.I = x$n.I, theta = theta)
   }
-  test.type <- ifelse(is(x, "gsProbability"), 3, x$test.type)
+  test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
   theta <- xval
   if (!base && outtype == 1) {
     if (is.null(lty)) lty <- x$k:1
@@ -915,7 +915,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
   itxt <- rep("Interim", x$k - 1)
   itxt <- paste(itxt, 1:(x$k - 1), sep = " ")
 
-  if (is(x, "gsProbability") || (is(x, "gsDesign") && test.type > 1)) {
+  if (inherits(x, "gsProbability") || (inherits(x, "gsDesign") && test.type > 1)) {
     itxt <- c(itxt, "Final", itxt)
     boundprob <- rep(1, length(xval))
     bound <- c(bound, rep(2, length(xval) * (x$k - 1)))
@@ -956,14 +956,14 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     lwd2 <- ifelse(length(lwd) > 1, lwd[2], lwd)
     lty2 <- ifelse(length(lty) > 1, lty[2], lty)
 
-    ylim <- if (is(x, "gsDesign") && test.type <= 2) c(0, 1) else c(0, 1.25)
+    ylim <- if (inherits(x, "gsDesign") && test.type <= 2) c(0, 1) else c(0, 1.25)
 
     graphics::plot(xval, x$upper$prob[1, ],
       xlab = xlab, main = main, ylab = ylab,
       ylim = ylim, type = "l", col = col[1], lty = lty[1], lwd = lwd[1], yaxt = "n"
     )
 
-    if (is(x, "gsDesign") && test.type <= 2) {
+    if (inherits(x, "gsDesign") && test.type <= 2) {
       graphics::axis(2, seq(0, 1, 0.1))
       graphics::axis(4, seq(0, 1, 0.1))
     }
@@ -976,7 +976,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
       return(invisible(x))
     }
 
-    if ((is(x, "gsDesign") && test.type > 2) || !is(x, "gsDesign")) {
+    if ((inherits(x, "gsDesign") && test.type > 2) || !inherits(x, "gsDesign")) {
       graphics::lines(xval, 1 - x$lower$prob[1, ], lty = lty2, col = col2, lwd = lwd2)
       plo <- x$lower$prob[1, ]
 

--- a/R/sequentialPValue.R
+++ b/R/sequentialPValue.R
@@ -61,7 +61,7 @@ sequentialPValue <- function(gsD = gsDesign(),
                              usTime = NULL,
                              interval=c(.00001,.9999)){
   # check that gsD has class "gsDesign" (note: this includes "gsSurv" type)
-  if (!methods::is(gsD, "gsDesign")) stop("d should be an object of class gsDesign or gsSurv")
+  if (!inherits(gsD, "gsDesign")) stop("d should be an object of class gsDesign or gsSurv")
   # check that gsD$test.type is 1,4 or 6
   if(max(gsD$test.type == c(1,4,6)) != 1) stop("gsD$test.type must be 1, 4, or 6 (no binding lower bound allowed)")
   # if n.I not specified, assume planned values used

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,8 @@
+url: https://keaven.github.io/gsDesign/
+
+template:
+  bootstrap: 5
+
 reference:
 - title: Group Sequential Computation
   contents:
@@ -98,6 +103,7 @@ reference:
 - title: Testing multiple hypotheses
   contents:
   - hGraph
+
 articles:
   - title: "Designing for time-to-event endpoints"
     desc: >

--- a/tests/gsDesign_independent_code.R
+++ b/tests/gsDesign_independent_code.R
@@ -1016,7 +1016,6 @@ Validate_comp_sprt_bnd <- function(alpha, beta, p0, p1, nmin, nmax) {
 save_gg_plot <- function(code, width = 4, height = 4) {
   path <- tempfile(fileext = ".png")
   ggsave(path, plot = code, width = width, height = height, dpi = 72, units = "in")
-  code
   path
 }
 
@@ -1029,9 +1028,10 @@ save_gg_plot <- function(code, width = 4, height = 4) {
 save_gr_plot <- function(code, width = 400, height = 400) {
   path <- tempfile(fileext = ".png")
   png(path, width = width, height = height)
-  oldpar <- par(no.readonly = TRUE)    
+  oldpar <- par(no.readonly = TRUE)
   on.exit(par(oldpar))
   code
+  invisible(dev.off())
   path
 }
 #-------------------------------------------------------------------------------

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -14,7 +14,7 @@ testthat::context("base tests")
         # cat("a = ", a, "b = ", b, "\n")
         res <- try(gsDesign(test.type = type, alpha = a, beta = b, sfu = sf))
 
-        if (is(res, "try-error")) {
+        if (inherits(res, "try-error")) {
           no.err <- FALSE
         }
       }
@@ -31,7 +31,7 @@ testthat::context("base tests")
   {
     res <- try(gsDesign(test.type = type, sfu = sf, sfupar = p))
 
-    if (is(res, "try-error")) {
+    if (inherits(res, "try-error")) {
       no.err <- FALSE
     }
   }

--- a/tests/testthat/test-gs_stress.R
+++ b/tests/testthat/test-gs_stress.R
@@ -13,7 +13,7 @@ testthat::context("gs stress")
         # cat("a = ", a, "b = ", b, "\n")
         res <- try(gsDesign(test.type = type, alpha = a, beta = b, sfu = sf))
         
-        if (is(res, "try-error")) {
+        if (inherits(res, "try-error")) {
           no.err <- FALSE
         }
       }
@@ -30,7 +30,7 @@ testthat::context("gs stress")
   {
     res <- try(gsDesign(test.type = type, sfu = sf, sfupar = p))
     
-    if (is(res, "try-error")) {
+    if (inherits(res, "try-error")) {
       no.err <- FALSE
     }
   }

--- a/tests/testthat/test-independent-test-plot.ssrCP.R
+++ b/tests/testthat/test-independent-test-plot.ssrCP.R
@@ -8,7 +8,7 @@ testthat::test_that("Test: plot.ssrCP graphs are correctly rendered ", {
                       overrun = 0, beta = 0.1, cpadj = c(0.5, 1 - 0.2),
                       x = gsDesign(k = 2, delta = 0.2), z2 = z2NC)
 
-  save_plot_obj <- save_gg_plot(plot.ssrCP(x = ssr.cp.des, z1ticks = NULL, 
+  save_plot_obj <- save_gr_plot(plot.ssrCP(x = ssr.cp.des, z1ticks = NULL, 
                                        mar = c(7, 4, 4, 4) + 0.1,
     ylab = "Adapted sample size", xlaboffset = -0.2, lty = 1, col = 1))
 

--- a/tests/testthat/test-independent-test-plotsf.R
+++ b/tests/testthat/test-independent-test-plotsf.R
@@ -49,7 +49,7 @@ test_that(desc = "Test plotsf graphs are correctly rendered,test.type = 5",
   x <- gsDesign(k = 3, test.type = 5, alpha = 0.025, beta = 0.1,
                 delta1 = 0.3, sfu = sfLDOF)
   
-  save_plot_obj <- save_gg_plot(plotsf(x = x, base = TRUE))
+  save_plot_obj <- save_gr_plot(plotsf(x = x, base = TRUE))
   local_edition(3)
   expect_snapshot_file(save_plot_obj, "plotsf_2.png")
   

--- a/vignettes/SurvivalOverview.Rmd
+++ b/vignettes/SurvivalOverview.Rmd
@@ -263,7 +263,7 @@ hrz2n(hr = hr, z = z, ratio = r)
 ## Lachin and Foulkes design
 
 For the purpose of sample size and power for group sequential design, the @LachinFoulkes is based on substantial evaluation not documented further here.
-We try to make clear here what some of the strengths and weaknesses of both the @LachinFoules method as well as its implementation in the `gsDesign::nSurv()` (fixed design) and `gsDesign::gsSurv()` (group sequential) functions.
+We try to make clear here what some of the strengths and weaknesses of both the @LachinFoulkes method as well as its implementation in the `gsDesign::nSurv()` (fixed design) and `gsDesign::gsSurv()` (group sequential) functions.
 For historical and testing purposes, we also discuss use of the less flexible `gsDesign::nSurvival()` function that was independently programmed and can be used for some limited validations of `gsDesign::nSurv()`.
 
 ### Model assumptions

--- a/vignettes/SurvivalOverview.Rmd
+++ b/vignettes/SurvivalOverview.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Overview of survival endpoint design"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 bibliography: gsDesign.bib
 vignette: >
@@ -9,14 +8,13 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include = FALSE}
+```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 
-options( width = 58 )
-
+options(width = 58)
 ```
 
 ## Introduction
@@ -39,7 +37,7 @@ The following functions support use of the very straightforward @Schoenfeld1981 
 - `hrn2z()`: approximate Z-value corresponding to a specified HR and event count.
 - `hrz2n()`: approximate event count corresponding to a specified HR and Z-value.
 
-The above functions do not directly support sample size calculations. 
+The above functions do not directly support sample size calculations.
 This is done with the @LachinFoulkes method. Functions include:
 
 - `nSurvival()`: Sample size restricted to single enrollment rate; single analysis.
@@ -54,7 +52,7 @@ Output for survival design information is supported in various formats:
 
 ## Schoenfeld approximation support
 
-We will assume a hazard ratio $\nu < 1$ represents a benefit of experimental treatment over control. 
+We will assume a hazard ratio $\nu < 1$ represents a benefit of experimental treatment over control.
 We let $\delta = \log\nu$ denote the so-called *natural parameter* for this case.
 Asymptotically the distribution of the Cox model estimate $\hat{\delta}$ under the proportional hazards assumption is
 $$\hat\delta\sim \hbox{Normal}(\delta=\log\nu, (1+r)^2/nr).$$
@@ -64,18 +62,18 @@ Using a Cox model to estimate $\delta$, the Wald test for $\hbox{H_0}: \delta=0$
 $$Z_W\approx \frac{\sqrt {nr}}{1+r}\hat\delta=\frac{\ln(\hat\nu)\sqrt{nr}}{1+r}.$$
 
 
-Also, we know that the Wald test $Z_W$ and a standard normal version of the logrank $Z$ are both asymptotically efficient and therefore asymptotically equivalent. 
+Also, we know that the Wald test $Z_W$ and a standard normal version of the logrank $Z$ are both asymptotically efficient and therefore asymptotically equivalent.
 We denote the *standardized effect size* as
 
 $$\theta = \delta\sqrt r / (1+r)= \log(\nu)\sqrt r / (1+r).$$
 Letting $\hat\theta = -\sqrt r/(1+r)\hat\delta$ we have
 $$ \hat \theta \sim \hbox{Normal}(\theta, 1/ n).$$
-Thus, the standardized Z version of the logrank is approximately distributed as 
+Thus, the standardized Z version of the logrank is approximately distributed as
 
 $$Z\sim\hbox{Normal}(\sqrt n\theta,1).$$
 Treatment effect favoring experimental treatment compared to control in this notation corresponds to a hazard ratio $\nu < 1$, as well as negative values of the standardized effect $\theta$, natural parameter $\delta$ and standardized Z-test.
 
-### Power and sample size with nEvents() 
+### Power and sample size with nEvents()
 
 Based on the above, the power for the logrank test is approximated by
 
@@ -88,13 +86,13 @@ hr <- .7
 delta <- log(hr)
 alpha <- .025
 r <- 1
-pnorm(qnorm(alpha) - sqrt(n*r)/(1+r)*delta)
+pnorm(qnorm(alpha) - sqrt(n * r) / (1 + r) * delta)
 ```
 
 We can compute this with `gsDesign::nEvents()` as:
 
 ```{r}
-nEvents(n=n,alpha=alpha,hr=hr,r=r)
+nEvents(n = n, alpha = alpha, hr = hr, r = r)
 ```
 
 We solve for the number of events $n$ to see how many events are required to obtain a desired power
@@ -108,8 +106,9 @@ Thus, the approximate number of events required to power for HR=0.7 with $\alpha
 
 ```{r}
 beta <- 0.1
-(1+r)^2/r/log(hr)^2 * ((qnorm(1 - alpha) + qnorm(1 - beta)))^2
+(1 + r)^2 / r / log(hr)^2 * ((qnorm(1 - alpha) + qnorm(1 - beta)))^2
 ```
+
 which, rounding up, matches (with tabular output):
 
 ```{r}
@@ -123,13 +122,12 @@ The notation `delta` in the above table changes the sign for the standardized tr
 theta <- delta * sqrt(r) / (1 + r)
 theta
 ```
+
 The `se` in the table is the estimated standard error for the log hazard ratio $\delta=\log\hat\nu$
 
 ```{r}
 (1 + r) / sqrt(331 * r)
 ```
-
-
 
 ### Group sequential design
 
@@ -139,21 +137,22 @@ This example code can be useful in practice.
 We begin by passing the number of events for a fixed design in the parameter `n.fix` (continuous, not rounded) to adapt to a group sequential design.
 
 ```{r}
-Schoenfeld <- gsDesign(k=2, 
-                       n.fix = nEvents(hr = hr, alpha = alpha, beta = beta, r = 1),
-                       delta1 = log(hr))
-Schoenfeld %>% 
-  gsBoundSummary(deltaname = "HR", logdelta = TRUE) %>% 
+Schoenfeld <- gsDesign(
+  k = 2,
+  n.fix = nEvents(hr = hr, alpha = alpha, beta = beta, r = 1),
+  delta1 = log(hr)
+)
+Schoenfeld %>%
+  gsBoundSummary(deltaname = "HR", logdelta = TRUE) %>%
   kable(row.names = FALSE)
 ```
 
 ### Information based design
 
-Exactly the same result can be obtained with the following, passing the standardized effect size `theta` from above to the parameter `delta` in `gsDesign()`.  
- 
+Exactly the same result can be obtained with the following, passing the standardized effect size `theta` from above to the parameter `delta` in `gsDesign()`.
 
 ```{r, eval=FALSE}
-Schoenfeld <- gsDesign(k=2, delta = -theta, delta1 = log(hr))
+Schoenfeld <- gsDesign(k = 2, delta = -theta, delta1 = log(hr))
 ```
 
 We noted above that the asymptotic variance for $\hat\theta$ is $1/n$ which corresponds to statistical information $\mathcal I=n$ for the parameter $\theta$.
@@ -162,33 +161,32 @@ Thus, the value
 ```{r}
 Schoenfeld$n.I
 ```
+
 corresponds both to the number of events and the statistical information for the standardized effect size $\theta$ required to power the trial at the desired level.
 Note that if you plug in the natural parameter $\delta= -\log\nu > 0$, then $n.I$ returns the statistical information for the log hazard ratio.
 
 ```{r}
-gsDesign(k=2, delta = -log(hr))$n.I
+gsDesign(k = 2, delta = -log(hr))$n.I
 ```
-The reader may wish to look above to derive the exact relationship between events and statistical information for $\delta$.
 
+The reader may wish to look above to derive the exact relationship between events and statistical information for $\delta$.
 
 ### Approximating boundary characteristics
 
-Another application of the @Schoenfeld1981 method is to approximate boundary characteristics of a design. As noted in the introduction above, we will consider `zn2hr()`, `gsHR()` and `gsBoundSummary()` to approximate the treatment effect required to cross design bounds. 
+Another application of the @Schoenfeld1981 method is to approximate boundary characteristics of a design. As noted in the introduction above, we will consider `zn2hr()`, `gsHR()` and `gsBoundSummary()` to approximate the treatment effect required to cross design bounds.
 `zn2hr()` is complemented by the functions `hrn2z()` and `hrz2n()`.
 We begin with the basic approximation used across all of these functions in this section and follow with a sub-section with example code to reproduce some of what is in the table above.
 
 We return to the following equation from above:
 
 $$Z\approx Z_W\approx \frac{\sqrt {nr}}{1+r}\hat\delta=\frac{\ln(\hat\nu)\sqrt{nr}}{1+r}.$$
-By fixing $Z=z, n$ we can solve for $\hat\nu$ from the above: 
+By fixing $Z=z, n$ we can solve for $\hat\nu$ from the above:
 
 $$\hat{\nu} = \exp(z(1+r)/\sqrt{rn}).$$
 By fixing $\hat\nu$ and $z$, we can solve for the corresponding number of events required:
 $$ n = (z(1+r)/\log(\hat{\nu}))^2/r.$$
 
 ### Examples
-
-
 
 For our first example, we note that the event counts in `Schoenfeld` are actually continuous numbers that are rounded up in the table:
 
@@ -199,12 +197,13 @@ Schoenfeld$n.I
 We reproduce the approximate hazard ratios required to cross efficacy bounds using the Schoenfeld approximations above:
 
 ```{r}
-gsHR(z = Schoenfeld$upper$bound, # Z-values at bound
-     i = 1:2,                    # Analysis number
-     x = Schoenfeld,             # Group sequential design from above
-     ratio = r)                  # Experimental/control randomization ratio
+gsHR(
+  z = Schoenfeld$upper$bound, # Z-values at bound
+  i = 1:2, # Analysis number
+  x = Schoenfeld, # Group sequential design from above
+  ratio = r # Experimental/control randomization ratio
+)
 ```
-
 
 For the following examples, we assume $r=1$.
 
@@ -212,20 +211,20 @@ For the following examples, we assume $r=1$.
 r <- 1
 ```
 
-
 1) Assuming a Cox model estimate $\hat\nu$ and a corresponding event count, approximately what Z-value (p-value) does this correspond to? We use the first equation above:
 
 ```{r}
-hr <- .73 # observed hr
+hr <- .73 # Observed hr
 events <- 125 # Events in analysis
 
-z <- log(hr) * sqrt(events*r) / (1+r)
+z <- log(hr) * sqrt(events * r) / (1 + r)
 c(z, pnorm(z)) # Z- and p-value
 ```
 
 We replicate the Z-value with
+
 ```{r}
-hrn2z(hr=hr, n = events, ratio = r)
+hrn2z(hr = hr, n = events, ratio = r)
 ```
 
 2) Assuming an efficacy bound Z-value and event count, approximately what hazard ratio must be observed to cross the bound? We use the second equation above:
@@ -239,7 +238,7 @@ exp(z * (1 + r) / sqrt(r * events))
 We can reproduce this with `zn2hr()` by switching the sign of `z` above; note that the default is `ratio = 1` for all of these functions and often is not specified:
 
 ```{r}
-zn2hr(z = -z, n = events,  ratio = r)
+zn2hr(z = -z, n = events, ratio = r)
 ```
 
 3) Finally, if we want an observed hazard ratio $\hat\nu = .8$ to represent a positive result, how many events would be need to observe to achieve a 1-sided p-value of 0.025? assuming 2:1 randomization? We use the third equation above:
@@ -252,13 +251,11 @@ events <- (z * (1 + r) / log(hr))^2 / r
 events
 ```
 
-
 This is replicated with
 
 ```{r}
 hrz2n(hr = hr, z = z, ratio = r)
 ```
-
 
 ## Lachin and Foulkes design
 
@@ -268,7 +265,7 @@ For historical and testing purposes, we also discuss use of the less flexible `g
 
 ### Model assumptions
 
-Some detail in specification comes With the flexibility allowed by the @LachinFoulkes method. 
+Some detail in specification comes With the flexibility allowed by the @LachinFoulkes method.
 The model assumes
 
 - A fixed enrollment period with piecewise constant enrollment rates
@@ -279,15 +276,15 @@ The model assumes
 - A stratified population
 - A fixed randomization ratio of experimental to control group assignment
 
-Other than the proportional hazards assumption, this allows a great deal of flexibility in trial design assumptions. 
+Other than the proportional hazards assumption, this allows a great deal of flexibility in trial design assumptions.
 While @LachinFoulkes adjusts the piecewise constant enrollment rates proportionately to derive a sample size, `gsDesign$nSurv()` also enables the approach of @KimTsiatis which fixes enrollment rates and extends the final enrollment rate duration to power the trial; the minimum follow-up period is still assumed this approach.
 We do not enable the drop-in option proposed in @LachinFoulkes.
 
 The two practical differences the @LachinFoulkes method has from the @Schoenfeld1981 method are:
 
 1) By assuming enrollment, failure and dropout rates the method delivers sample size $N$ as well as events required.
-2) The variance for the log hazard ratio $\hat\delta$ is computed differently and both a null ($\sigma^2_0) and alternate hypothesis ($\sigma^2_1$) variance are incorporated through the formula
-$$ N  = \left(\frac{\Phi^{-1}(1-\alpha)\sigma_0 + \Phi^{-1}(1-\beta)\sigma_1}{\delta}\right).$$
+2) The variance for the log hazard ratio $\hat\delta$ is computed differently and both a null ($\sigma^2_0$) and alternate hypothesis ($\sigma^2_1$) variance are incorporated through the formula
+$$N = \left(\frac{\Phi^{-1}(1-\alpha)\sigma_0 + \Phi^{-1}(1-\beta)\sigma_1}{\delta}\right).$$
 The null hypothesis is derived by averaging the alternate hypothesis rates, weighting according to the proportion randomized in each group.
 
 ### Fixed design
@@ -296,26 +293,28 @@ We will use the same hazard ratio 0.7 as for the @Schoenfeld1981 sample size cal
 We assume further that the trial will enroll for a constant rate for 12 months, have a control group median of 8 months (exponential failure rate $\lambda = \log(2)/8$), a dropout rate of 0.001 per month, and 16 months of minimum follow-up. As before, we assume a randomization ratio $r=1$, one-sided Type I error $\alpha=0.025$, 90% power which is equivalent to Type II error $\beta=0.1$.
 
 ```{r}
-r <- 1               # Experimental/control randomization ratio
-alpha <- 0.025       # 1-sided Type I error
-beta <- 0.1          # Type II error (1 - power)
-hr <- 0.7            # Hazard ratio (experimental / control)
+r <- 1 # Experimental/control randomization ratio
+alpha <- 0.025 # 1-sided Type I error
+beta <- 0.1 # Type II error (1 - power)
+hr <- 0.7 # Hazard ratio (experimental / control)
 controlMedian <- 8
 dropoutRate <- 0.001 # Exponential dropout rate per time unit
 enrollDuration <- 12
-minfup <- 16         # minimum follow-up
-Nlf <- nSurv(lambdaC = log(2) / controlMedian,
-             hr = hr,
-             eta = dropoutRate,
-             T = enrollDuration + minfup, # Trial duration
-             minfup = minfup,
-             ratio = r,
-             alpha = alpha, 
-             beta = beta
-      )
+minfup <- 16 # Minimum follow-up
+Nlf <- nSurv(
+  lambdaC = log(2) / controlMedian,
+  hr = hr,
+  eta = dropoutRate,
+  T = enrollDuration + minfup, # Trial duration
+  minfup = minfup,
+  ratio = r,
+  alpha = alpha,
+  beta = beta
+)
 cat(paste("Sample size: ", ceiling(Nlf$n), "Events: ", ceiling(Nlf$d), "\n"))
 ```
-Recall that the @Schoenfeld1981 method recommended 
+
+Recall that the @Schoenfeld1981 method recommended
 `r ceiling(nEvents(hr=hr, alpha=alpha, beta=beta, ratio=r))` events. The two methods tend to yield very similar event count recommendations, but not the same. Other methods will also differ slightly; see @LachinFoulkes. Sample size recommendations can vary more between methods.
 
 We can get the same result with the `nSurvival()` routine since only a single enrollment, failure and dropout rate is proposed for this example.
@@ -334,23 +333,24 @@ nSurvival(
 )
 ```
 
-
-
 ### Group sequential design
 
 ```{r}
-k <- 2  # Total number of analyses
-lfgs <- gsSurv(k=2,
-             lambdaC = log(2) / controlMedian,
-             hr = hr,
-             eta = dropoutRate,
-             T = enrollDuration + minfup, # Trial duration
-             minfup = minfup,
-             ratio = r,
-             alpha = alpha, 
-             beta = beta
-      )
-lfgs %>% gsBoundSummary() %>% kable(row.names = FALSE)
+k <- 2 # Total number of analyses
+lfgs <- gsSurv(
+  k = 2,
+  lambdaC = log(2) / controlMedian,
+  hr = hr,
+  eta = dropoutRate,
+  T = enrollDuration + minfup, # Trial duration
+  minfup = minfup,
+  ratio = r,
+  alpha = alpha,
+  beta = beta
+)
+lfgs %>%
+  gsBoundSummary() %>%
+  kable(row.names = FALSE)
 ```
 
 Although we did not use the @Schoenfeld1981 for sample size, it is still used for the approximate HR at bound calculation above:
@@ -360,25 +360,27 @@ events <- lfgs$n.I
 z <- lfgs$upper$bound
 zn2hr(z = z, n = events) # Schoenfeld approximation to HR
 ```
+
 ### Plotting
 
 There are various plots available. The approximate hazard ratios required to cross bounds again use the @Schoenfeld1981 approximation. For a **ggplot2** version of this plot, use the default `base = FALSE`.
 
 ```{r,fig.width=6.5, fig.height=4}
-plot(lfgs, pl="hr", dgt=4, base=TRUE)
+plot(lfgs, pl = "hr", dgt = 4, base = TRUE)
 ```
-
 
 ### Event accrual
 
-The variance calculations for the Lachin and Foulkes method are mostly determined by expected event accrual under the null and alternate hypotheses. 
+The variance calculations for the Lachin and Foulkes method are mostly determined by expected event accrual under the null and alternate hypotheses.
 The null hypothesis characterized above is seemingly designed so that event accrual will be similar under each hypothesis.
 You can see the expected events accrued at each analysis under the alternate hypothesis with:
 
 ```{r}
-tibble::tibble(Analysis = 1:2, 
-               `Control events` = lfgs$eDC, 
-               `Experimental events` =  lfgs$eDE) %>%
+tibble::tibble(
+  Analysis = 1:2,
+  `Control events` = lfgs$eDC,
+  `Experimental events` = lfgs$eDE
+) %>%
   kable()
 ```
 
@@ -389,23 +391,28 @@ The expected event accrual of events over time for a design can be computed as f
 
 ```{r, fig.width=6.5, fig.height=4}
 Month <- seq(0.025, enrollDuration + minfup, .025)
-plot(c(0,Month), 
-     c(0, sapply(Month, function(x){nEventsIA(tIA=x, x = lfgs)})), 
-     type = 'l', xlab="Month", ylab="Expected events",
-     main="Expected event accrual over time")
+plot(
+  c(0, Month),
+  c(0, sapply(Month, function(x) {
+    nEventsIA(tIA = x, x = lfgs)
+  })),
+  type = "l", xlab = "Month", ylab = "Expected events",
+  main = "Expected event accrual over time"
+)
 ```
 
 On the other hand, if you want to know the expected time to accrue 25% of the final events and what the expected enrollment accrual is at that time, you compute using:
 
 ```{r}
 b <- tEventsIA(x = lfgs, timing = 0.25)
-cat(paste(" Time: ", b$T, 
-          "\n Expected enrollment:", b$eNC + b$eNE,
-          "\n Expected control events:", b$eDC,
-          "\n Expected experimental events:", b$eDE, "\n"))
+cat(paste(
+  " Time: ", b$T,
+  "\n Expected enrollment:", b$eNC + b$eNE,
+  "\n Expected control events:", b$eDC,
+  "\n Expected experimental events:", b$eDE, "\n"
+))
 ```
 
 For expected accrual of events without a design returned by `gsDesign::gsSurv()`, see the help file for `gsDesign::eEvents()`.
 
 ## References
-

--- a/vignettes/gsSurvBasicExamples.Rmd
+++ b/vignettes/gsSurvBasicExamples.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Basic time-to-event group sequential design using gsSurv"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 bibliography: gsDesign.bib
 vignette: >
@@ -9,21 +8,20 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include = FALSE}
+```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 
-options( width = 58 )
-
+options(width = 58)
 ```
 
 # Introduction
 
 This article/vignette provides a basic time-to-event endpoint designs for fixed designs using `nSurv()` and group sequential designs using `gsSurv()`.
 Some detail in specification comes with the flexibility allowed by the @LachinFoulkes method for sample size under a proportional hazards model with piecewise constant enrollment, piecewise exponential failure and dropout rates.
-Users may also be interested in the [Shiny interface](https://gsdesign.shinyapps.io/prod/) as a learning tool. 
+Users may also be interested in the [Shiny interface](https://gsdesign.shinyapps.io/prod/) as a learning tool.
 We only use the simplest options here with a single stratum and exponential failure and dropout rates; see the help file for `gsSurv()` for examples with a stratified population or piecewise exponential failure.
 
 We apply the @LachinFoulkes sample size method and extend it to group sequential design.
@@ -39,14 +37,14 @@ Since the parameters used for a design with no interim are also used for a group
 We begin with information about the median time-to-event in the control group, dropout rate, hazard ratios under the null and alternate hypotheses for experimental therapy compared to control, and the desired Type I and II error rates.
 
 ```{r}
-# median control time-to-event
+# Median control time-to-event
 median <- 12
-# exponential dropout rate per unit of time
+# Exponential dropout rate per unit of time
 eta <- .001
-# hypothesized experimental/control hazard ratio 
+# Hypothesized experimental/control hazard ratio
 # (alternate hypothesis)
 hr <- .75
-# null hazard ratio (1 for superiority, >1 for non-inferiority)
+# Null hazard ratio (1 for superiority, >1 for non-inferiority)
 hr0 <- 1
 # Type I error (1-sided)
 alpha <- .025
@@ -62,15 +60,15 @@ The @LachinFoulkes method demonstrated here fixes the enrollment pattern and dur
 The alternate recommended method is along the lines of @KimTsiatis, fixing the enrollment rates and follow-up duration, varying the total trial duration to power the design; this will also be demonstrated below.
 
 ```{r,message=FALSE}
-# study duration
-T <- 36 
-# follow-up duration of last patient enrolled
+# Study duration
+T <- 36
+# Follow-up duration of last patient enrolled
 minfup <- 12
-# enrollment period durations
-R <- c(1,2,3,4)
-# relative enrollment rates during above periods
-gamma <- c(1,1.5,2.5,4)
-# randomization ratio, experimental/control
+# Enrollment period durations
+R <- c(1, 2, 3, 4)
+# Relative enrollment rates during above periods
+gamma <- c(1, 1.5, 2.5, 4)
+# Randomization ratio, experimental/control
 ratio <- 1
 ```
 
@@ -80,18 +78,21 @@ The above information is sufficient to design a trial with no interim analyses.
 Note that when calling `nSurv()`, we transform the median time-to-event ($m$) to an exponential event rate ($\lambda$) with the formula
 $$\lambda=\log(2)/m.$$
 
-```{r,tidy=FALSE,warning=FALSE}
+```{r, warning=FALSE, message=FALSE}
 library(gsDesign)
-x <- nSurv(R = R,
-           gamma = gamma,
-           eta = eta,
-           minfup = minfup,
-           T = T,
-           lambdaC = log(2)/median,
-           hr = hr,
-           hr0 = hr0,
-           beta = beta,
-           alpha = alpha)
+
+x <- nSurv(
+  R = R,
+  gamma = gamma,
+  eta = eta,
+  minfup = minfup,
+  T = T,
+  lambdaC = log(2) / median,
+  hr = hr,
+  hr0 = hr0,
+  beta = beta,
+  alpha = alpha
+)
 ```
 
 A textual summary of this design is given by printing it.
@@ -106,27 +107,27 @@ x
 If we had set `T = NULL` above, the specified enrollment rates would not be changed but enrollment duration would be adjusted to achieve desired power.
 For the low enrollment rates specified in `gamma` above, this would have resulted in a long trial.
 
-
 ```{r,eval=FALSE}
 # THIS CODE IS EXAMPLE ONLY; NOT EXECUTED HERE
-nSurv(R = R,
-   gamma = gamma,
-   eta = eta,
-   minfup = minfup,
-   T = NULL, # this was changed
-   lambdaC = log(2)/median,
-   hr = hr,
-   hr0 = hr0,
-   beta = beta,
-   alpha = alpha)
+nSurv(
+  R = R,
+  gamma = gamma,
+  eta = eta,
+  minfup = minfup,
+  T = NULL, # This was changed
+  lambdaC = log(2) / median,
+  hr = hr,
+  hr0 = hr0,
+  beta = beta,
+  alpha = alpha
+)
 ```
 
-
-# Group sequential design 
+# Group sequential design
 
 Now we move on to a group sequential design.
 
-## Additional parameters 
+## Additional parameters
 
 All the parameters above are used.
 We set up the number of analyses, timing and spending function parameters.
@@ -143,41 +144,41 @@ Here the choices considered the following:
     - The Lan-DeMets spending function approximating an O'Brien-Fleming bound @LanDeMets is often acceptable to regulators for early stopping
 
 ```{r}
-# number of analyses (interim + final)
+# Number of analyses (interim + final)
 k <- 3
-# timing of interim analyses (k-1 increasing numbers >0 and <1)
-# proportion of final events at each interim
-timing <- c(.25,.75)
-# efficacy bound spending function
-# We use Lan-DeMets spending function approximating O'Brien-Fleming bound
-# no parameter required for this spending function
+# Timing of interim analyses (k-1 increasing numbers >0 and <1).
+# Proportion of final events at each interim.
+timing <- c(.25, .75)
+# Efficacy bound spending function.
+# We use Lan-DeMets spending function approximating O'Brien-Fleming bound.
+# No parameter required for this spending function.
 sfu <- sfLDOF
 sfupar <- NULL
-# futility bound spending function
-sfl <- sfHSD 
-# futility bound spending parameter specification
+# Futility bound spending function
+sfl <- sfHSD
+# Futility bound spending parameter specification
 sflpar <- -7
 ```
-
 
 Type II error (1-power) may be set up differently than for a fixed design so that more meaningful futility analyses can be performed during the course of the trial.
 
 ```{r}
-# Type II error = 1-Power
+# Type II error = 1 - Power
 beta <- .15
 ```
-
 
 ## Generating the design
 
 Now we are prepared to generate the design.
 
-```{r,tidy=FALSE}
-# generate design
-x <- gsSurv(k = k, timing = timing, R = R, gamma = gamma, eta = eta,
-            minfup = minfup,T = T, lambdaC = log(2) / median,
-            hr = hr, hr0 = hr0 , beta = beta, alpha = alpha,
-            sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar)
+```{r}
+# Generate design
+x <- gsSurv(
+  k = k, timing = timing, R = R, gamma = gamma, eta = eta,
+  minfup = minfup, T = T, lambdaC = log(2) / median,
+  hr = hr, hr0 = hr0, beta = beta, alpha = alpha,
+  sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar
+)
 ```
 
 ## Textual summary
@@ -197,51 +198,61 @@ Following are the enrollment rates required to power the trial.
 ```{r,warning=FALSE}
 library(gt)
 library(tibble)
-tibble(Period = paste("Month",rownames(x$gamma)),
-       Rate = as.numeric(x$gamma)) %>% 
-  gt() %>% tab_header(title = "Enrollment rate requirements")
+
+tibble(
+  Period = paste("Month", rownames(x$gamma)),
+  Rate = as.numeric(x$gamma)
+) %>%
+  gt() %>%
+  tab_header(title = "Enrollment rate requirements")
 ```
 
 Next we provide a tabular summary of bounds for the design.
-We have added extensive footnoting to the table, which may or may not be required for your design. However, as seen here it makes many choices for design parameters and properties transparent. 
+We have added extensive footnoting to the table, which may or may not be required for your design. However, as seen here it makes many choices for design parameters and properties transparent.
 No attempt has been made to automate this, but it may be worth considering for a template if you wish to make the same choice across many trials.
 Note that the `exclude` argument for `gsBoundSummary()` allows additional descriptions for design bounds such as conditional or predictive power; see the help file for details or just provide `exclude = NULL` to `gsBoundSummary()` to see all options.
 
 ```{r}
-# footnote text for table
+# Footnote text for table
 footnote1 <- "P{Cross} is the probability of crossing the given bound (efficacy or futility) at or before the given analysis under the assumed hazard ratio (HR)."
 footnote2 <- " Design assumes futility bound is discretionary (non-binding); upper boundary crossing probabilities shown here assume trial stops at first boundary crossed and thus total less than the design Type I error."
 footnoteHR <- "HR presented is not a requirement, but an estimate of approximately what HR would be required to cross each bound."
 footnoteM <- "Month is approximated given enrollment and event rate assumptions under alternate hypothesis."
-# spending function footnotes
-footnoteUS <-"Efficacy bound set using Lan-DeMets spending function approximating an O'Brien-Fleming bound."
-footnoteLS <- paste("Futility bound set using ",x$lower$name," beta-spending function with ", 
-                    x$lower$parname,"=",x$lower$param,".",sep = "")
-# caption text for table
-caption <- paste("Overall survival trial design with HR=",hr,", ",100*(1-beta),"% power and ",100*alpha,"% Type 1 error",sep = "")
+
+# Spending function footnotes
+footnoteUS <- "Efficacy bound set using Lan-DeMets spending function approximating an O'Brien-Fleming bound."
+footnoteLS <- paste(
+  "Futility bound set using ", x$lower$name, " beta-spending function with ",
+  x$lower$parname, "=", x$lower$param, ".",
+  sep = ""
+)
+
+# Caption text for table
+caption <- paste(
+  "Overall survival trial design with HR=", hr, ", ",
+  100 * (1 - beta), "% power and ",
+  100 * alpha, "% Type I error",
+  sep = ""
+)
 ```
 
-
-
-
-```{r, echo=TRUE,message=FALSE,tidy=FALSE}
-gsBoundSummary(x) %>% 
+```{r, echo=TRUE,message=FALSE}
+gsBoundSummary(x) %>%
   gt() %>%
-  tab_header(title = "Time-to-event group sequential design") %>% 
+  tab_header(title = "Time-to-event group sequential design") %>%
   cols_align("left") %>%
-  tab_footnote(footnoteUS,locations = cells_column_labels(columns = 3)) %>% 
-  tab_footnote(footnoteLS,locations = cells_column_labels(columns = 4)) %>% 
-  tab_footnote(footnoteHR,locations = cells_body(columns = 2,rows = c(3,8,13))) %>% 
-  tab_footnote(footnoteM,locations = cells_body(columns = 1,rows = c(4,9,14))) %>% 
-  tab_footnote(footnote1,locations = cells_body(columns = 2,rows = c(4,5,9,10,14,15))) %>% 
-  tab_footnote(footnote2,locations = cells_body(columns = 2,rows = c(4,9,14)))
+  tab_footnote(footnoteUS, locations = cells_column_labels(columns = 3)) %>%
+  tab_footnote(footnoteLS, locations = cells_column_labels(columns = 4)) %>%
+  tab_footnote(footnoteHR, locations = cells_body(columns = 2, rows = c(3, 8, 13))) %>%
+  tab_footnote(footnoteM, locations = cells_body(columns = 1, rows = c(4, 9, 14))) %>%
+  tab_footnote(footnote1, locations = cells_body(columns = 2, rows = c(4, 5, 9, 10, 14, 15))) %>%
+  tab_footnote(footnote2, locations = cells_body(columns = 2, rows = c(4, 9, 14)))
 ```
 
 ## Summary plots
 
-Several plots are available to summarize a design; see help for `plot.gsDesign()`; one easy way to see how to generate each is by checking plots and code generated by the [Shiny interface](https://gsdesign.shinyapps.io/prod/). 
+Several plots are available to summarize a design; see help for `plot.gsDesign()`; one easy way to see how to generate each is by checking plots and code generated by the [Shiny interface](https://gsdesign.shinyapps.io/prod/).
 The power plot is information-rich, but also requires some explanation; thus, we demonstrate here.
-
 
 The solid black line represents the trial power by effect size.
 Power at interim 1 is represented by the black dotted line.
@@ -252,7 +263,8 @@ The red dashed line is 1 minus the cumulative probability of crossing the futili
 ```{r, fig.height=3.5,fig.width=7,warning=FALSE,message=FALSE}
 library(ggplot2)
 library(scales)
-plot(x,plottype = "power",cex = .8,xlab = "HR") + 
+
+plot(x, plottype = "power", cex = .8, xlab = "HR") +
   scale_y_continuous(labels = scales::percent)
 ```
 
@@ -267,42 +279,54 @@ We also present computation of conditional and predictive power.
 First, we update the actual number of events for interims 1 and 2 and assume the final analysis event count is still as originally planned:
 
 ```{r}
-# number of events (final is still planned number)
+# Number of events (final is still planned number)
 n.I <- c(115, 364, ceiling(x$n.I[x$k]))
 ```
 
 The simple updates to Z-values and p-values for the design based on information fraction just requires the fraction of final events planned, but does not include the number of events or treatment effect in the output:
 
 ```{r}
-xu <- gsDesign(alpha = x$alpha, beta = x$beta,
-               maxn.IPlan = x$n.I[x$k], n.I = n.I,
-               sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar,
-               delta = x$delta, delta1 = x$delta1, delta0 = x$delta0)
+xu <- gsDesign(
+  alpha = x$alpha, beta = x$beta,
+  maxn.IPlan = x$n.I[x$k], n.I = n.I,
+  sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar,
+  delta = x$delta, delta1 = x$delta1, delta0 = x$delta0
+)
 ```
-
 
 Now we print the design summary, selecting minimal calculations for a table to provide guidance for review of results.
 If you wish to see all possible summaries of bounds, change to `exclude = NULL` below.
 Here we have assumed futility guidance is based on the hazard ratio at interim analysis; this is not generally the case, but is an option as these bounds are guidance rather than having strict inferential interpretation.
 
-
 ```{r}
-gsBoundSummary(xu,
-               deltaname="HR",
-               logdelta=TRUE,
-               Nname="Events",
-               exclude = c("Spending", "B-value", "CP", "CP H1", 
-                           "PP", "P(Cross) if HR=1","P(Cross) if HR=0.75")) %>%
-  gt() %>% 
+gsBoundSummary(
+  xu,
+  deltaname = "HR",
+  logdelta = TRUE,
+  Nname = "Events",
+  exclude = c(
+    "Spending", "B-value", "CP", "CP H1",
+    "PP", "P(Cross) if HR=1", "P(Cross) if HR=0.75"
+  )
+) %>%
+  gt() %>%
   cols_align("left") %>%
-  tab_header(title = "Time-to-event group sequential bound guidance",
-             subtitle = "Bounds updated based on event counts through IA2") %>% 
-  tab_footnote("Nominal p-value required to establish statistical significance.",
-               locations=cells_body(columns = 3, rows = c(2, 5, 8))) %>% 
-  tab_footnote("Interim futility guidance based on observed HR is non-binding.",
-               locations=cells_body(columns = 4, rows = c(3, 6))) %>%
-  tab_footnote("HR bounds are approximations; decisions on crossing are based solely on p-values.",
-               locations=cells_body(column= 2, rows = c(3, 6, 9)))
+  tab_header(
+    title = "Time-to-event group sequential bound guidance",
+    subtitle = "Bounds updated based on event counts through IA2"
+  ) %>%
+  tab_footnote(
+    "Nominal p-value required to establish statistical significance.",
+    locations = cells_body(columns = 3, rows = c(2, 5, 8))
+  ) %>%
+  tab_footnote(
+    "Interim futility guidance based on observed HR is non-binding.",
+    locations = cells_body(columns = 4, rows = c(3, 6))
+  ) %>%
+  tab_footnote(
+    "HR bounds are approximations; decisions on crossing are based solely on p-values.",
+    locations = cells_body(column = 2, rows = c(3, 6, 9))
+  )
 ```
 
 ## Evaluating interim results
@@ -322,9 +346,10 @@ Z <- c(0.25, 2)
 Conditional power at interim analysis 2 is computed for the current trend, under the null hypothesis (HR=1), and under the alternate hypothesis (HR=0.75 in this case) as follows:
 
 ```{r}
-gsCP(x = xu, # updated design
-     i = 2,  # interim analysis 2
-     zi = Z[2] # observed Z-value for testing
+gsCP(
+  x = xu, # Updated design
+  i = 2, # Interim analysis 2
+  zi = Z[2] # Observed Z-value for testing
 )$upper$prob
 ```
 
@@ -333,23 +358,28 @@ The computation assumes a prior distribution for the treatment effect and then u
 The conditional probability of a positive finding is then averaged according to this posterior.
 We specify a normal prior for the standardized effect size using the `gsDesign::normalGrid()` function.
 We select a weak prior with mean half-way between the alternative (`x$delta`) and null (0) hypotheses and a variance equivalent to observing 5% (=1/20) of the targeted events at the final analysis;
-the following shows that the standard deviation for the prior is well over twice the mean, so the prior is relatively weak. 
+the following shows that the standard deviation for the prior is well over twice the mean, so the prior is relatively weak.
 
 ```{r}
-prior <- normalGrid(mu = x$delta/2,
-                    sigma = sqrt(20/max(x$n.I)))
-cat(paste(" Prior mean:", round(x$delta/2, 3), 
-          "\n Prior standard deviation", round(sqrt(20/x$n.fix), 3), "\n"))
+prior <- normalGrid(
+  mu = x$delta / 2,
+  sigma = sqrt(20 / max(x$n.I))
+)
+cat(paste(
+  " Prior mean:", round(x$delta / 2, 3),
+  "\n Prior standard deviation", round(sqrt(20 / x$n.fix), 3), "\n"
+))
 ```
 
 Now based on the interim 2 result, we compute the predictive power of a positive final analysis.
 
 ```{r}
-gsPP(x = xu, # updated design
-     i = 2,  # interim analysis 2
-     zi = Z[2], # observed Z-value for testing
-     theta = prior$z, # grid points for above prior
-     wgts = prior$wgts # weights for averaging over grid
+gsPP(
+  x = xu, # Updated design
+  i = 2, # Interim analysis 2
+  zi = Z[2], # Observed Z-value for testing
+  theta = prior$z, # Grid points for above prior
+  wgts = prior$wgts # Weights for averaging over grid
 )
 ```
 
@@ -361,26 +391,27 @@ The trend is proportional to the logarithm of the underlying hazard ratio.
 The projected final test is based on the dashed line which represents a linear trend based on the most recent B-value computed; this projection is what was used in the conditional power calculation under the current trend that was computed above.
 
 ```{r,fig.width=6.5, fig.height=5}
-maxx <- 450 # max for x-axis specified by user  
-ylim <- c(-1,3) # user-specified y-axis limits
-analysis <- 2  # current analysis specified by user
+maxx <- 450 # Max for x-axis specified by user
+ylim <- c(-1, 3) # User-specified y-axis limits
+analysis <- 2 # Current analysis specified by user
 # Following code should require no further changes
-plot(xu, plottype="B", base=TRUE, xlim=c(0,maxx), ylim=ylim, main="B-value projection",
-     lty=1, col=1:2, xlab="Events")
+plot(
+  xu,
+  plottype = "B", base = TRUE, xlim = c(0, maxx), ylim = ylim, main = "B-value projection",
+  lty = 1, col = 1:2, xlab = "Events"
+)
 N <- c(0, xu$n.I[1:analysis])
 B <- c(0, Z * sqrt(xu$timing[1:analysis]))
 points(x = N, y = B, col = 4)
 lines(x = N, y = B, col = 4)
-slope <- B[analysis+1] / N[analysis + 1]
-Nvals <- c(N[analysis+1], max(xu$n.I))
-lines(x = Nvals,
-      y = B[analysis + 1] + c(0, slope * (Nvals[2] - Nvals[1])),
-      col = 4,
-      lty = 2)
+slope <- B[analysis + 1] / N[analysis + 1]
+Nvals <- c(N[analysis + 1], max(xu$n.I))
+lines(
+  x = Nvals,
+  y = B[analysis + 1] + c(0, slope * (Nvals[2] - Nvals[1])),
+  col = 4,
+  lty = 2
+)
 ```
-
-
-
-
 
 # References

--- a/vignettes/hGraph.Rmd
+++ b/vignettes/hGraph.Rmd
@@ -17,19 +17,16 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
 library(gsDesign)
 library(dplyr)
 library(gridExtra)
 ```
 
-
-
-
 With version 3.1, we have added a function to support graphical multiplicity methods using ***ggplot2***.
 The graphical method is introduced nicely in @Bretz2011 and supported by the ***gMCP*** package (@gMCP).
 It was extended to group sequential design by @MaurerBretz2013.
-While the ***gMCP*** 
+While the ***gMCP***
 package supports graphics, here we add the `hGraph()` function to create multiplicity graphs using the ***ggplot2*** package as a convenience for those desiring this format.
 We demonstrate basic formatting in this article and demonstrate use with ***gMCP*** elsewhere.
 
@@ -41,21 +38,19 @@ Use of `hGraph()` is organized as follows:
 - Specifying the transition matrix between hypotheses
 - Using colors and legends
 
-
 # The basic graph layout
 
 We begin with the default plot to demonstrate the basic formatting below.
 Hypthoses and initial $\alpha$-allocation or weighting are presented in shaded ellipses with the first hyothesis specified in the upper-left part of the  plot.
 While the user has full control of ellipse placement and color, the default is to present clockwise on a larger ellipse with gray shading.
 One advantage of default placement is that generally transition lines between hypotheses will not cross hypothesis ellipses, including when the graph is updated when some hypotheses are rejected.
-Transition weights between hypotheses are specified on directional lines between the hypothesis ellipses. 
+Transition weights between hypotheses are specified on directional lines between the hypothesis ellipses.
 Try this in a plot window. Note the effect if you change the size of the plot window.
 In a similar fashion, if you are using R Markdown, `fig.width` and `fig.height` parameters will affect formatting.
 
 ```{r, message=FALSE, fig.width=7.5, fig.height=4}
 hGraph()
 ```
-
 
 # Specifying hypothesis names and $\alpha$-allocation
 
@@ -66,21 +61,21 @@ The character used for weights (specified in `wchar`) is by default $\alpha$ und
 Note the clockwise placement of hypotheses.
 
 ```{r, fig.width=7.5, fig.height=4.5}
-hGraph(nHypotheses = 3,
-       nameHypotheses = c("HA\n First", "HC\n Second", "HB\n Third"),
-       alphaHypotheses = c(.2, .3, .5),
-       wchar = 'w' # character before weights
+hGraph(
+  nHypotheses = 3,
+  nameHypotheses = c("HA\n First", "HC\n Second", "HB\n Third"),
+  alphaHypotheses = c(.2, .3, .5),
+  wchar = "w" # Character before weights
 )
 ```
-
 
 # Text formatting and location, ellipse size
 
 You can specify location of hypothesis ellipses in two ways.
 
-- For the first, specify in radians where on the large ellipse  where the first hypothesis is placed.
+- For the first, specify in radians where on the large ellipse where the first hypothesis is placed.
 Setting $\pi/2$ for `radianStart` places the first hypothesis at the center and top of the plot (left plot).
-- Specifying `x` and `y` coordinates, right graph, allows custom placement; note that the differences in minimum and maximum x- and y-values you use as well as window size will impact formatting. 
+- Specifying `x` and `y` coordinates, right graph, allows custom placement; note that the differences in minimum and maximum x- and y-values you use as well as window size will impact formatting.
 
 Ellipse and the text size as well as maximum significant digits for hypotheses are controlled as follows:
 
@@ -98,25 +93,26 @@ Box and text size as well as maximum significant digit display for transition we
 
 The other parameter shown here is `offset` (left graph). This is in radians; it increases and decreases offset of transition lines between hypothesis ellipses. If there are not any transition arrows in both directions between any pair of hypotheses, `offset = 0` is a reasonable option.
 
-
 ```{r, message=FALSE, fig.width=8, fig.height=4}
 grid.arrange(
-  # left graph in figure
-  hGraph(nHypotheses = 3,
-         size = 5, # decrease hypothesis text size from default 6
-         halfWid = 1.25, # increase ellipse width from default 0.5
-         trhw = 0.25, # increase transition box sizes from default 0.075
-         radianStart = pi/2, # first hypothesis top middle
-         offset = pi/20, # decrease offset between transition lines
-         arrowsize = .03 # increase from default 0.02
+  # Left graph in figure
+  hGraph(
+    nHypotheses = 3,
+    size = 5, # Decrease hypothesis text size from default 6
+    halfWid = 1.25, # Increase ellipse width from default 0.5
+    trhw = 0.25, # Increase transition box sizes from default 0.075
+    radianStart = pi / 2, # First hypothesis top middle
+    offset = pi / 20, # Decrease offset between transition lines
+    arrowsize = .03 # Increase from default 0.02
   ),
-  # right graph in figure
-  hGraph(nHypotheses = 3,
-       x = c(-1, 1, -1), # custom placement using x and y
-       y = c(1, 1, -1),
-       halfWid = 0.7, # increase ellipse width from default 0.5
-       boxtextsize = 3, # decrease box text size from default 4
-       trprop = .15 # slide transition boxes closer to initiating hypothesis
+  # Right graph in figure
+  hGraph(
+    nHypotheses = 3,
+    x = c(-1, 1, -1), # Custom placement using x and y
+    y = c(1, 1, -1),
+    halfWid = 0.7, # Increase ellipse width from default 0.5
+    boxtextsize = 3, # Decrease box text size from default 4
+    trprop = .15 # Slide transition boxes closer to initiating hypothesis
   ),
   nrow = 1
 )
@@ -131,21 +127,22 @@ Colors are specified as follows:
 - A `fill` color category; here we group the first 2 hypotheses and last 2 hypotheses (both graphs)
 - The `palette` specifies a palette for the colors (right graph)
 
-
-
 ```{r,fig.width=7.5,fig.height=4}
 grid.arrange(
-  # left graph in figure
-  hGraph(fill=c(1,1,2,2),
-         alphaHypotheses = c(.2,.2,.2,.4) * .025),
-  # right graph in figure
-  hGraph(fill=c(1,1,2,2),
-         palette = c("pink", "lightblue"),
-         alphaHypotheses = c(.2,.2,.2,.4) * .025),
+  # Left graph in figure
+  hGraph(
+    fill = c(1, 1, 2, 2),
+    alphaHypotheses = c(.2, .2, .2, .4) * .025
+  ),
+  # Right graph in figure
+  hGraph(
+    fill = c(1, 1, 2, 2),
+    palette = c("pink", "lightblue"),
+    alphaHypotheses = c(.2, .2, .2, .4) * .025
+  ),
   nrow = 1
 )
 ```
-
 
 Next, we add a legend.
 
@@ -154,12 +151,13 @@ Next, we add a legend.
 - `labels` specifies labels corresponding to the `fill` parameter
 
 ```{r,fig.width=7.5,fig.height=4}
-hGraph(nHypotheses = 3,
-       fill = c(1,1,2),
-       palette = c("yellow", "lightblue"),
-       legend.name = "Color scheme",
-       labels = c("Primary", "Secondary"),
-       legend.position = c(.75,.25)
+hGraph(
+  nHypotheses = 3,
+  fill = c(1, 1, 2),
+  palette = c("yellow", "lightblue"),
+  legend.name = "Color scheme",
+  labels = c("Primary", "Secondary"),
+  legend.position = c(.75, .25)
 )
 ```
 
@@ -167,21 +165,21 @@ hGraph(nHypotheses = 3,
 
 Transition weights are specified in matrix format in the variable `m`.
 The matrix must be square of dimension `nHypotheses` and have 0 on the diagonal.
-Rows respresent the hypotheses from which transitions start; row values should sum to 1.
+Rows represent the hypotheses from which transitions start; row values should sum to 1.
 Columns represent the hypotheses to which transition arrows go.
 Any transition weight of 0 has no corresponding transition line in the figure.
 
 ```{r,fig.width=7.5,fig.height=4}
-hGraph(nHypotheses = 3, 
-       m = matrix(c(0, 1, 0, 
-                    .2, 0, .8,
-                    .3, .7, 0),
-                  nrow=3, byrow=TRUE),
+hGraph(
+  nHypotheses = 3,
+  m = matrix(c(
+    0, 1, 0,
+    .2, 0, .8,
+    .3, .7, 0
+  ),
+  nrow = 3, byrow = TRUE
+  ),
 )
 ```
-
-
-
-
 
 # References

--- a/vignettes/nNormal.Rmd
+++ b/vignettes/nNormal.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
 library(gsDesign)
 library(tidyr)
 library(knitr)
@@ -29,10 +29,10 @@ We provide a tool where for a large sample case where a reasonable estimate of s
 
 # The problem considered
 
-The overall sample size notation used for **gsDesign** is to consider a standardized effect size parameter which is referred to as $\theta$ in @JTBook. 
-We begin with the 2-sample normal problem where we assume a possibly different standard deviation in each treatment group. 
-For $j=1,2$, we let $X_{j,i}$, $i=1,2,\ldots n_j$ represent independent and identically distributed observations following a normal distribution with mean $\mu_j$ and standard deviation $\sigma_j$.
-The natural parameter for comparing the two distributions is 
+The overall sample size notation used for **gsDesign** is to consider a standardized effect size parameter which is referred to as $\theta$ in @JTBook.
+We begin with the 2-sample normal problem where we assume a possibly different standard deviation in each treatment group.
+For $j = 1, 2$, we let $X_{j, i}$, $i = 1, 2, \ldots n_j$ represent independent and identically distributed observations following a normal distribution with mean $\mu_j$ and standard deviation $\sigma_j$.
+The natural parameter for comparing the two distributions is
 
 $$\delta = \mu_2 - \mu_1$$
 
@@ -47,28 +47,26 @@ For our examples we use this $t$-test and show that the sample size computation 
 
 # Sample size
 
-
 Thus, $n_2=rn/(1+r)$, $n_1=n/(1+r)$ and when $r=1$ we have $n_1=n_2=n/2$.
 Now that we have completed needed notation, those not interested in the theory behind the sample size and power calculation used may skip the rest of this section.
 
-
 We let $$\sigma^2=(1+r)(\sigma_1^2+\sigma_2^2/r)$$
-and define 
+and define
 $$ \theta= (\delta -\delta_0)/\sigma.$$
-Under the given assumptions, 
+Under the given assumptions,
 $$Z \sim \hbox{Normal}\left(\sqrt n\theta,1\right).$$
 Under the null hypothesis that $\delta=\delta_0$, we have $Z\sim \hbox{Normal}(0,1)$.
 Thus, regardless of $n$ we have
-$$P_0[Z\ge \Phi^{-1}(1-\alpha)]=\alpha.$$ 
+$$P_0[Z\ge \Phi^{-1}(1-\alpha)]=\alpha.$$
 Under the alternate hypothesis that $\delta=\delta_1$ and we denote a corresponding $\theta_1$.
-We define the type 2 error $\beta$ and power $1-\beta$ by
+We define the type II error $\beta$ and power $1-\beta$ by
 
 $$
 \begin{align}
 1-\beta =& P_1[Z\ge \Phi^{-1}(1-\alpha)]\\
 =& P[Z-\sqrt n\theta_1\ge \Phi^{-1}(1-\alpha)-\sqrt n\theta_1]\\
 =&\Phi(\Phi^{-1}(1-\alpha)-\sqrt n\theta_1)).
-\end{align}$$ 
+\end{align}$$
 
 If the power $1-\beta$ is fixed, we can invert this formula to compute sample size with:
 
@@ -79,9 +77,8 @@ For 2-sided testing, we simply substitute $\alpha/2$ for $\alpha$ in the above t
 # Examples
 
 We consider two examples to check the above formulas vs. `nNormal()`.
-We then confirm that the approximation is working well by simulating and confirming that the power and Type I error approximations are useful. 
+We then confirm that the approximation is working well by simulating and confirming that the power and Type I error approximations are useful.
 Finally, we provide a simple group sequential design example.
-
 
 ## Sample size
 
@@ -89,15 +86,13 @@ We consider an example with $\sigma_2=1.25$, $\sigma_1=1.6$, $\delta=0.8$ and $\
 We let the sample size ratio be 2 experimental group observations per control observation.
 We compute sample size with `nNormal()` assuming one-sided Type I error $\alpha=0.025$ and 90% power ($1-\beta=0.9$).
 
-
-
 Checking using the sample size formula above, we have:
 
 ```{r}
 r <- 2
-sigma <- sqrt((1+r)*(1.6^2 + 1.25^2/r)) 
-theta <- 0.8/sigma
-((qnorm(.9)+qnorm(.975))/theta)^2
+sigma <- sqrt((1 + r) * (1.6^2 + 1.25^2 / r))
+theta <- 0.8 / sigma
+((qnorm(.9) + qnorm(.975)) / theta)^2
 ```
 
 ## Power
@@ -105,7 +100,7 @@ theta <- 0.8/sigma
 Now, assume we let the sample size be 200 and compute power under the same scenario.
 
 ```{r}
-nNormal(delta1=0.8, sd = 1.6, sd2 = 1.25, alpha = 0.025, n = 200, ratio = 2)
+nNormal(delta1 = 0.8, sd = 1.6, sd2 = 1.25, alpha = 0.025, n = 200, ratio = 2)
 ```
 
 From the power formula above, we duplicate this with:
@@ -120,28 +115,28 @@ If we want to plot power for a variety of sample sizes, we can input `n` as a ve
 ```{r}
 n <- 100:200
 pwrn <- nNormal(delta1 = 0.8, sd = 1.6, sd2 = 1.25, alpha = 0.025, n = n, ratio = 2)
-plot(n, pwrn, type="l")
+plot(n, pwrn, type = "l")
 ```
 
 Alternatively, you could fix sample size at 200 and plot power under different treatment effect assumptions:
 
 ```{r}
-delta1 <- seq(.5,1,.025)
+delta1 <- seq(.5, 1, .025)
 pwrdelta1 <- nNormal(delta1 = delta1, sd = 1.6, sd2 = 1.25, alpha = 0.025, n = 200, ratio = 2)
-plot(delta1, pwrdelta1, type="l")
+plot(delta1, pwrdelta1, type = "l")
 ```
-
 
 ## Verification with simulation
 
 Rather than simulate individual observations, we will take advantage of the fact that for $j=1,2$
 
 $$\bar X_j\sim \hbox{Normal}(\mu_j,\sigma_j^2/n_j)$$
-and 
+
+and
 
 $$(n_j-1)s_j^2/\sigma_j^2=\sum_{i=1}^{n_j} (X_{ij}-\bar X_j)/\sigma^2 \sim \chi ^2_{n_j-1}$$
 
-are independent. 
+are independent.
 Thus, we can simulate trial power with $n=200$ 1 million times with a t-statistic with unequal variances quickly as follows under the alternate hypothesis:
 
 ```{r}
@@ -151,9 +146,12 @@ sd1 <- 1.6
 sd2 <- 1.25
 n1 <- 67
 n2 <- 133
-deltahat <- rnorm(n=nsim, mean=delta, sd=sd1/sqrt(n1)) - rnorm(n=nsim, mean=0, sd=sd2/sqrt(n2))
-s <- sqrt(sd1^2 * rchisq(n=nsim, df=n1 - 1)/(n1-1)/n1 +
-           sd2^2 * rchisq(n=nsim, df=n2 - 1)/(n2-1)/n2)
+deltahat <- rnorm(n = nsim, mean = delta, sd = sd1 / sqrt(n1)) -
+  rnorm(n = nsim, mean = 0, sd = sd2 / sqrt(n2))
+s <- sqrt(
+  sd1^2 * rchisq(n = nsim, df = n1 - 1) / (n1 - 1) / n1 +
+    sd2^2 * rchisq(n = nsim, df = n2 - 1) / (n2 - 1) / n2
+)
 z <- deltahat / s
 mean(z >= qnorm(.975))
 ```
@@ -161,8 +159,9 @@ mean(z >= qnorm(.975))
 The standard error for this simulation power calculation is approximately
 
 ```{r}
-sqrt(pwr*(1-pwr)/nsim)
+sqrt(pwr * (1 - pwr) / nsim)
 ```
+
 suggesting we should be within less than about 0.001 if the actual power, which suggests the normal power approximation is reasonable for this scenario.
 
 ## Group sequential design
@@ -172,11 +171,13 @@ We will largely use default parameters and show two methods.
 For the first, we plug in the fixed sample size above as follows:
 
 ```{r}
-d <- 
-gsDesign(k=2,
-         n.fix = nNormal(delta1=0.8, sd = 1.6, sd2 = 1.25, alpha = 0.025, beta = .1, ratio = 2),
-         delta1 = 0.8)
-d %>%  gsBoundSummary(deltaname = "Mean difference") %>% 
+d <- gsDesign(
+  k = 2,
+  n.fix = nNormal(delta1 = 0.8, sd = 1.6, sd2 = 1.25, alpha = 0.025, beta = .1, ratio = 2),
+  delta1 = 0.8
+)
+d %>%
+  gsBoundSummary(deltaname = "Mean difference") %>%
   kable(row.names = FALSE)
 ```
 
@@ -186,18 +187,18 @@ A textual summary of the design is given by:
 cat(summary(d))
 ```
 
-
 We can get the same answer by plugging in the standardized effect size we computed above:
 
 ```{r}
-gsDesign(k=2,
-         delta = theta,
-         delta1 = 0.8) %>%
-  gsBoundSummary(deltaname = "Mean difference") %>% 
-  kable(row.names=FALSE)
+gsDesign(
+  k = 2,
+  delta = theta,
+  delta1 = 0.8
+) %>%
+  gsBoundSummary(deltaname = "Mean difference") %>%
+  kable(row.names = FALSE)
 ```
 
 We leave it to the reader to verify the properties of the above design using simulation as in the fixed design example.
-
 
 # References


### PR DESCRIPTION
This PR includes these maintenance fixes:

- Use `inherits()` instead of `is()` to determine if an object is an instance of a class, when appropriate.
- Correctly close graphics device in unit tests to avoid plot output file not found issues.
- Use pkgdown 2.x and Bootstrap 5 to build the documentation website.
- Format code in vignettes with tidyverse style.
- Update the GitHub Actions to the latest version.

All action builds passed in my forked repo.