### PR TITLE
Add new vignette to pkgdown index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -121,3 +121,4 @@ articles:
       - hGraph
       - GraphicalMultiplicity
       - VaccineEfficacy
+      - CComponentsOverview


### PR DESCRIPTION
This PR added the new vignette to the pkgdown index.

This fixes a pkgdown build issue as it now treats "missing topics" as errors.