### PR TITLE
Add technical manual link to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,4 +42,4 @@ Suggests:
     utils
 VignetteBuilder:
     knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/gsBinomialExact.R
+++ b/R/gsBinomialExact.R
@@ -221,9 +221,8 @@ utils::globalVariables(c("N", "EN", "Bound", "rr", "Percent", "Outcome"))
 #' \dontrun{ 
 #'   nBinomial1Sample(p0 = 0.05, p1 = 0.2, alpha = 0.025, beta = .2, n = 25:30)
 #' }
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Jon Hartzel, Yevgen Tymofyeyev and Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsProbability}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential

--- a/R/gsCP.R
+++ b/R/gsCP.R
@@ -182,9 +182,8 @@
 #' # start with point estimate, followed by 90% prediction interval
 #' gsPI(x = x, i = 1, zi = z1, j = 2, theta = prior$z, wgts = prior$wgts, level = 0)
 #' gsPI(x = x, i = 1, zi = z1, j = 2, theta = prior$z, wgts = prior$wgts, level = .9)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{normalGrid}}, \code{\link{gsDesign}},
 #' \code{\link{gsProbability}}, \code{\link{gsBoundCP}}, \code{\link{ssrCP}},
@@ -352,9 +351,8 @@ gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c
 #' 
 #' # compute conditional power based on original x$delta
 #' gsBoundCP(x, theta = x$delta)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}},
 #' \code{\link{gsCP}}

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -58,9 +58,8 @@
 #' lower boundary crossing probabilities; computed using input lower bound and
 #' derived upper bound.} \item{probhi}{vector of upper boundary crossing
 #' probabilities as input.}
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign package overview}, \code{\link{gsDesign}},
 #' \code{\link{gsProbability}}
@@ -424,9 +423,8 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #'   k = 4, timing = timing, sfu = sfPoints, sfupar = sfup, sfl = sfPoints,
 #'   sflpar = sflp
 #' )
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign package overview}, \link{gsBoundSummary}, 
 #' \link{plot.gsDesign},
@@ -637,9 +635,8 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 #' # default plottype is now 2
 #' # this is the same range for theta, but plot now has theta on x axis
 #' plot(z)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{plot.gsDesign}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -792,9 +789,8 @@ gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0
 #' u <- x$upper$bound[4]
 #' text(expression(paste(theta, "=", delta)), x = 2.2, y = .2, cex = 1.5)
 #' text(expression(paste(theta, "=0")), x = .55, y = .4, cex = 1.5)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}},
 #' \code{\link{gsBoundCP}}

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -559,9 +559,8 @@ print.nSurvival <- function(x, ...) {
 #' # for nice LaTeX table output, use xprint
 #' xprint(xtable::xtable(gsBoundSummary(xOR, deltaname = "OR", logdelta = TRUE), 
 #'                                           caption = "Table caption."))
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign}, \link{plot.gsDesign},
 #' \code{\link{gsProbability}}, \code{\link{xtable.gsSurv}}

--- a/R/gsNormalGrid.R
+++ b/R/gsNormalGrid.R
@@ -86,9 +86,8 @@
 #'   main = "Expected sample size for different theta values"
 #' )
 #' lines(y$z, z$en)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential
 #' Methods with Applications to Clinical Trials}. Boca Raton: Chapman and Hall.

--- a/R/gsSpending.R
+++ b/R/gsSpending.R
@@ -124,9 +124,8 @@
 #' # from the others
 #' param <- c(.25, .5, .05, .1)
 #' plotsf(.025, t, param)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential
@@ -262,11 +261,9 @@ sfLogistic <- function(alpha, t, param) {
 #'   )
 #' )
 #' text(x = .59, y = .95 * .025, labels = "<--approximates O'Brien-Fleming")
-#' @note The manual shows how to use \code{sfExponential()} to closely
-#' approximate an O'Brien-Fleming design. An example is given below. The manual
-#' is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual shows how to use \code{sfExponential()}
+#'   to closely approximate an O'Brien-Fleming design. An example is given below.
+#'   The manual is available at <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -567,9 +564,8 @@ sfExtremeValue2 <- function(alpha, t, param) {
 #'   x = c(.0, .375), y = .025 * c(.8, 1), lty = 1:3,
 #'   legend = c("gamma= -4", "gamma= -2", "gamma= 1")
 #' )
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -684,9 +680,8 @@ sfHSD <- function(alpha, t, param) {
 #'   geom_line()+
 #'   guides(col=guide_legend(expression(rho)))+
 #'   ggtitle("Generalized Lan-DeMets O'Brien-Fleming Spending Function")
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -921,9 +916,8 @@ sfNormal <- function(alpha, t, param) {
 #' sum(z1alt >= x$upper$bound[1] | z2alt >= x$upper$bound[2]) / 1000000
 #' 
 #' @aliases sfLinear
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1104,9 +1098,8 @@ sfStep <- function(alpha, t, param) {
 #' )
 #' x
 #' 
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}, \link{sfLogistic}
@@ -1222,9 +1215,8 @@ sfPoints <- function(alpha, t, param) {
 #'   x = c(.0, .357), y = .025 * c(.65, .85), lty = 1:3, bty = "n", col = 2,
 #'   legend = c("gamma= -4", "gamma= -2", "gamma=1")
 #' )
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1343,9 +1335,8 @@ sfPower <- function(alpha, t, param) {
 #'   x = c(.0, .3), y = .025 * c(.7, 1), lty = 1:5,
 #'   legend = c("df = 1", "df = 1.5", "df = 3", "df = 10", "df = 100")
 #' )
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1559,9 +1550,8 @@ sfTDist <- function(alpha, t, param) {
 #' # note that by setting trange[1] to .2, the spend at t=.2 is used for the first
 #' # interim at or after 20 percent of information
 #' x <- gsDesign(n.fix = 100, sfl = sfGapped, sflpar = list(trange = c(.2, .9), sf = sfHSD, param = 1))
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}

--- a/R/gsWTPT.R
+++ b/R/gsWTPT.R
@@ -32,9 +32,8 @@
 # @name Wang-Tsiatis Bounds
 # @aliases O'Brien-Fleming Bounds Wang-Tsiatis Bounds Pocock Bounds
 # @docType package
-# @note The manual is not linked to this help file, but is available in
-# library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-# installed.
+# @note The gsDesign technical manual is available at
+#   <https://keaven.github.io/gsd-tech-manual/>.
 # @author Keaven Anderson \email{keaven_anderson@@merck.com}
 # @seealso \code{\link{Spending_Function_Overview}, \link{gsDesign}},
 # \code{\link{gsProbability}}

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -132,9 +132,8 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #' # the following translates to a call to plot.gsProbability since
 #' # y has that type
 #' plot(y)
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential

--- a/R/package.R
+++ b/R/package.R
@@ -122,9 +122,8 @@ NULL
 #' from there.  Contains probabilities of boundary crossing at \code{i}-th
 #' analysis for \code{j}-th theta value input to \code{gsDesign()} in
 #' \code{prob[i,j]}.}
-#' @note The manual is not linked to this help file, but is available in
-#' library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-#' installed.
+#' @note The gsDesign technical manual is available at
+#'   <https://keaven.github.io/gsd-tech-manual/>.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{sfHSD}}, \code{\link{sfPower}},
 #' \code{\link{sfLogistic}}, \code{\link{sfExponential}},

--- a/man/Spending_Function_Overview.Rd
+++ b/man/Spending_Function_Overview.Rd
@@ -65,9 +65,8 @@ demonstrated below in examples. In addition to using supplied spending
 functions, a user can write code for a spending function. See examples.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsBinomialExact.Rd
+++ b/man/gsBinomialExact.Rd
@@ -161,7 +161,7 @@ been extended using \code{plot.gsBinomialExact} to plot
 ratio test (SPRT) which is a specific instance of an exact binomial group
 sequential design for a single arm trial with a binary outcome.
 
-%\code{gsBinomialPP} computes a truncated binomial (group) sequential design
+\code{gsBinomialPP} computes a truncated binomial (group) sequential design
 based on predictive probability.
 
 \code{nBinomial1Sample} uses exact binomial calculations to compute power
@@ -221,9 +221,8 @@ that it covers the possible range of values that include the true minimum.
 NOTE: the one-sided evaluation of significance is more conservative than using the 2-sided exact test in \code{binom.test}.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsBound.Rd
+++ b/man/gsBound.Rd
@@ -81,9 +81,8 @@ knowledge of behavior when a design corresponding to the input parameters
 does not exist.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 

--- a/man/gsBoundCP.Rd
+++ b/man/gsBoundCP.Rd
@@ -39,9 +39,8 @@ See Conditional power section of manual for further clarification. See also
 Muller and Schaffer (2001) for background theory.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 

--- a/man/gsBoundSummary.Rd
+++ b/man/gsBoundSummary.Rd
@@ -260,9 +260,8 @@ the probability of crossing the efficacy bound at or before the analysis of
 interest.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsCP.Rd
+++ b/man/gsCP.Rd
@@ -156,9 +156,8 @@ must have \code{sum(gridwgts * density)} equal to 1; this is NOT checked,
 however.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsDensity.Rd
+++ b/man/gsDensity.Rd
@@ -48,9 +48,8 @@ See Jennison and Turnbull (2000) for details on how these computations are
 performed.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsDesign.Rd
+++ b/man/gsDesign.Rd
@@ -316,9 +316,8 @@ other options. Options 5 and 6 compute lower bound spending under the null
 hypothesis.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/gsProbability.Rd
+++ b/man/gsProbability.Rd
@@ -75,9 +75,8 @@ input \code{d}. On output, the values of \code{theta} input to
 characterized.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/normalGrid.Rd
+++ b/man/normalGrid.Rd
@@ -45,9 +45,8 @@ the function integrated is not large in the tails of the grid where points
 are spread further apart.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/plot.gsDesign.Rd
+++ b/man/plot.gsDesign.Rd
@@ -120,9 +120,8 @@ Thus, the expected value of a B-value at an analysis is the true value of
 that time. See Proschan, Lan and Wittes (2006).
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfDistribution.Rd
+++ b/man/sfDistribution.Rd
@@ -85,9 +85,8 @@ the standard distribution is flipped about 0. This is reflected in
 \code{sfExtremeValue2()} where \deqn{F(x)=1-\exp(-\exp(x)).}
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfExponential.Rd
+++ b/man/sfExponential.Rd
@@ -51,11 +51,9 @@ spending function (\code{sfLDOF()}), \deqn{f(t; \alpha)=2-2\Phi \left(
 alpha)=2-2*Phi(Phi^(-1)(1-alpha/2)/t^(1/2)).}
 }
 \note{
-The manual shows how to use \code{sfExponential()} to closely
-approximate an O'Brien-Fleming design. An example is given below. The manual
-is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual shows how to use \code{sfExponential()}
+  to closely approximate an O'Brien-Fleming design. An example is given below.
+  The manual is available at <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfHSD.Rd
+++ b/man/sfHSD.Rd
@@ -41,9 +41,8 @@ for a better fit), while a value of \eqn{\gamma=1}{gamma=1} approximates a
 Pocock design well.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfLDOF.Rd
+++ b/man/sfLDOF.Rd
@@ -53,9 +53,8 @@ O'Brien-Fleming bounds can be closely approximated using
 \code{\link{sfExponential}}.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfLinear.Rd
+++ b/man/sfLinear.Rd
@@ -65,9 +65,8 @@ I error when timing of analyses are changed based on knowing the treatment
 effect at an interim.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfPoints.Rd
+++ b/man/sfPoints.Rd
@@ -38,9 +38,8 @@ specified points (e.g,, linear interpolation); also consider fitting smooth
 spending functions; see \link{Spending_Function_Overview}.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfPower.Rd
+++ b/man/sfPower.Rd
@@ -41,9 +41,8 @@ passed in \code{param}. See examples below for a range of values of
 documented there).
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)

--- a/man/sfSpecial.Rd
+++ b/man/sfSpecial.Rd
@@ -71,9 +71,8 @@ function parameter(s) in \code{param$param}. See example using
 \code{sfLinear} that spends uniformly over specified range.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 

--- a/man/sfTDist.Rd
+++ b/man/sfTDist.Rd
@@ -57,9 +57,8 @@ F(a+bF^{-1}(t))} where \eqn{F()} is a cumulative t-distribution function
 with \code{df} degrees of freedom and \eqn{F^{-1}()} is its inverse.
 }
 \note{
-The manual is not linked to this help file, but is available in
-library/gsdesign/doc/gsDesignManual.pdf in the directory where R is
-installed.
+The gsDesign technical manual is available at
+  <https://keaven.github.io/gsd-tech-manual/>.
 }
 \examples{
 library(ggplot2)


### PR DESCRIPTION
This PR updates the documentation, adding the gsDesign technical manual bookdown project link and replacing the outdated information of a previous PDF format manual.