### PR TITLE
Use Rd URL directive

### DIFF
--- a/R/gsBinomialExact.R
+++ b/R/gsBinomialExact.R
@@ -222,7 +222,7 @@ utils::globalVariables(c("N", "EN", "Bound", "rr", "Percent", "Outcome"))
 #'   nBinomial1Sample(p0 = 0.05, p1 = 0.2, alpha = 0.025, beta = .2, n = 25:30)
 #' }
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Jon Hartzel, Yevgen Tymofyeyev and Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsProbability}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential

--- a/R/gsCP.R
+++ b/R/gsCP.R
@@ -183,7 +183,7 @@
 #' gsPI(x = x, i = 1, zi = z1, j = 2, theta = prior$z, wgts = prior$wgts, level = 0)
 #' gsPI(x = x, i = 1, zi = z1, j = 2, theta = prior$z, wgts = prior$wgts, level = .9)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{normalGrid}}, \code{\link{gsDesign}},
 #' \code{\link{gsProbability}}, \code{\link{gsBoundCP}}, \code{\link{ssrCP}},
@@ -352,7 +352,7 @@ gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c
 #' # compute conditional power based on original x$delta
 #' gsBoundCP(x, theta = x$delta)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}},
 #' \code{\link{gsCP}}

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -59,7 +59,7 @@
 #' derived upper bound.} \item{probhi}{vector of upper boundary crossing
 #' probabilities as input.}
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign package overview}, \code{\link{gsDesign}},
 #' \code{\link{gsProbability}}
@@ -424,7 +424,7 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #'   sflpar = sflp
 #' )
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign package overview}, \link{gsBoundSummary}, 
 #' \link{plot.gsDesign},
@@ -636,7 +636,7 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 #' # this is the same range for theta, but plot now has theta on x axis
 #' plot(z)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{plot.gsDesign}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -790,7 +790,7 @@ gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0
 #' text(expression(paste(theta, "=", delta)), x = 2.2, y = .2, cex = 1.5)
 #' text(expression(paste(theta, "=0")), x = .55, y = .4, cex = 1.5)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}},
 #' \code{\link{gsBoundCP}}

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -560,7 +560,7 @@ print.nSurvival <- function(x, ...) {
 #' xprint(xtable::xtable(gsBoundSummary(xOR, deltaname = "OR", logdelta = TRUE), 
 #'                                           caption = "Table caption."))
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{gsDesign}, \link{plot.gsDesign},
 #' \code{\link{gsProbability}}, \code{\link{xtable.gsSurv}}

--- a/R/gsNormalGrid.R
+++ b/R/gsNormalGrid.R
@@ -87,7 +87,7 @@
 #' )
 #' lines(y$z, z$en)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential
 #' Methods with Applications to Clinical Trials}. Boca Raton: Chapman and Hall.

--- a/R/gsSpending.R
+++ b/R/gsSpending.R
@@ -125,7 +125,7 @@
 #' param <- c(.25, .5, .05, .1)
 #' plotsf(.025, t, param)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential
@@ -565,7 +565,7 @@ sfExtremeValue2 <- function(alpha, t, param) {
 #'   legend = c("gamma= -4", "gamma= -2", "gamma= 1")
 #' )
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -681,7 +681,7 @@ sfHSD <- function(alpha, t, param) {
 #'   guides(col=guide_legend(expression(rho)))+
 #'   ggtitle("Generalized Lan-DeMets O'Brien-Fleming Spending Function")
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -917,7 +917,7 @@ sfNormal <- function(alpha, t, param) {
 #' 
 #' @aliases sfLinear
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1099,7 +1099,7 @@ sfStep <- function(alpha, t, param) {
 #' x
 #' 
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}, \link{sfLogistic}
@@ -1216,7 +1216,7 @@ sfPoints <- function(alpha, t, param) {
 #'   legend = c("gamma= -4", "gamma= -2", "gamma=1")
 #' )
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1336,7 +1336,7 @@ sfPower <- function(alpha, t, param) {
 #'   legend = c("df = 1", "df = 1.5", "df = 3", "df = 10", "df = 100")
 #' )
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}
@@ -1551,7 +1551,7 @@ sfTDist <- function(alpha, t, param) {
 #' # interim at or after 20 percent of information
 #' x <- gsDesign(n.fix = 100, sfl = sfGapped, sflpar = list(trange = c(.2, .9), sf = sfHSD, param = 1))
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \link{Spending_Function_Overview}, \code{\link{gsDesign}},
 #' \link{gsDesign package overview}

--- a/R/gsWTPT.R
+++ b/R/gsWTPT.R
@@ -33,7 +33,7 @@
 # @aliases O'Brien-Fleming Bounds Wang-Tsiatis Bounds Pocock Bounds
 # @docType package
 # @note The gsDesign technical manual is available at
-#   <https://keaven.github.io/gsd-tech-manual/>.
+#   \url{https://keaven.github.io/gsd-tech-manual/}.
 # @author Keaven Anderson \email{keaven_anderson@@merck.com}
 # @seealso \code{\link{Spending_Function_Overview}, \link{gsDesign}},
 # \code{\link{gsProbability}}

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -133,7 +133,7 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #' # y has that type
 #' plot(y)
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{gsProbability}}
 #' @references Jennison C and Turnbull BW (2000), \emph{Group Sequential

--- a/R/package.R
+++ b/R/package.R
@@ -123,7 +123,7 @@ NULL
 #' analysis for \code{j}-th theta value input to \code{gsDesign()} in
 #' \code{prob[i,j]}.}
 #' @note The gsDesign technical manual is available at
-#'   <https://keaven.github.io/gsd-tech-manual/>.
+#'   \url{https://keaven.github.io/gsd-tech-manual/}.
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #' @seealso \code{\link{gsDesign}}, \code{\link{sfHSD}}, \code{\link{sfPower}},
 #' \code{\link{sfLogistic}}, \code{\link{sfExponential}},

--- a/man/Spending_Function_Overview.Rd
+++ b/man/Spending_Function_Overview.Rd
@@ -66,7 +66,7 @@ functions, a user can write code for a spending function. See examples.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsBinomialExact.Rd
+++ b/man/gsBinomialExact.Rd
@@ -222,7 +222,7 @@ NOTE: the one-sided evaluation of significance is more conservative than using t
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsBound.Rd
+++ b/man/gsBound.Rd
@@ -82,7 +82,7 @@ does not exist.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 

--- a/man/gsBoundCP.Rd
+++ b/man/gsBoundCP.Rd
@@ -40,7 +40,7 @@ Muller and Schaffer (2001) for background theory.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 

--- a/man/gsBoundSummary.Rd
+++ b/man/gsBoundSummary.Rd
@@ -261,7 +261,7 @@ interest.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsCP.Rd
+++ b/man/gsCP.Rd
@@ -157,7 +157,7 @@ however.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsDensity.Rd
+++ b/man/gsDensity.Rd
@@ -49,7 +49,7 @@ performed.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsDesign.Rd
+++ b/man/gsDesign.Rd
@@ -317,7 +317,7 @@ hypothesis.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/gsProbability.Rd
+++ b/man/gsProbability.Rd
@@ -76,7 +76,7 @@ characterized.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/normalGrid.Rd
+++ b/man/normalGrid.Rd
@@ -46,7 +46,7 @@ are spread further apart.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/plot.gsDesign.Rd
+++ b/man/plot.gsDesign.Rd
@@ -121,7 +121,7 @@ that time. See Proschan, Lan and Wittes (2006).
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfDistribution.Rd
+++ b/man/sfDistribution.Rd
@@ -86,7 +86,7 @@ the standard distribution is flipped about 0. This is reflected in
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfHSD.Rd
+++ b/man/sfHSD.Rd
@@ -42,7 +42,7 @@ Pocock design well.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfLDOF.Rd
+++ b/man/sfLDOF.Rd
@@ -54,7 +54,7 @@ O'Brien-Fleming bounds can be closely approximated using
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfLinear.Rd
+++ b/man/sfLinear.Rd
@@ -66,7 +66,7 @@ effect at an interim.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfPoints.Rd
+++ b/man/sfPoints.Rd
@@ -39,7 +39,7 @@ spending functions; see \link{Spending_Function_Overview}.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfPower.Rd
+++ b/man/sfPower.Rd
@@ -42,7 +42,7 @@ documented there).
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)

--- a/man/sfSpecial.Rd
+++ b/man/sfSpecial.Rd
@@ -72,7 +72,7 @@ function parameter(s) in \code{param$param}. See example using
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 

--- a/man/sfTDist.Rd
+++ b/man/sfTDist.Rd
@@ -58,7 +58,7 @@ with \code{df} degrees of freedom and \eqn{F^{-1}()} is its inverse.
 }
 \note{
 The gsDesign technical manual is available at
-  <https://keaven.github.io/gsd-tech-manual/>.
+  \url{https://keaven.github.io/gsd-tech-manual/}.
 }
 \examples{
 library(ggplot2)


### PR DESCRIPTION
This PR updates the pointy brackets `<>` to `\url{}` so the elements in roxygen is rendered into hyperlink.

This is needed because the package has not enabled Markdown for roxygen with `Roxygen: list(markdown = TRUE)` at the moment.