### PR TITLE
Name `guide` argument in `hGraph()`

### DIFF
--- a/R/hgraph.R
+++ b/R/hgraph.R
@@ -208,7 +208,7 @@ hGraph <- function(
     #   scale_alpha(guide="none") + 
     scale_fill_manual(values=palette,
                       labels=labels,
-                      guide_legend(legend.name)) +
+                      guide=guide_legend(legend.name)) +
     theme(legend.position = legend.position) +
     # Add text
     geom_text(data=hData,aes(x=x,y=y,label=txt),size=size) + 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break gMCPLite. The culprit of the breakage is that we have made the `name` argument of scales the first, see https://github.com/tidyverse/ggplot2/pull/5583.  

Given that there are some overlapping contributors/authors, I can disclose that this essentially repeats https://github.com/Merck/gMCPLite/pull/25 for the same reason, but for gsDesign. I noticed the deprecation warnings about the `gsDesign::hGraph()` function in favour of the gMCPLite one, but decided that the courteous thing to do is to put in a seperate PR anyway.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help gsDesign get out a fix if necessary.

Please, feel entirely free to close this PR if `gMCPLite::hGraph()` will replace `gsDesign::hGraph()`.