### PR TITLE
Fix equation syntax and update pkgdown preset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ Suggests:
     utils
 VignetteBuilder:
     knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -31,9 +31,9 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #' are used. For a \code{gsDesign} object where \code{theta} is input as
 #' \code{NULL} (the default), \code{theta=seq(0,2,.05)*x$delta}) is used.  For
 #' a \code{gsDesign} object, the x-axis values are rescaled to
-#' \code{theta/x$delta} and the label for the x-axis \eqn{$theta / $delta}. For a
+#' \code{theta/x$delta} and the label for the x-axis \eqn{\theta / \delta}. For a
 #' \code{gsProbability} object, the values of \code{theta} are plotted and are
-#' labeled as \eqn{$theta}. See examples below.
+#' labeled as \eqn{\theta}. See examples below.
 #'
 #' Approximate treatment effects at boundaries are computed dividing the Z-values
 #' at the boundaries by the square root of \code{n.I} at that analysis.
@@ -57,7 +57,7 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #'
 #' B-values are Z-values multiplied by \code{sqrt(t)=sqrt(x$n.I/x$n.I[x$k])}.
 #' Thus, the expected value of a B-value at an analysis is the true value of
-#' \eqn{theta} multiplied by the proportion of total planned observations at
+#' \eqn{\theta} multiplied by the proportion of total planned observations at
 #' that time. See Proschan, Lan and Wittes (2006).
 #'
 #' @param x Object of class \code{gsDesign} for \code{plot.gsDesign()} or

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,8 @@ url: https://keaven.github.io/gsDesign/
 
 template:
   bootstrap: 5
+  bslib:
+    preset: "bootstrap"
 
 reference:
 - title: Group Sequential Computation

--- a/man/gsDesign-package.Rd
+++ b/man/gsDesign-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{gsDesign-package}
 \alias{gsDesign-package}
-\alias{_PACKAGE}
 \title{gsDesign: Group Sequential Design}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}

--- a/man/plot.gsDesign.Rd
+++ b/man/plot.gsDesign.Rd
@@ -90,9 +90,9 @@ for a \code{gsProbability} object, the \code{theta} values from that object
 are used. For a \code{gsDesign} object where \code{theta} is input as
 \code{NULL} (the default), \code{theta=seq(0,2,.05)*x$delta}) is used.  For
 a \code{gsDesign} object, the x-axis values are rescaled to
-\code{theta/x$delta} and the label for the x-axis \eqn{theta / delta}. For a
+\code{theta/x$delta} and the label for the x-axis \eqn{\theta / \delta}. For a
 \code{gsProbability} object, the values of \code{theta} are plotted and are
-labeled as \eqn{theta}. See examples below.
+labeled as \eqn{\theta}. See examples below.
 
 Approximate treatment effects at boundaries are computed dividing the Z-values
 at the boundaries by the square root of \code{n.I} at that analysis.
@@ -116,7 +116,7 @@ the final analysis.
 
 B-values are Z-values multiplied by \code{sqrt(t)=sqrt(x$n.I/x$n.I[x$k])}.
 Thus, the expected value of a B-value at an analysis is the true value of
-\eqn{theta} multiplied by the proportion of total planned observations at
+\eqn{\theta} multiplied by the proportion of total planned observations at
 that time. See Proschan, Lan and Wittes (2006).
 }
 \note{


### PR DESCRIPTION
This PR:

- Set `preset` to `"bootstrap"` in `_pkgdown.yml` explicitly, to avoid the theming changes due to bslib 0.6.0 changing the default of `preset` to `"shiny"`.
- Fix the equation syntax in https://github.com/keaven/gsDesign/commit/bd70f66e346603229b46de2a7a84f0a714857ba1 so the math symbols render properly.
- Update to roxygen2 7.3.1.