### PR TITLE
Update plotgsPower() to use offset arg for Future Analysis legend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.6.0.1
+Version: 3.6.0.2
 Title: Group Sequential Design
 Authors@R: person(given = "Keaven", family = "Anderson", email =
           "keaven_anderson@merck.com", role = c('aut','cre'))

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -1,4 +1,4 @@
-globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "Future Analysis"))
+globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "Analysis"))
 
 # plot.gsDesign roxy [sinew] ----
 #' @title Plots for group sequential designs
@@ -812,8 +812,9 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
 #' @importFrom ggplot2 ggplot aes geom_line ylab guides guide_legend xlab scale_linetype_manual scale_color_manual scale_y_continuous ggtitle scale_x_continuous scale_colour_manual geom_text
 #' @importFrom rlang !! sym
 #' @importFrom graphics plot axis lines strwidth text
-#' @param offset Integer to offset the numeric labels of the Future Analysis
-#'   legend (default: 0)
+#' @param offset Integer to offset the numeric labels of the "Analysis" legend
+#'   (default: 0). Only relevant for \code{outtype = 1}. By default will change
+#'   legend title to "Future Analysis".
 # plotgsPower function [sinew] ----
 plotgsPower <- function(x, main = "Boundary crossing probabilities by effect size",
                         ylab = "Cumulative Boundary Crossing Probability",
@@ -863,8 +864,14 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     
     y2$Probability[y2$Bound == "1-Lower bound"] <- 1 - y2$Probability[y2$Bound == "1-Lower bound"]
     
-    y2$`Future Analysis` <- factor(y$id + offset)
+    y2$Analysis <- factor(y$id + offset)
     
+    # Determine title of Analysis legend
+    titleAnalysis <- "Analysis"
+    if (offset > 0) {
+      titleAnalysis <- "Future Analysis"
+    }
+
     y2$delta <- xval[y$thetaidx]
     
     p <- ggplot2::ggplot(y2, 
@@ -872,17 +879,17 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
                            x = !!rlang::sym('delta'), 
                            y = !!rlang::sym('Probability'), 
                            col = !!rlang::sym('Bound'), 
-                           lty = !!rlang::sym('Future Analysis'))
+                           lty = !!rlang::sym('Analysis'))
                          ) + 
       ggplot2::geom_line(size = lwd) + 
       ggplot2::ylab(ylab) +
       ggplot2::guides(color = ggplot2::guide_legend(title = "Probability")) + 
       ggplot2::xlab(xlab) +
-      ggplot2::scale_linetype_manual(values = lty) +
+      ggplot2::scale_linetype_manual(values = lty, name = titleAnalysis) +
       ggplot2::scale_color_manual(values = getColor(col)) +
       ggplot2::scale_y_continuous(breaks = seq(0, 1, .2))
     
-      return(p + ggplot2::ggtitle(label = main))
+    return(p + ggplot2::ggtitle(label = main))
   }
   if (is.null(col)) {
     if (base || outtype == 2) {

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -814,15 +814,23 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
 #' @importFrom graphics plot axis lines strwidth text
 #' @param offset Integer to offset the numeric labels of the "Analysis" legend
 #'   (default: 0). Only relevant for \code{outtype = 1}. By default will change
-#'   legend title to "Future Analysis".
+#'   legend title to "Future Analysis". To customize the title, pass the label
+#'   to the argument \code{titleAnalysisCustom}
+#' @param titleAnalysisCustom Label to use as the title for the "Analysis"
+#'   legend (default: NULL)
 # plotgsPower function [sinew] ----
 plotgsPower <- function(x, main = "Boundary crossing probabilities by effect size",
                         ylab = "Cumulative Boundary Crossing Probability",
                         xlab = NULL, lty = NULL, col = NULL, lwd = 1, cex = 1,
                         theta = if (inherits(x, "gsDesign")) seq(0, 2, .05) * x$delta else x$theta,
-                        xval = NULL, base = FALSE, outtype = 1, offset = 0, ...) {
+                        xval = NULL, base = FALSE, outtype = 1, offset = 0,
+                        titleAnalysisCustom = NULL, ...) {
 
-  stopifnot(is.numeric(offset) && length(offset) == 1)
+  stopifnot(
+    is.numeric(offset) && length(offset) == 1,
+    is.null(titleAnalysisCustom) ||
+      (is.character(titleAnalysisCustom) && length(titleAnalysisCustom) == 1)
+  )
   if (is.null(xval)) {
     if (inherits(x, "gsDesign")) {
       xval <- x$delta0 + (x$delta1 - x$delta0) * theta / x$delta
@@ -870,6 +878,9 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     titleAnalysis <- "Analysis"
     if (offset > 0) {
       titleAnalysis <- "Future Analysis"
+    }
+    if (!is.null(titleAnalysisCustom)) {
+      titleAnalysis <- titleAnalysisCustom
     }
 
     y2$delta <- xval[y$thetaidx]

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -1,4 +1,4 @@
-globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "Analysis"))
+globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "Future Analysis"))
 
 # plot.gsDesign roxy [sinew] ----
 #' @title Plots for group sequential designs
@@ -812,13 +812,16 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
 #' @importFrom ggplot2 ggplot aes geom_line ylab guides guide_legend xlab scale_linetype_manual scale_color_manual scale_y_continuous ggtitle scale_x_continuous scale_colour_manual geom_text
 #' @importFrom rlang !! sym
 #' @importFrom graphics plot axis lines strwidth text
+#' @param offset Integer to offset the numeric labels of the Future Analysis
+#'   legend (default: 0)
 # plotgsPower function [sinew] ----
 plotgsPower <- function(x, main = "Boundary crossing probabilities by effect size",
                         ylab = "Cumulative Boundary Crossing Probability",
                         xlab = NULL, lty = NULL, col = NULL, lwd = 1, cex = 1,
                         theta = if (inherits(x, "gsDesign")) seq(0, 2, .05) * x$delta else x$theta,
-                        xval = NULL, base = FALSE, outtype = 1, ...) {
+                        xval = NULL, base = FALSE, outtype = 1, offset = 0, ...) {
 
+  stopifnot(is.numeric(offset) && length(offset) == 1)
   if (is.null(xval)) {
     if (inherits(x, "gsDesign")) {
       xval <- x$delta0 + (x$delta1 - x$delta0) * theta / x$delta
@@ -860,7 +863,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     
     y2$Probability[y2$Bound == "1-Lower bound"] <- 1 - y2$Probability[y2$Bound == "1-Lower bound"]
     
-    y2$Analysis <- factor(y$id)
+    y2$`Future Analysis` <- factor(y$id + offset)
     
     y2$delta <- xval[y$thetaidx]
     
@@ -869,7 +872,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
                            x = !!rlang::sym('delta'), 
                            y = !!rlang::sym('Probability'), 
                            col = !!rlang::sym('Bound'), 
-                           lty = !!rlang::sym('Analysis'))
+                           lty = !!rlang::sym('Future Analysis'))
                          ) + 
       ggplot2::geom_line(size = lwd) + 
       ggplot2::ylab(ylab) +

--- a/tests/testthat/test-independent-test-plotgsPower.R
+++ b/tests/testthat/test-independent-test-plotgsPower.R
@@ -134,4 +134,19 @@ test_that(desc = 'Test: plotgsPower graphs can use offset arg for Future Analysi
     plotobj[["plot_env"]][["titleAnalysis"]],
     "Future Analysis"
   )
+
+  # Enable custom legend title
+  plotobj <- plotgsPower(x, titleAnalysisCustom = "custom")
+
+  expect_equal(
+    plotobj[["plot_env"]][["titleAnalysis"]],
+    "custom"
+  )
+
+  plotobj <- plotgsPower(x, offset = 1, titleAnalysisCustom = "custom")
+
+  expect_equal(
+    plotobj[["plot_env"]][["titleAnalysis"]],
+    "custom"
+  )
 })

--- a/tests/testthat/test-independent-test-plotgsPower.R
+++ b/tests/testthat/test-independent-test-plotgsPower.R
@@ -53,9 +53,9 @@ test_that(desc = 'check plot data values,
                 beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
   plotobj <- plotgsPower(x)
   
-  res_upper <- subset(plotobj$data, delta == 0 & `Future Analysis` == 3 &
+  res_upper <- subset(plotobj$data, delta == 0 & Analysis == 3 &
                   Bound == 'Upper bound')$Probability
-  res_lower <- subset(plotobj$data, delta == 0 & `Future Analysis` == 3 &
+  res_lower <- subset(plotobj$data, delta == 0 & Analysis == 3 &
                   Bound == '1-Lower bound')$Probability
   res <- 1 - res_lower + res_upper
   expect_lte(abs(res - 0.05000001), 1e-6)
@@ -68,9 +68,9 @@ test_that(desc = 'check plot data values,
                 beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
   plotobj <- plotgsPower(x)
   
-  res_upper <- subset(plotobj$data, delta == .15 & `Future Analysis` == 3 &
+  res_upper <- subset(plotobj$data, delta == .15 & Analysis == 3 &
                         Bound == 'Upper bound')$Probability
-  res_lower <- subset(plotobj$data, delta == .15 & `Future Analysis` == 3 &
+  res_lower <- subset(plotobj$data, delta == .15 & Analysis == 3 &
                         Bound == '1-Lower bound')$Probability
   res <- 1 - res_lower + res_upper
   expect_lte(abs(res - 0.36688393), 1e-3)
@@ -83,9 +83,9 @@ test_that(desc = 'check plot data values,
                  beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
    plotobj <- plotgsPower(x)
    
-   res_upper <- subset(plotobj$data, delta == .45 & `Future Analysis` == 3 &
+   res_upper <- subset(plotobj$data, delta == .45 & Analysis == 3 &
                          Bound == 'Upper bound')$Probability
-   res_lower <- subset(plotobj$data, delta == .45 & `Future Analysis` == 3 &
+   res_lower <- subset(plotobj$data, delta == .45 & Analysis == 3 &
                          Bound == '1-Lower bound')$Probability
    res <- 1 - res_lower + res_upper
    expect_lte(abs(res - 0.99808417), 1e-3)
@@ -108,10 +108,30 @@ test_that(desc = 'Test: plotgsPower graphs can use offset arg for Future Analysi
           code = {
   x <- gsDesign(k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
                 delta1 = 0.3, sfu = sfLDOF)
+
+  # Without offset
+  plotobj <- plotgsPower(x)
+
+  expect_equal(
+    levels(plotobj$data$Analysis),
+    as.character(1:3)
+  )
+
+  expect_equal(
+    plotobj[["plot_env"]][["titleAnalysis"]],
+    "Analysis"
+  )
+
+  # With offset
   plotobj <- plotgsPower(x, offset = 1)
 
   expect_equal(
-    levels(plotobj$data$`Future Analysis`),
+    levels(plotobj$data$Analysis),
     as.character(2:4)
+  )
+
+  expect_equal(
+    plotobj[["plot_env"]][["titleAnalysis"]],
+    "Future Analysis"
   )
 })

--- a/tests/testthat/test-independent-test-plotgsPower.R
+++ b/tests/testthat/test-independent-test-plotgsPower.R
@@ -53,9 +53,9 @@ test_that(desc = 'check plot data values,
                 beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
   plotobj <- plotgsPower(x)
   
-  res_upper <- subset(plotobj$data, delta == 0 & Analysis == 3 &
+  res_upper <- subset(plotobj$data, delta == 0 & `Future Analysis` == 3 &
                   Bound == 'Upper bound')$Probability
-  res_lower <- subset(plotobj$data, delta == 0 & Analysis == 3 & 
+  res_lower <- subset(plotobj$data, delta == 0 & `Future Analysis` == 3 &
                   Bound == '1-Lower bound')$Probability
   res <- 1 - res_lower + res_upper
   expect_lte(abs(res - 0.05000001), 1e-6)
@@ -68,9 +68,9 @@ test_that(desc = 'check plot data values,
                 beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
   plotobj <- plotgsPower(x)
   
-  res_upper <- subset(plotobj$data, delta == .15 & Analysis == 3 &
+  res_upper <- subset(plotobj$data, delta == .15 & `Future Analysis` == 3 &
                         Bound == 'Upper bound')$Probability
-  res_lower <- subset(plotobj$data, delta == .15 & Analysis == 3 & 
+  res_lower <- subset(plotobj$data, delta == .15 & `Future Analysis` == 3 &
                         Bound == '1-Lower bound')$Probability
   res <- 1 - res_lower + res_upper
   expect_lte(abs(res - 0.36688393), 1e-3)
@@ -83,9 +83,9 @@ test_that(desc = 'check plot data values,
                  beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
    plotobj <- plotgsPower(x)
    
-   res_upper <- subset(plotobj$data, delta == .45 & Analysis == 3 &
+   res_upper <- subset(plotobj$data, delta == .45 & `Future Analysis` == 3 &
                          Bound == 'Upper bound')$Probability
-   res_lower <- subset(plotobj$data, delta == .45 & Analysis == 3 & 
+   res_lower <- subset(plotobj$data, delta == .45 & `Future Analysis` == 3 &
                          Bound == '1-Lower bound')$Probability
    res <- 1 - res_lower + res_upper
    expect_lte(abs(res - 0.99808417), 1e-3)
@@ -102,4 +102,16 @@ test_that(desc = 'Test: plotgsPower graphs are correctly rendered,test.type = 1'
   local_edition(3)
   
   expect_snapshot_file(save_plot_obj, "plotgsPower_2.png")
+})
+
+test_that(desc = 'Test: plotgsPower graphs can use offset arg for Future Analysis legend',
+          code = {
+  x <- gsDesign(k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
+                delta1 = 0.3, sfu = sfLDOF)
+  plotobj <- plotgsPower(x, offset = 1)
+
+  expect_equal(
+    levels(plotobj$data$`Future Analysis`),
+    as.character(2:4)
+  )
 })


### PR DESCRIPTION
I changed the legend title from `Analysis` to `Future Analysis`. I did this by directly updating the column name in the underlying data that is passed to {ggplot2}. An alternative would be to keep the column name as `Analysis` and only change the legend title. Please let me know if that would be preferred.

I also added an argument `offset` to add an arbitrary integer value to the Future Analysis legend labels. I added a roxygen2 `@param` for this argument, but it's not being used. AFAICT there is no man page for `plotgsPower()`, but I am not familiar with [{sinew}](https://www.r-bloggers.com/2017/05/sinew-a-r-package-to-create-self-populating-roxygen2-skeletons/)

## Demonstration

```R
library("gsDesign")
x <- gsDesign(test.type = 1, delta1 = 0.3, sfu = sfLDOF)

# Future Analysis: 1, 2, 3
gsDesign:::plotgsPower(x)

# Future Analysis: 2, 3, 4
gsDesign:::plotgsPower(x, offset = 1)
```

![image](https://github.com/keaven/gsDesign/assets/1608317/21a85672-1c37-4649-a358-5b9a6e9ad2b8)

![image](https://github.com/keaven/gsDesign/assets/1608317/64dff147-39ce-4ab5-996c-c5639de97b21)
