### PR TITLE
Keaven's plotgsPower() updates

### DIFF
--- a/vignettes/SurvivalOverview.Rmd
+++ b/vignettes/SurvivalOverview.Rmd
@@ -61,6 +61,12 @@ Output for survival design information is supported in various formats:
 
 We will assume a hazard ratio $\nu < 1$ represents a benefit of experimental treatment over control.
 We let $\delta = \log\nu$ denote the so-called *natural parameter* for this case.
+We assume a randomization ratio (experimental:control) denoted by $r$, which is often 1 and $n$ represents the number of events observed in the combined treatment arms.
+Asymptotically the distribution of the Cox model estimate $\hat{\delta}$ under the proportional hazards assumption is (@Schoenfeld1981)
+$$\hat\delta\sim \hbox{Normal}(\delta=\log\nu, (1+r)^2/nr).$$
+The inverse of the variance is the statistical information:
+$$\mathcal I = nr/(1 + r)^2.$$
+
 Asymptotically the distribution of the Cox model estimate $\hat{\delta}$ under the proportional hazards assumption is
 $$\hat\delta\sim \hbox{Normal}(\delta=\log\nu, (1+r)^2/nr)$$ 
 where $n$ represents the number of events observed.
@@ -70,12 +76,12 @@ Using a Cox model to estimate $\delta$, the Wald test for $\hbox{H_0}: \delta=0$
 $$Z_W\approx \frac{\sqrt {nr}}{1+r}\hat\delta=\frac{\ln(\hat\nu)\sqrt{nr}}{1+r}.$$
 
 
-Also, we know that the Wald test $Z_W$ and a standard normal version of the logrank $Z$ are both asymptotically efficient and therefore asymptotically equivalent.
+Also, we know that the Wald test $Z_W$ and a standard normal version of the logrank $Z$ are both asymptotically efficient and therefore asymptotically equivalent, at least under a local hypothesis framework.
 We denote the *standardized effect size* as
 
 $$\theta = \delta\sqrt r / (1+r)= \log(\nu)\sqrt r / (1+r).$$
-Letting $\hat\theta = -\sqrt r/(1+r)\hat\delta$ we have
-$$ \hat \theta \sim \hbox{Normal}(\theta, 1/ n).$$
+Letting $\hat\theta = -\sqrt r/(1+r)\hat\delta$ and $n$ representing the number of events observed, we have
+$$\hat \theta \sim \hbox{Normal}(\theta, 1/ n).$$
 Thus, the standardized Z version of the logrank is approximately distributed as
 
 $$Z\sim\hbox{Normal}(\sqrt n\theta,1).$$
@@ -120,7 +126,7 @@ beta <- 0.1
 which, rounding up, matches (with tabular output):
 
 ```{r}
-nEvents(hr = hr, alpha = alpha, beta = beta, r = 1, tbl = TRUE) %>%
+nEvents(hr = hr, alpha = alpha, beta = beta, r = 1, tbl = TRUE) |>
   kable()
 ```
 
@@ -143,16 +149,16 @@ We can create a group sequential design for the above problem either with $\thet
 The name of the effect size is specified in `deltaname` and the parameter `logdelta = TRUE` indicates that `delta` input needs to be exponentiated to obtain HR in the output below.
 This example code can be useful in practice.
 We begin by passing the number of events for a fixed design in the parameter `n.fix` (continuous, not rounded) to adapt to a group sequential design.
-By rounding to integer event counts with the `toInteger()` function we increase the power slightly over the targeted 90%.
+We round the event counts at interims and round up at the final analysis with the `toInteger()` function; this creates a slight increase over the targeted 90% power.
 
 ```{r}
 Schoenfeld <- gsDesign(
   k = 2,
   n.fix = nEvents(hr = hr, alpha = alpha, beta = beta, r = 1),
   delta1 = log(hr)
-) |> toInteger() # Converts to integer event counts at analyses
-Schoenfeld %>%
-  gsBoundSummary(deltaname = "HR", logdelta = TRUE) %>%
+) |> toInteger()
+Schoenfeld |>
+  gsBoundSummary(deltaname = "HR", logdelta = TRUE, Nname = "Events") |>
   kable(row.names = FALSE)
 ```
 
@@ -161,7 +167,7 @@ Schoenfeld %>%
 Exactly the same result can be obtained with the following, passing the standardized effect size `theta` from above to the parameter `delta` in `gsDesign()`.
 
 ```{r, eval=FALSE}
-Schoenfeld <- gsDesign(k = 2, delta = -theta, delta1 = log(hr))
+Schoenfeld <- gsDesign(k = 2, delta = -theta, delta1 = log(hr)) |> toInteger()
 ```
 
 We noted above that the asymptotic variance for $\hat\theta$ is $1/n$ which corresponds to statistical information $\mathcal I=n$ for the parameter $\theta$.
@@ -198,7 +204,7 @@ $$ n = (z(1+r)/\log(\hat{\nu}))^2/r.$$
 
 ### Examples
 
-For our first example, we note that the event counts in `Schoenfeld` are actually continuous numbers that are rounded up in the table:
+We continue with the `Schoenfeld` example event counts:
 
 ```{r}
 Schoenfeld$n.I
@@ -361,8 +367,8 @@ lfgs <- gsSurv(
   alpha = alpha,
   beta = beta
 ) |> toInteger()
-lfgs %>%
-  gsBoundSummary() %>%
+lfgs |>
+  gsBoundSummary() |>
   kable(row.names = FALSE)
 ```
 
@@ -393,7 +399,7 @@ tibble::tibble(
   Analysis = 1:2,
   `Control events` = lfgs$eDC,
   `Experimental events` = lfgs$eDE
-) %>%
+) |>
   kable()
 ```
 


### PR DESCRIPTION
This is an alternative to #126. It is mostly identical. The minor differences are due to:

1. In #126, Keaven made a few extra edits while fixing the merge conflicts (eg `dgt = 4`). This PR does not contain those changes
2. In this PR, I was able to keep a final commit from Keaven that he made after merging master. We had removed this commit while preparing #126. However, I suspect that most of those edits were reverting to changes already in the master branch, because the differences I see locally with `git diff HEAD~1 vignettes/SurvivalOverview.Rmd` don't appear in this PR

In the end, both this PR and #126 edit the vignette `SurvivalOverview.Rmd`. We need to pick one and then close the other.