### PR TITLE
Minor maintenance

### DIFF
--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -818,6 +818,7 @@ plotASN <- function(x, xlab = NULL, ylab = NULL, main = NULL, theta = NULL, xval
 #'   to the argument \code{titleAnalysisLegend}
 #' @param titleAnalysisLegend Label to use as the title for the "Analysis"
 #'   legend (default: NULL)
+#' @noRd
 # plotgsPower function [sinew] ----
 plotgsPower <- function(x, main = "Boundary crossing probabilities by effect size",
                         ylab = "Cumulative Boundary Crossing Probability",

--- a/vignettes/SurvivalOverview.Rmd
+++ b/vignettes/SurvivalOverview.Rmd
@@ -121,7 +121,7 @@ beta <- 0.1
 which, rounding up, matches (with tabular output):
 
 ```{r}
-nEvents(hr = hr, alpha = alpha, beta = beta, r = 1, tbl = TRUE) |>
+nEvents(hr = hr, alpha = alpha, beta = beta, r = 1, tbl = TRUE) %>%
   kable()
 ```
 
@@ -151,9 +151,9 @@ Schoenfeld <- gsDesign(
   k = 2,
   n.fix = nEvents(hr = hr, alpha = alpha, beta = beta, r = 1),
   delta1 = log(hr)
-) |> toInteger()
-Schoenfeld |>
-  gsBoundSummary(deltaname = "HR", logdelta = TRUE, Nname = "Events") |>
+) %>% toInteger()
+Schoenfeld %>%
+  gsBoundSummary(deltaname = "HR", logdelta = TRUE, Nname = "Events") %>%
   kable(row.names = FALSE)
 ```
 
@@ -162,7 +162,7 @@ Schoenfeld |>
 Exactly the same result can be obtained with the following, passing the standardized effect size `theta` from above to the parameter `delta` in `gsDesign()`.
 
 ```{r, eval=FALSE}
-Schoenfeld <- gsDesign(k = 2, delta = -theta, delta1 = log(hr)) |> toInteger()
+Schoenfeld <- gsDesign(k = 2, delta = -theta, delta1 = log(hr)) %>% toInteger()
 ```
 
 We noted above that the asymptotic variance for $\hat\theta$ is $1/n$ which corresponds to statistical information $\mathcal I=n$ for the parameter $\theta$.
@@ -361,9 +361,9 @@ lfgs <- gsSurv(
   ratio = r,
   alpha = alpha,
   beta = beta
-) |> toInteger()
-lfgs |>
-  gsBoundSummary() |>
+) %>% toInteger()
+lfgs %>%
+  gsBoundSummary() %>%
   kable(row.names = FALSE)
 ```
 
@@ -394,7 +394,7 @@ tibble::tibble(
   Analysis = 1:2,
   `Control events` = lfgs$eDC,
   `Experimental events` = lfgs$eDE
-) |>
+) %>%
   kable()
 ```
 


### PR DESCRIPTION
This PR performs some minor maintenance. Thanks to @nanxstats for both suggestions.

First it removes the roxygen2 warning introduced in #121

```R
# before
devtools::document(roclets = "rd")
## ℹ Updating gsDesign documentation
## ℹ Loading gsDesign
## ✖ In topic 'plotgsPower.Rd': Skipping; no name and/or title.

# after
devtools::document(roclets = "rd")
## ℹ Updating gsDesign documentation
## ℹ Loading gsDesign
```

Second it replaces the native pipe with the magrittr pipe in the vignette `SurvivalOverview.Rmd` introduced in #126. Note that this is mostly for consistency. The native pipe was introduced in R 4.1, so if you use it in the package R code in `R/`, then you have to set the minimum R version to `R (>= 4.1.0)`. However, this isn't as strictly required when using the native pipe in examples and vignettes. This is because this code isn't run during installation, so a user could still install the package and run the code, but wouldn't be able to verbatim copy-paste the code in the examples/vignettes. This is discussed at length in this [r-package-devel thread](https://www.mail-archive.com/r-package-devel@r-project.org/msg09443.html). And there are even [workarounds](https://www.mail-archive.com/r-package-devel@r-project.org/msg09468.html) available if you wanted the package to be able to pass `R CMD check` with R 4.1. Given how the rest of the package continues to use the magrittr pipe, I recommend continuing to use it for consistency. At some point we can update all the vignettes to use the native pipe, and perhaps put a note in the news specifying that while the package is installable with R < 4.1, the vignettes require R >= 4.1.

