### PR TITLE
Update news for gsDesign 3.6.3

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown@2.0.9, local::.
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown@2.0.9, local::.
           needs: website
 
       - name: Build site

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.6.2
+Version: 3.6.3
 Title: Group Sequential Design
 Authors@R: person(given = "Keaven", family = "Anderson", email =
           "keaven_anderson@merck.com", role = c('aut','cre'))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# gsDesign 3.6.3 (July, 2024)
+
+## New features
+
+- Implemented conditional error spending functions `sfXG1()`, `sfXG2()`,
+  and `sfXG3()` based on Xi and Gallo (2019).
+  See `vignette("ConditionalErrorSpending")` for details and reproduced
+  examples from the literature (@keaven, #147. Thanks, @xidongdxi,
+  for comments on vignette).
+
+## Improvements
+
+- Enhanced `eEvents()` with input validation to ensure `lambda` is not `NULL`
+  (@keaven, [97f629d](https://github.com/keaven/gsDesign/commit/97f629d)).
+
+## Testing
+
+- Added independent testing for `gsSurvCalendar()` (@myeongjong, #144).
+- Expanded test coverage for `gsBinomialExact()` (@menglu2, #143).
+
 # gsDesign 3.6.2 (April, 2024)
 
 ## Documentation


### PR DESCRIPTION
This PR:

- Increment version number to 3.6.3
- Update changelog for gsDesign 3.6.3