### PR TITLE
Do not report parameter "none" for sfLDOF()

### DIFF
--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -808,7 +808,16 @@ summary.spendfn <- function(object, ...) {
     if (!is.null(object$param$parname)) {
       s <- paste(s, " with", paste(object$param$parname, collapse = " "), "=", paste(object$param$param, collapse = " "))
     }
-  } else {
+  }
+  else if (object$name == "Lan-DeMets O'Brien-Fleming approximation") {
+    if (object$parname == "none") {
+      s <- "Lan-DeMets O'Brien-Fleming approximation spending function (no parameters)"
+    }
+    else {
+      s <- paste(s, "with", paste(object$parname, collapse = " "), "=", paste(object$param, collapse = " "))
+    }
+  }
+  else {
     s <- paste(object$name, "spending function")
     if (!is.null(object$parname) && !is.null(object$param)) {
       s <- paste(s, "with", paste(object$parname, collapse = " "), "=", paste(object$param, collapse = " "))


### PR DESCRIPTION
Close #46

With this PR, the `summary()` method no longer reports `none = 1` for `sfLDOF()`

```R
summary(sfLDOF(alpha = 0.25, t = 0.5))
## [1] "Lan-DeMets O'Brien-Fleming approximation spending function (no parameters)"
summary(sfLDOF(alpha = 0.25, t = 0.5, param = 0))
## [1] "Lan-DeMets O'Brien-Fleming approximation spending function (no parameters)"
summary(sfLDOF(alpha = 0.25, t = 0.5, param = 1))
## [1] "Lan-DeMets O'Brien-Fleming approximation spending function (no parameters)"
summary(sfLDOF(alpha = 0.25, t = 0.5, param = 2))
## [1] "Generalized Lan-DeMets O'Brien-Fleming spending function with rho = 2"
```

I also checked `sfLDPocock()`, since it also has no parameters. However, it has `parname` and `param` set to `NULL`, so it already properly reports no parameters.

```R
summary(sfLDPocock(alpha = 0.25, t = 0.5))
[1] "Lan-DeMets Pocock approximation spending function"
```