### PR TITLE
Improve text summary of spending functions with multiple parameters

### DIFF
--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -820,7 +820,11 @@ summary.spendfn <- function(object, ...) {
   else {
     s <- paste(object$name, "spending function")
     if (!is.null(object$parname) && !is.null(object$param)) {
-      s <- paste(s, "with", paste(object$parname, collapse = " "), "=", paste(object$param, collapse = " "))
+      # Use %s for the numeric object$param in order to preserve the decimal
+      # places entered by the user
+      params <- sprintf("%s = %s", object$parname, round(object$param, digits = 5))
+      params <- paste(params, collapse = ", ")
+      s <- paste(s, "with", params)
     }
   }
   return(s)


### PR DESCRIPTION
Contributes to #160

I have improved the text summary of the spending functions with multiple parameters. Instead of `a b = 0.5 1.5`, they now return `a = 0.5, b = 1.5`. I'll address the more complex spending function text summaries in a future PR.


```R
# before

# 1 parameter
gsDesign(k = 2, test.type = 1, sfu = sfXG3, sfupar = .5) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Xi-Gallo, method 1 spending function with gamma = 0.5."

# 2 parameters
gsDesign(k = 2, test.type = 1, sfu = sfLogistic, sfupar = c(.5, 1.5)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Logistic spending function with a b = 0.5 1.5."

# >2 parameters
gsDesign(k = 2, test.type = 1, sfu = sfLogistic, sfupar = c(.5, .75, .2, .4)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Logistic spending function with a b = -1.38629436111989 0.892789260714372."
gsDesign(k = 2, test.type = 4, sfu = sfLDOF, sfl = sfLogistic, sflpar = c(.5, .75, .2, .4)) |> summary()
## [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Lan-DeMets O'Brien-Fleming approximation spending function (no parameters). Futility bounds derived using a Logistic spending function with a b = -1.38629436111989 0.892789260714372."
gsDesign(k = 2, test.type = 1, sfu = sfTDist, sfupar = c(.5, .75, .2, .4, 6)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a t-distribution spending function with a b df = -0.905703285180532 0.893124425838299 6."
gsDesign(k = 2, test.type = 1, sfu = sfTDist, sfupar = c(.1, 2, 6)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a t-distribution spending function with a b df = 0.1 2 6."

# after

# 1 parameter
gsDesign(k = 2, test.type = 1, sfu = sfXG3, sfupar = .5) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Xi-Gallo, method 1 spending function with gamma = 0.5."

# 2 parameters
gsDesign(k = 2, test.type = 1, sfu = sfLogistic, sfupar = c(.5, 1.5)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Logistic spending function with a = 0.5, b = 1.5."

# >2 parameters
gsDesign(k = 2, test.type = 1, sfu = sfLogistic, sfupar = c(.5, .75, .2, .4)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Logistic spending function with a = -1.38629, b = 0.89279."

gsDesign(k = 2, test.type = 4, sfu = sfLDOF, sfl = sfLogistic, sflpar = c(.5, .75, .2, .4)) |> summary()
## [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a Lan-DeMets O'Brien-Fleming approximation spending function (no parameters). Futility bounds derived using a Logistic spending function with a = -1.38629, b = 0.89279."

gsDesign(k = 2, test.type = 1, sfu = sfTDist, sfupar = c(.5, .75, .2, .4, 6)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a t-distribution spending function with a = -0.9057, b = 0.89312, df = 6."

gsDesign(k = 2, test.type = 1, sfu = sfTDist, sfupar = c(.1, 2, 6)) |> summary()
## [1] "One-sided group sequential design with 2 analyses, sample size 2, 90 percent power, 2.5 percent (1-sided) Type I error. Efficacy bounds derived using a t-distribution spending function with a = 0.1, b = 2, df = 6."
```
