### PR TITLE
Add `cph` role to `Authors@R` field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,10 @@
 Package: gsDesign
 Version: 3.6.4
 Title: Group Sequential Design
-Authors@R: person(given = "Keaven", family = "Anderson", email =
-          "keaven_anderson@merck.com", role = c('aut','cre'))
+Authors@R: c(
+    person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
+    )
 Description: Derives group sequential clinical trial designs and describes
     their properties. Particular focus on time-to-event, binary, and
     continuous outcomes. Largely based on methods described in
@@ -10,7 +12,6 @@ Description: Derives group sequential clinical trial designs and describes
     "Group Sequential Methods with Applications to Clinical Trials"
     ISBN: 0-8493-0316-8.
 License: GPL (>= 3)
-Copyright: Copyright 2010, Merck Research Laboratories
 URL: https://keaven.github.io/gsDesign/, https://github.com/keaven/gsDesign
 BugReports: https://github.com/keaven/gsDesign/issues
 Encoding: UTF-8


### PR DESCRIPTION
From [CRAN repository policies](https://cran.r-project.org/web/packages/policies.html):

> Where copyrights are held by an entity other than the package authors, this should preferably be indicated via `cph` roles in the `Authors@R` field, or using a `Copyright` field (if necessary referring to an `inst/COPYRIGHTS` file).

This PR adds the `cph` role (with the latest recommended copyright text) to the `Authors@R` field, to supersede the use of `Copyright` field.

A more practical benefit of using `Authors@R` is for the pkgdown site: a proper `authors.html` will be generated and linked as "More about authors..." under the Developers section of the sidebar on the landing page.