### PR TITLE
Update news for gsDesign 3.6.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.6.4
+Version: 3.6.5
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# gsDesign 3.6.5 (November, 2024)
+
+## Improvements
+
+- `toInteger()` (introduced in gsDesign 3.5.0) is updated to match broader,
+  non-gsDesign conventions for deriving integer sample size and event counts
+  (@keaven, #172).
+
+  This update may result in different outputs compared to previous versions.
+  Users who use this function should review the updated function documentation
+  (`?toInteger`) and `vignette("toInteger")` for details.
+
+## Testing
+
+- Add snapshot tests for `as_rtf()` methods (@DMuriuki, #168).
+
+## Documentation
+
+- Add the `cph` role to the `Authors@R` field following best practices
+  (@nanxstats, #166).
+
 # gsDesign 3.6.4 (July, 2024)
 
 ## Improvements

--- a/R/toInteger.R
+++ b/R/toInteger.R
@@ -22,7 +22,7 @@
 #'
 #' @details
 #' It is useful to explicitly provide the argument \code{ratio} when a
-#' \code{gsDesign} object is input since \code{gsDesign} does not have a
+#' \code{gsDesign} object is input since \code{gsDesign()} does not have a
 #' \code{ratio} in return.
 #' \code{ratio = 0, roundUpFinal = TRUE} will just round up the sample size
 #' (also event count).

--- a/man/gsDesign-package.Rd
+++ b/man/gsDesign-package.Rd
@@ -21,5 +21,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Keaven Anderson \email{keaven_anderson@merck.com}
 
+Other contributors:
+\itemize{
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder]
+}
+
 }
 \keyword{internal}

--- a/man/toInteger.Rd
+++ b/man/toInteger.Rd
@@ -36,7 +36,7 @@ or sample size (other designs)
 }
 \details{
 It is useful to explicitly provide the argument \code{ratio} when a
-\code{gsDesign} object is input since \code{gsDesign} does not have a
+\code{gsDesign} object is input since \code{gsDesign()} does not have a
 \code{ratio} in return.
 \code{ratio = 0, roundUpFinal = TRUE} will just round up the sample size
 (also event count).


### PR DESCRIPTION
This PR:

- Does a minor fix on `toInteger()` docs and runs roxygen2
- Increments version number to 3.6.5
- Updates changelog for gsDesign 3.6.5