### PR TITLE
Refactor graphical tests with `vdiffr::expect_doppelganger()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Suggests:
     rmarkdown,
     scales,
     testthat,
-    utils
+    utils,
+    vdiffr
 VignetteBuilder:
     knitr
 RoxygenNote: 7.3.2

--- a/tests/testthat/_snaps/independent-test-hGraph/alpha-allocation-hypotheses-names-transitions.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/alpha-allocation-hypotheses-names-transitions.svg
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='178.90,106.02 178.35,98.24 176.69,90.57 173.96,83.14 170.20,76.05 165.45,69.42 159.81,63.34 153.34,57.91 146.15,53.21 138.35,49.31 130.06,46.27 121.39,44.14 112.49,42.94 103.49,42.70 94.52,43.42 85.72,45.09 77.23,47.68 69.17,51.16 61.66,55.47 54.82,60.54 48.75,66.30 43.55,72.67 39.28,79.54 36.03,86.82 33.83,94.38 32.73,102.12 32.73,109.92 33.83,117.66 36.03,125.23 39.28,132.50 43.55,139.37 48.75,145.74 54.82,151.50 61.66,156.58 69.17,160.89 77.23,164.36 85.72,166.95 94.52,168.62 103.49,169.34 112.49,169.10 121.39,167.91 130.06,165.77 138.35,162.73 146.15,158.83 153.34,154.13 159.81,148.70 165.45,142.62 170.20,135.99 173.96,128.91 176.69,121.47 178.35,113.81 178.90,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,106.02 686.72,98.24 685.06,90.57 682.33,83.14 678.57,76.05 673.83,69.42 668.18,63.34 661.71,57.91 654.53,53.21 646.73,49.31 638.43,46.27 629.77,44.14 620.87,42.94 611.86,42.70 602.90,43.42 594.10,45.09 585.60,47.68 577.54,51.16 570.03,55.47 563.19,60.54 557.12,66.30 551.92,72.67 547.66,79.54 544.40,86.82 542.21,94.38 541.10,102.12 541.10,109.92 542.21,117.66 544.40,125.23 547.66,132.50 551.92,139.37 557.12,145.74 563.19,151.50 570.03,156.58 577.54,160.89 585.60,164.36 594.10,166.95 602.90,168.62 611.86,169.34 620.87,169.10 629.77,167.91 638.43,165.77 646.73,162.73 654.53,158.83 661.71,154.13 668.18,148.70 673.83,142.62 678.57,135.99 682.33,128.91 685.06,121.47 686.72,113.81 687.27,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='433.09,487.28 432.53,479.50 430.88,471.83 428.15,464.40 424.38,457.31 419.64,450.68 413.99,444.60 407.53,439.17 400.34,434.47 392.54,430.57 384.24,427.53 375.58,425.40 366.68,424.20 357.68,423.96 348.71,424.68 339.91,426.35 331.42,428.94 323.35,432.42 315.84,436.73 309.00,441.80 302.94,447.57 297.73,453.93 293.47,460.80 290.22,468.08 288.02,475.64 286.91,483.38 286.91,491.18 288.02,498.92 290.22,506.49 293.47,513.76 297.73,520.63 302.94,527.00 309.00,532.76 315.84,537.84 323.35,542.15 331.42,545.62 339.91,548.22 348.71,549.89 357.68,550.60 366.68,550.36 375.58,549.17 384.24,547.03 392.54,543.99 400.34,540.09 407.53,535.39 413.99,529.96 419.64,523.89 424.38,517.25 428.15,510.17 430.88,502.74 432.53,495.07 433.09,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='105.74' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='37.95px' lengthAdjust='spacingAndGlyphs'>ORR</text>
+<text x='105.74' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<text x='614.12' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='33.21px' lengthAdjust='spacingAndGlyphs'>PFS</text>
+<text x='614.12' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.007</text>
+<text x='359.93' y='480.87' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='24.68px' lengthAdjust='spacingAndGlyphs'>OS</text>
+<text x='359.93' y='505.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.013</text>
+<line x1='176.62' y1='89.57' x2='543.24' y2='89.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='533.56,95.16 543.24,89.57 533.56,83.99 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='595.13' y1='167.40' x2='411.82' y2='442.35' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='412.54,431.20 411.82,442.35 421.83,437.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='308.05' y1='442.35' x2='124.74' y2='167.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='134.75,172.35 124.74,167.40 125.46,178.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='284.15' y='80.04' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='519.35' y='249.52' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='232.27' y='341.17' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='298.83' y='93.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='534.02' y='262.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='246.94' y='354.62' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='270.07px' lengthAdjust='spacingAndGlyphs'>alpha allocation hypotheses names transitions</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/alpha-digits.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/alpha-digits.svg
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='496.87,106.02 495.83,98.24 492.73,90.57 487.62,83.14 480.57,76.05 471.69,69.42 461.11,63.34 449.00,57.91 435.54,53.21 420.94,49.31 405.40,46.27 389.18,44.14 372.51,42.94 355.65,42.70 338.86,43.42 322.38,45.09 306.47,47.68 291.37,51.16 277.31,55.47 264.50,60.54 253.14,66.30 243.39,72.67 235.41,79.54 229.32,86.82 225.20,94.38 223.13,102.12 223.13,109.92 225.20,117.66 229.32,125.23 235.41,132.50 243.39,139.37 253.14,145.74 264.50,151.50 277.31,156.58 291.37,160.89 306.47,164.36 322.38,166.95 338.86,168.62 355.65,169.34 372.51,169.10 389.18,167.91 405.40,165.77 420.94,162.73 435.54,158.83 449.00,154.13 461.11,148.70 471.69,142.62 480.57,135.99 487.62,128.91 492.73,121.47 495.83,113.81 496.87,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,487.28 686.23,479.50 683.13,471.83 678.02,464.40 670.97,457.31 662.09,450.68 651.52,444.60 639.41,439.17 625.95,434.47 611.34,430.57 595.81,427.53 579.58,425.40 562.92,424.20 546.06,423.96 529.26,424.68 512.78,426.35 496.87,428.94 481.78,432.42 467.71,436.73 454.91,441.80 443.54,447.57 433.80,453.93 425.82,460.80 419.72,468.08 415.61,475.64 413.54,483.38 413.54,491.18 415.61,498.92 419.72,506.49 425.82,513.76 433.80,520.63 443.54,527.00 454.91,532.76 467.71,537.84 481.78,542.15 496.87,545.62 512.78,548.22 529.26,549.89 546.06,550.60 562.92,550.36 579.58,549.17 595.81,547.03 611.34,543.99 625.95,540.09 639.41,535.39 651.52,529.96 662.09,523.89 670.97,517.25 678.02,510.17 683.13,502.74 686.23,495.07 687.27,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='306.46,487.28 305.43,479.50 302.33,471.83 297.21,464.40 290.16,457.31 281.28,450.68 270.71,444.60 258.60,439.17 245.14,434.47 230.53,430.57 215.00,427.53 198.77,425.40 182.11,424.20 165.25,423.96 148.45,424.68 131.97,426.35 116.07,428.94 100.97,432.42 86.91,436.73 74.10,441.80 62.73,447.57 52.99,453.93 45.01,460.80 38.91,468.08 34.80,475.64 32.73,483.38 32.73,491.18 34.80,498.92 38.91,506.49 45.01,513.76 52.99,520.63 62.73,527.00 74.10,532.76 86.91,537.84 100.97,542.15 116.07,545.62 131.97,548.22 148.45,549.89 165.25,550.60 182.11,550.36 198.77,549.17 215.00,547.03 230.53,543.99 245.14,540.09 258.60,535.39 270.71,529.96 281.28,523.89 290.16,517.25 297.21,510.17 302.33,502.74 305.43,495.07 306.46,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='359.87' y='100.67' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='359.87' y='121.16' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='54.19px' lengthAdjust='spacingAndGlyphs'>w=0.008</text>
+<text x='550.27' y='481.94' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='550.27' y='502.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='54.19px' lengthAdjust='spacingAndGlyphs'>w=0.008</text>
+<text x='169.47' y='481.94' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='169.47' y='502.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='54.19px' lengthAdjust='spacingAndGlyphs'>w=0.008</text>
+<line x1='411.35' y1='164.94' x2='540.68' y2='423.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.70,414.65 540.68,423.89 541.69,407.16 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='350.28' y1='169.41' x2='220.95' y2='428.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='219.94,411.64 220.95,428.37 234.93,419.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='498.79' y1='428.37' x2='369.46' y2='169.41' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='383.45,178.65 369.46,169.41 368.45,186.14 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='414.55' y1='497.22' x2='305.19' y2='497.22' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='319.70,488.84 305.19,497.22 319.70,505.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='179.06' y1='423.89' x2='308.39' y2='164.94' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='309.40,181.67 308.39,164.94 294.40,174.18 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='305.19' y1='477.34' x2='414.55' y2='477.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='400.04,485.72 414.55,477.34 400.04,468.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='426.98' y='241.72' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='279.68' y='246.20' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='428.20' y='332.52' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='350.62' y='487.69' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='194.69' y='328.04' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='314.16' y='467.81' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='454.46' y='255.17' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='307.17' y='259.65' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='455.68' y='345.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='378.10' y='501.14' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='222.17' y='341.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='341.64' y='481.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='66.78px' lengthAdjust='spacingAndGlyphs'>alpha digits</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/basic-layout.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/basic-layout.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='203.20,108.86 202.55,100.73 200.62,92.72 197.43,84.95 193.04,77.55 187.51,70.62 180.93,64.27 173.39,58.59 165.01,53.68 155.91,49.61 146.24,46.43 136.13,44.20 125.75,42.95 115.25,42.70 104.79,43.45 94.53,45.19 84.63,47.90 75.22,51.54 66.47,56.04 58.49,61.34 51.41,67.36 45.34,74.02 40.37,81.20 36.58,88.79 34.02,96.70 32.73,104.79 32.73,112.94 34.02,121.02 36.58,128.93 40.37,136.53 45.34,143.71 51.41,150.36 58.49,156.38 66.47,161.69 75.22,166.19 84.63,169.82 94.53,172.53 104.79,174.27 115.25,175.02 125.75,174.77 136.13,173.52 146.24,171.29 155.91,168.12 165.01,164.04 173.39,159.13 180.93,153.46 187.51,147.11 193.04,140.18 197.43,132.77 200.62,125.01 202.55,117.00 203.20,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,108.86 686.63,100.73 684.70,92.72 681.51,84.95 677.12,77.55 671.59,70.62 665.01,64.27 657.47,58.59 649.08,53.68 639.99,49.61 630.31,46.43 620.21,44.20 609.83,42.95 599.33,42.70 588.87,43.45 578.61,45.19 568.70,47.90 559.30,51.54 550.54,56.04 542.57,61.34 535.49,67.36 529.42,74.02 524.45,81.20 520.66,88.79 518.09,96.70 516.80,104.79 516.80,112.94 518.09,121.02 520.66,128.93 524.45,136.53 529.42,143.71 535.49,150.36 542.57,156.38 550.54,161.69 559.30,166.19 568.70,169.82 578.61,172.53 588.87,174.27 599.33,175.02 609.83,174.77 620.21,173.52 630.31,171.29 639.99,168.12 649.08,164.04 657.47,159.13 665.01,153.46 671.59,147.11 677.12,140.18 681.51,132.77 684.70,125.01 686.63,117.00 687.27,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,484.44 686.63,476.31 684.70,468.30 681.51,460.53 677.12,453.13 671.59,446.20 665.01,439.85 657.47,434.17 649.08,429.26 639.99,425.19 630.31,422.01 620.21,419.78 609.83,418.53 599.33,418.28 588.87,419.03 578.61,420.78 568.70,423.48 559.30,427.12 550.54,431.62 542.57,436.92 535.49,442.94 529.42,449.60 524.45,456.78 520.66,464.38 518.09,472.28 516.80,480.37 516.80,488.52 518.09,496.61 520.66,504.51 524.45,512.11 529.42,519.29 535.49,525.94 542.57,531.96 550.54,537.27 559.30,541.77 568.70,545.40 578.61,548.11 588.87,549.85 599.33,550.60 609.83,550.35 620.21,549.10 630.31,546.87 639.99,543.70 649.08,539.62 657.47,534.71 665.01,529.04 671.59,522.69 677.12,515.76 681.51,508.35 684.70,500.59 686.63,492.58 687.27,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='203.20,484.44 202.55,476.31 200.62,468.30 197.43,460.53 193.04,453.13 187.51,446.20 180.93,439.85 173.39,434.17 165.01,429.26 155.91,425.19 146.24,422.01 136.13,419.78 125.75,418.53 115.25,418.28 104.79,419.03 94.53,420.78 84.63,423.48 75.22,427.12 66.47,431.62 58.49,436.92 51.41,442.94 45.34,449.60 40.37,456.78 36.58,464.38 34.02,472.28 32.73,480.37 32.73,488.52 34.02,496.61 36.58,504.51 40.37,512.11 45.34,519.29 51.41,525.94 58.49,531.96 66.47,537.27 75.22,541.77 84.63,545.40 94.53,548.11 104.79,549.85 115.25,550.60 125.75,550.35 136.13,549.10 146.24,546.87 155.91,543.70 165.01,539.62 173.39,534.71 180.93,529.04 187.51,522.69 193.04,515.76 197.43,508.35 200.62,500.59 202.55,492.58 203.20,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='117.88' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='117.88' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='601.96' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='601.96' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='601.96' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='601.96' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='117.88' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='117.88' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<line x1='201.81' y1='95.91' x2='518.03' y2='95.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,101.50 518.03,95.91 508.35,90.32 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='189.03' y1='145.75' x2='554.42' y2='429.24' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='543.35,427.72 554.42,429.24 550.19,418.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='134.58' y1='173.98' x2='134.58' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='128.99,409.65 134.58,419.32 140.16,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='121.81' x2='201.81' y2='121.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,116.23 201.81,121.81 211.49,127.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='618.65' y1='173.98' x2='618.65' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='613.07,409.65 618.65,419.32 624.24,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='554.42' y1='164.07' x2='189.03' y2='447.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='193.25,437.21 189.03,447.56 200.10,446.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='530.81' y1='447.56' x2='165.42' y2='164.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='176.49,165.58 165.42,164.07 169.64,174.41 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='585.26' y1='419.32' x2='585.26' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.85,183.66 585.26,173.98 579.68,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='497.40' x2='201.81' y2='497.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,491.81 201.81,497.40 211.49,502.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.19' y1='419.32' x2='101.19' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='106.77,183.66 101.19,173.98 95.60,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='165.42' y1='429.24' x2='530.81' y2='145.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.58,156.09 530.81,145.75 519.74,147.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='471.49' x2='518.03' y2='471.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,477.08 518.03,471.49 508.35,465.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='290.10' y='85.95' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='293.71' y='230.29' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='117.46' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='111.86' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='601.54' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='415.51' y='248.60' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='391.90' y='343.10' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='568.15' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='487.44' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='84.07' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='270.10' y='324.78' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='461.53' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='307.22' y='99.82' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='310.83' y='244.16' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='134.58' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='125.73' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='618.65' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='432.62' y='262.48' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='409.01' y='356.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='585.26' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='501.31' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='101.19' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='287.22' y='338.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='475.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='69.72px' lengthAdjust='spacingAndGlyphs'>basic layout</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/clockwise-order.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/clockwise-order.svg
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='267.61,97.54 267.10,90.80 265.56,84.16 263.02,77.72 259.52,71.58 255.12,65.84 249.87,60.58 243.86,55.87 237.18,51.80 229.94,48.43 222.23,45.79 214.18,43.94 205.91,42.91 197.55,42.70 189.21,43.32 181.04,44.77 173.14,47.01 165.65,50.02 158.68,53.76 152.32,58.15 146.68,63.14 141.85,68.66 137.89,74.61 134.87,80.91 132.82,87.46 131.80,94.16 131.80,100.92 132.82,107.62 134.87,114.17 137.89,120.47 141.85,126.42 146.68,131.94 152.32,136.93 158.68,141.33 165.65,145.06 173.14,148.07 181.04,150.31 189.21,151.76 197.55,152.38 205.91,152.17 214.18,151.14 222.23,149.29 229.94,146.66 237.18,143.28 243.86,139.21 249.87,134.50 255.12,129.24 259.52,123.50 263.02,117.36 265.56,110.92 267.10,104.28 267.61,97.54 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='588.20,97.54 587.69,90.80 586.15,84.16 583.61,77.72 580.12,71.58 575.71,65.84 570.46,60.58 564.46,55.87 557.78,51.80 550.53,48.43 542.82,45.79 534.77,43.94 526.50,42.91 518.14,42.70 509.81,43.32 501.63,44.77 493.74,47.01 486.25,50.02 479.27,53.76 472.91,58.15 467.28,63.14 462.44,68.66 458.48,74.61 455.46,80.91 453.42,87.46 452.39,94.16 452.39,100.92 453.42,107.62 455.46,114.17 458.48,120.47 462.44,126.42 467.28,131.94 472.91,136.93 479.27,141.33 486.25,145.06 493.74,148.07 501.63,150.31 509.81,151.76 518.14,152.38 526.50,152.17 534.77,151.14 542.82,149.29 550.53,146.66 557.78,143.28 564.46,139.21 570.46,134.50 575.71,129.24 580.12,123.50 583.61,117.36 586.15,110.92 587.69,104.28 588.20,97.54 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,343.66 686.76,336.91 685.22,330.27 682.68,323.84 679.18,317.70 674.78,311.96 669.53,306.69 663.52,301.99 656.85,297.92 649.60,294.54 641.89,291.91 633.84,290.06 625.57,289.02 617.21,288.81 608.87,289.44 600.70,290.88 592.81,293.13 585.31,296.14 578.34,299.87 571.98,304.27 566.34,309.26 561.51,314.77 557.55,320.72 554.53,327.02 552.49,333.57 551.46,340.28 551.46,347.03 552.49,353.74 554.53,360.29 557.55,366.59 561.51,372.54 566.34,378.05 571.98,383.05 578.34,387.44 585.31,391.17 592.81,394.18 600.70,396.43 608.87,397.87 617.21,398.50 625.57,398.29 633.84,397.25 641.89,395.40 649.60,392.77 656.85,389.39 663.52,385.32 669.53,380.62 674.78,375.36 679.18,369.61 682.68,363.48 685.22,357.04 686.76,350.40 687.27,343.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='427.91,495.76 427.39,489.02 425.85,482.38 423.32,475.94 419.82,469.81 415.41,464.06 410.17,458.80 404.16,454.10 397.48,450.03 390.23,446.65 382.53,444.02 374.48,442.17 366.21,441.13 357.84,440.92 349.51,441.55 341.33,442.99 333.44,445.24 325.95,448.25 318.97,451.98 312.62,456.37 306.98,461.37 302.14,466.88 298.19,472.83 295.16,479.13 293.12,485.68 292.09,492.39 292.09,499.14 293.12,505.85 295.16,512.40 298.19,518.70 302.14,524.65 306.98,530.16 312.62,535.15 318.97,539.55 325.95,543.28 333.44,546.29 341.33,548.54 349.51,549.98 357.84,550.60 366.21,550.40 374.48,549.36 382.53,547.51 390.23,544.88 397.48,541.50 404.16,537.43 410.17,532.73 415.41,527.46 419.82,521.72 423.32,515.58 425.85,509.15 427.39,502.51 427.91,495.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='168.54,343.66 168.03,336.91 166.49,330.27 163.95,323.84 160.46,317.70 156.05,311.96 150.80,306.69 144.79,301.99 138.12,297.92 130.87,294.54 123.16,291.91 115.11,290.06 106.84,289.02 98.48,288.81 90.14,289.44 81.97,290.88 74.08,293.13 66.58,296.14 59.61,299.87 53.25,304.27 47.61,309.26 42.78,314.77 38.82,320.72 35.80,327.02 33.76,333.57 32.73,340.28 32.73,347.03 33.76,353.74 35.80,360.29 38.82,366.59 42.78,372.54 47.61,378.05 53.25,383.05 59.61,387.44 66.58,391.17 74.08,394.18 81.97,396.43 90.14,397.87 98.48,398.50 106.84,398.29 115.11,397.25 123.16,395.40 130.87,392.77 138.12,389.39 144.79,385.32 150.80,380.62 156.05,375.36 160.46,369.61 163.95,363.48 166.49,357.04 168.03,350.40 168.54,343.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='199.64' y='91.12' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='199.64' y='115.71' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<text x='520.23' y='91.12' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='520.23' y='115.71' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<text x='619.30' y='337.24' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='619.30' y='361.82' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<text x='359.94' y='489.35' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='359.94' y='513.93' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<text x='100.57' y='337.24' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H5</text>
+<text x='100.57' y='361.82' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='65.03px' lengthAdjust='spacingAndGlyphs'>w=0.005</text>
+<line x1='266.98' y1='88.93' x2='452.89' y2='88.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='443.22,94.52 452.89,88.93 443.22,83.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='260.39' y1='122.52' x2='571.09' y2='304.74' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='559.92,304.67 571.09,304.74 565.57,295.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='230.59' y1='146.58' x2='349.27' y2='441.41' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='340.47,434.52 349.27,441.41 350.84,430.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='188.97' y1='151.90' x2='131.52' y2='294.62' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='129.95,283.56 131.52,294.62 140.32,287.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='452.89' y1='106.15' x2='266.98' y2='106.15' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='276.65,100.56 266.98,106.15 276.65,111.74 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='551.18' y1='146.58' x2='608.63' y2='289.30' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='599.84,282.41 608.63,289.30 610.20,278.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='509.57' y1='151.90' x2='390.89' y2='446.73' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='389.32,435.67 390.89,446.73 399.68,439.84 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='472.02' y1='136.45' x2='161.32' y2='318.67' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='166.84,308.96 161.32,318.67 172.49,318.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='558.55' y1='318.67' x2='247.85' y2='136.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='259.02,136.53 247.85,136.45 253.37,146.17 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='588.35' y1='294.62' x2='530.90' y2='151.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='539.69,158.79 530.90,151.90 529.33,162.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='571.09' y1='382.57' x2='420.68' y2='470.78' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='426.20,461.06 420.68,470.78 431.86,470.70 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='551.96' y1='352.26' x2='167.91' y2='352.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='177.59,346.68 167.91,352.26 177.59,357.85 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='328.98' y1='446.73' x2='210.30' y2='151.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='219.10,158.79 210.30,151.90 208.74,162.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='370.60' y1='441.41' x2='489.28' y2='146.58' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='490.85,157.64 489.28,146.58 480.48,153.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='408.14' y1='456.85' x2='558.55' y2='368.64' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='553.03,378.36 558.55,368.64 547.38,368.72 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='299.19' y1='470.78' x2='148.78' y2='382.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='159.95,382.65 148.78,382.57 154.30,392.28 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='111.24' y1='289.30' x2='168.69' y2='146.58' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='170.26,157.64 168.69,146.58 159.89,153.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='148.78' y1='304.74' x2='459.48' y2='122.52' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='453.96,132.24 459.48,122.52 448.31,122.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='167.91' y1='335.05' x2='551.96' y2='335.05' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='542.28,340.63 551.96,335.05 542.28,329.46 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='161.32' y1='368.64' x2='311.73' y2='456.85' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='300.55,456.77 311.73,456.85 306.21,447.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='315.31' y='80.68' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='350.32' y='175.01' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='256.52' y='236.60' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='156.19' y='191.22' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='377.29' y='97.89' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='556.70' y='185.90' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='456.37' y='241.92' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='354.82' y='188.94' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='441.35' y='249.68' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='555.56' y='238.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='507.32' y='403.72' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='410.31' y='344.01' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='275.79' y='340.20' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='396.52' y='334.88' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='444.65' y='419.19' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='235.42' y='433.12' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='116.75' y='233.47' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='238.71' y='235.75' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='282.29' y='326.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='197.82' y='389.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='328.95' y='92.85' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='363.95' y='187.18' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='270.15' y='248.77' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='169.82' y='203.39' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='390.92' y='110.07' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='570.33' y='198.07' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='470.01' y='254.09' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='368.45' y='201.11' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='454.98' y='261.85' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='569.20' y='250.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='520.96' y='415.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='423.94' y='356.18' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='289.42' y='352.37' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='410.16' y='347.05' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='458.28' y='431.36' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='249.05' y='445.29' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='130.39' y='245.64' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='252.35' y='247.92' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='295.93' y='338.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='211.45' y='401.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='90.98px' lengthAdjust='spacingAndGlyphs'>clockwise order</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/custom-ellipses-multiline.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/custom-ellipses-multiline.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='215.76,492.16 215.07,484.97 212.99,477.89 209.58,471.03 204.86,464.49 198.92,458.37 191.85,452.76 183.76,447.75 174.76,443.41 164.99,439.81 154.60,437.01 143.75,435.04 132.61,433.93 121.34,433.71 110.11,434.37 99.09,435.92 88.45,438.31 78.36,441.52 68.95,445.49 60.39,450.18 52.79,455.50 46.27,461.37 40.94,467.72 36.86,474.43 34.11,481.41 32.73,488.56 32.73,495.76 34.11,502.90 36.86,509.88 40.94,516.60 46.27,522.94 52.79,528.82 60.39,534.14 68.95,538.82 78.36,542.80 88.45,546.01 99.09,548.40 110.11,549.94 121.34,550.60 132.61,550.38 143.75,549.28 154.60,547.31 164.99,544.50 174.76,540.90 183.76,536.56 191.85,531.55 198.92,525.94 204.86,519.82 209.58,513.28 212.99,506.42 215.07,499.34 215.76,492.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #E69F00;' />
+<polygon points='522.03,101.15 521.34,93.96 519.26,86.88 515.84,80.02 511.13,73.48 505.19,67.36 498.12,61.75 490.03,56.74 481.03,52.40 471.26,48.80 460.87,46.00 450.02,44.03 438.88,42.92 427.61,42.70 416.38,43.36 405.36,44.90 394.72,47.30 384.62,50.51 375.22,54.48 366.66,59.17 359.06,64.49 352.54,70.36 347.21,76.71 343.13,83.42 340.38,90.40 339.00,97.55 339.00,104.75 340.38,111.89 343.13,118.87 347.21,125.59 352.54,131.93 359.06,137.81 366.66,143.13 375.22,147.81 384.62,151.79 394.72,155.00 405.36,157.39 416.38,158.93 427.61,159.59 438.88,159.37 450.02,158.27 460.87,156.30 471.26,153.49 481.03,149.89 490.03,145.55 498.12,140.54 505.19,134.93 511.13,128.81 515.84,122.27 519.26,115.41 521.34,108.33 522.03,101.15 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #56B4E9;' />
+<polygon points='648.89,394.40 648.20,387.22 646.12,380.14 642.71,373.28 637.99,366.74 632.05,360.62 624.98,355.01 616.89,350.00 607.89,345.66 598.12,342.06 587.73,339.25 576.88,337.28 565.74,336.18 554.47,335.96 543.24,336.62 532.22,338.16 521.58,340.56 511.49,343.76 502.08,347.74 493.52,352.43 485.92,357.75 479.40,363.62 474.07,369.96 469.99,376.68 467.24,383.66 465.86,390.81 465.86,398.00 467.24,405.15 469.99,412.13 474.07,418.84 479.40,425.19 485.92,431.06 493.52,436.38 502.08,441.07 511.49,445.05 521.58,448.25 532.22,450.65 543.24,452.19 554.47,452.85 565.74,452.63 576.88,451.53 587.73,449.56 598.12,446.75 607.89,443.15 616.89,438.81 624.98,433.80 632.05,428.19 637.99,422.07 642.71,415.53 646.12,408.67 648.20,401.59 648.89,394.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #56B4E9;' />
+<text x='124.16' y='473.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H1:</text>
+<text x='124.16' y='498.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='90.18px' lengthAdjust='spacingAndGlyphs'> Long name</text>
+<text x='124.16' y='522.62' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<text x='430.43' y='82.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H2:</text>
+<text x='430.43' y='107.02' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='105.36px' lengthAdjust='spacingAndGlyphs'> Longer name</text>
+<text x='430.43' y='131.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<text x='557.29' y='375.70' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H3:</text>
+<text x='557.29' y='400.28' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='112.96px' lengthAdjust='spacingAndGlyphs'> Longest name</text>
+<text x='557.29' y='424.86' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<line x1='142.58' y1='434.70' x2='369.47' y2='145.03' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='367.90,156.09 369.47,145.03 359.10,149.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='199.90' y1='458.96' x2='465.69' y2='398.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='457.48,406.56 465.69,398.98 455.02,395.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='412.01' y1='158.61' x2='185.12' y2='448.27' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='186.69,437.21 185.12,448.27 195.48,444.10 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='476.97' y1='151.71' x2='556.59' y2='335.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='547.62,329.09 556.59,335.75 557.87,324.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='481.54' y1='427.60' x2='215.76' y2='487.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='223.97,480.01 215.76,487.59 226.43,490.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='510.74' y1='343.84' x2='431.13' y2='159.80' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='440.10,166.46 431.13,159.80 429.84,170.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='34.45' y='323.48' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='104.74' y='424.30' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='152.62' y='240.50' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='319.75' y='198.40' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='209.18' y='432.93' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='300.44' y='267.83' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='218.21' y='342.06' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='288.50' y='442.88' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='336.38' y='259.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='503.51' y='216.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='392.95' y='451.51' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='484.20' y='286.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='656.72' y='308.35' style='font-size: 11.00px; font-family: sans;' textLength='39.76px' lengthAdjust='spacingAndGlyphs'>Legend:</text>
+<rect x='657.43' y='315.68' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #E69F00;' />
+<rect x='657.43' y='332.96' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #56B4E9;' />
+<text x='679.48' y='326.64' style='font-size: 8.80px; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Group 1</text>
+<text x='679.48' y='343.92' style='font-size: 8.80px; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Group 2</text>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='142.34px' lengthAdjust='spacingAndGlyphs'>custom ellipses multiline</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/gray-shades.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/gray-shades.svg
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='178.90,106.02 178.35,98.24 176.69,90.57 173.96,83.14 170.20,76.05 165.45,69.42 159.81,63.34 153.34,57.91 146.15,53.21 138.35,49.31 130.06,46.27 121.39,44.14 112.49,42.94 103.49,42.70 94.52,43.42 85.72,45.09 77.23,47.68 69.17,51.16 61.66,55.47 54.82,60.54 48.75,66.30 43.55,72.67 39.28,79.54 36.03,86.82 33.83,94.38 32.73,102.12 32.73,109.92 33.83,117.66 36.03,125.23 39.28,132.50 43.55,139.37 48.75,145.74 54.82,151.50 61.66,156.58 69.17,160.89 77.23,164.36 85.72,166.95 94.52,168.62 103.49,169.34 112.49,169.10 121.39,167.91 130.06,165.77 138.35,162.73 146.15,158.83 153.34,154.13 159.81,148.70 165.45,142.62 170.20,135.99 173.96,128.91 176.69,121.47 178.35,113.81 178.90,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,106.02 686.72,98.24 685.06,90.57 682.33,83.14 678.57,76.05 673.83,69.42 668.18,63.34 661.71,57.91 654.53,53.21 646.73,49.31 638.43,46.27 629.77,44.14 620.87,42.94 611.86,42.70 602.90,43.42 594.10,45.09 585.60,47.68 577.54,51.16 570.03,55.47 563.19,60.54 557.12,66.30 551.92,72.67 547.66,79.54 544.40,86.82 542.21,94.38 541.10,102.12 541.10,109.92 542.21,117.66 544.40,125.23 547.66,132.50 551.92,139.37 557.12,145.74 563.19,151.50 570.03,156.58 577.54,160.89 585.60,164.36 594.10,166.95 602.90,168.62 611.86,169.34 620.87,169.10 629.77,167.91 638.43,165.77 646.73,162.73 654.53,158.83 661.71,154.13 668.18,148.70 673.83,142.62 678.57,135.99 682.33,128.91 685.06,121.47 686.72,113.81 687.27,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #ABABAB;' />
+<polygon points='433.09,487.28 432.53,479.50 430.88,471.83 428.15,464.40 424.38,457.31 419.64,450.68 413.99,444.60 407.53,439.17 400.34,434.47 392.54,430.57 384.24,427.53 375.58,425.40 366.68,424.20 357.68,423.96 348.71,424.68 339.91,426.35 331.42,428.94 323.35,432.42 315.84,436.73 309.00,441.80 302.94,447.57 297.73,453.93 293.47,460.80 290.22,468.08 288.02,475.64 286.91,483.38 286.91,491.18 288.02,498.92 290.22,506.49 293.47,513.76 297.73,520.63 302.94,527.00 309.00,532.76 315.84,537.84 323.35,542.15 331.42,545.62 339.91,548.22 348.71,549.89 357.68,550.60 366.68,550.36 375.58,549.17 384.24,547.03 392.54,543.99 400.34,540.09 407.53,535.39 413.99,529.96 419.64,523.89 424.38,517.25 428.15,510.17 430.88,502.74 432.53,495.07 433.09,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #CCCCCC;' />
+<text x='105.74' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='105.74' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<text x='614.12' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='614.12' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<text x='359.93' y='480.87' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='359.93' y='505.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00833</text>
+<line x1='176.62' y1='89.57' x2='543.24' y2='89.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='533.56,95.16 543.24,89.57 533.56,83.99 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='157.63' y1='150.95' x2='340.94' y2='425.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='330.92,420.95 340.94,425.90 340.22,414.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='543.24' y1='122.47' x2='176.62' y2='122.47' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='186.30,116.88 176.62,122.47 186.30,128.05 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='595.13' y1='167.40' x2='411.82' y2='442.35' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='412.54,431.20 411.82,442.35 421.83,437.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='308.05' y1='442.35' x2='124.74' y2='167.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='134.75,172.35 124.74,167.40 125.46,178.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='378.92' y1='425.90' x2='562.23' y2='150.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='561.51,162.10 562.23,150.95 552.21,155.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='284.15' y='80.04' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='204.06' y='233.07' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='406.36' y='112.94' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='519.35' y='249.52' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='232.27' y='341.17' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='425.35' y='324.72' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='298.83' y='93.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='218.73' y='246.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='421.03' y='126.38' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='534.02' y='262.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='246.94' y='354.62' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='440.03' y='338.17' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='71.93px' lengthAdjust='spacingAndGlyphs'>gray shades</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-hGraph/hue-palette.svg
+++ b/tests/testthat/_snaps/independent-test-hGraph/hue-palette.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='203.20,108.86 202.55,100.73 200.62,92.72 197.43,84.95 193.04,77.55 187.51,70.62 180.93,64.27 173.39,58.59 165.01,53.68 155.91,49.61 146.24,46.43 136.13,44.20 125.75,42.95 115.25,42.70 104.79,43.45 94.53,45.19 84.63,47.90 75.22,51.54 66.47,56.04 58.49,61.34 51.41,67.36 45.34,74.02 40.37,81.20 36.58,88.79 34.02,96.70 32.73,104.79 32.73,112.94 34.02,121.02 36.58,128.93 40.37,136.53 45.34,143.71 51.41,150.36 58.49,156.38 66.47,161.69 75.22,166.19 84.63,169.82 94.53,172.53 104.79,174.27 115.25,175.02 125.75,174.77 136.13,173.52 146.24,171.29 155.91,168.12 165.01,164.04 173.39,159.13 180.93,153.46 187.51,147.11 193.04,140.18 197.43,132.77 200.62,125.01 202.55,117.00 203.20,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #FF9289;' />
+<polygon points='687.27,108.86 686.63,100.73 684.70,92.72 681.51,84.95 677.12,77.55 671.59,70.62 665.01,64.27 657.47,58.59 649.08,53.68 639.99,49.61 630.31,46.43 620.21,44.20 609.83,42.95 599.33,42.70 588.87,43.45 578.61,45.19 568.70,47.90 559.30,51.54 550.54,56.04 542.57,61.34 535.49,67.36 529.42,74.02 524.45,81.20 520.66,88.79 518.09,96.70 516.80,104.79 516.80,112.94 518.09,121.02 520.66,128.93 524.45,136.53 529.42,143.71 535.49,150.36 542.57,156.38 550.54,161.69 559.30,166.19 568.70,169.82 578.61,172.53 588.87,174.27 599.33,175.02 609.83,174.77 620.21,173.52 630.31,171.29 639.99,168.12 649.08,164.04 657.47,159.13 665.01,153.46 671.59,147.11 677.12,140.18 681.51,132.77 684.70,125.01 686.63,117.00 687.27,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #96CA00;' />
+<polygon points='687.27,484.44 686.63,476.31 684.70,468.30 681.51,460.53 677.12,453.13 671.59,446.20 665.01,439.85 657.47,434.17 649.08,429.26 639.99,425.19 630.31,422.01 620.21,419.78 609.83,418.53 599.33,418.28 588.87,419.03 578.61,420.78 568.70,423.48 559.30,427.12 550.54,431.62 542.57,436.92 535.49,442.94 529.42,449.60 524.45,456.78 520.66,464.38 518.09,472.28 516.80,480.37 516.80,488.52 518.09,496.61 520.66,504.51 524.45,512.11 529.42,519.29 535.49,525.94 542.57,531.96 550.54,537.27 559.30,541.77 568.70,545.40 578.61,548.11 588.87,549.85 599.33,550.60 609.83,550.35 620.21,549.10 630.31,546.87 639.99,543.70 649.08,539.62 657.47,534.71 665.01,529.04 671.59,522.69 677.12,515.76 681.51,508.35 684.70,500.59 686.63,492.58 687.27,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #00DAE0;' />
+<polygon points='203.20,484.44 202.55,476.31 200.62,468.30 197.43,460.53 193.04,453.13 187.51,446.20 180.93,439.85 173.39,434.17 165.01,429.26 155.91,425.19 146.24,422.01 136.13,419.78 125.75,418.53 115.25,418.28 104.79,419.03 94.53,420.78 84.63,423.48 75.22,427.12 66.47,431.62 58.49,436.92 51.41,442.94 45.34,449.60 40.37,456.78 36.58,464.38 34.02,472.28 32.73,480.37 32.73,488.52 34.02,496.61 36.58,504.51 40.37,512.11 45.34,519.29 51.41,525.94 58.49,531.96 66.47,537.27 75.22,541.77 84.63,545.40 94.53,548.11 104.79,549.85 115.25,550.60 125.75,550.35 136.13,549.10 146.24,546.87 155.91,543.70 165.01,539.62 173.39,534.71 180.93,529.04 187.51,522.69 193.04,515.76 197.43,508.35 200.62,500.59 202.55,492.58 203.20,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #E199FF;' />
+<text x='117.88' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='117.88' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='601.96' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='601.96' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='601.96' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='601.96' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<text x='117.88' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='117.88' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='84.02px' lengthAdjust='spacingAndGlyphs'>w=0.00625</text>
+<line x1='201.81' y1='95.91' x2='518.03' y2='95.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,101.50 518.03,95.91 508.35,90.32 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='189.03' y1='145.75' x2='554.42' y2='429.24' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='543.35,427.72 554.42,429.24 550.19,418.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='134.58' y1='173.98' x2='134.58' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='128.99,409.65 134.58,419.32 140.16,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='121.81' x2='201.81' y2='121.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,116.23 201.81,121.81 211.49,127.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='618.65' y1='173.98' x2='618.65' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='613.07,409.65 618.65,419.32 624.24,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='554.42' y1='164.07' x2='189.03' y2='447.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='193.25,437.21 189.03,447.56 200.10,446.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='530.81' y1='447.56' x2='165.42' y2='164.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='176.49,165.58 165.42,164.07 169.64,174.41 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='585.26' y1='419.32' x2='585.26' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.85,183.66 585.26,173.98 579.68,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='497.40' x2='201.81' y2='497.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,491.81 201.81,497.40 211.49,502.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.19' y1='419.32' x2='101.19' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='106.77,183.66 101.19,173.98 95.60,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='165.42' y1='429.24' x2='530.81' y2='145.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.58,156.09 530.81,145.75 519.74,147.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='471.49' x2='518.03' y2='471.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,477.08 518.03,471.49 508.35,465.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='290.10' y='85.95' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='293.71' y='230.29' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='117.46' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='111.86' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='601.54' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='415.51' y='248.60' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='391.90' y='343.10' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='568.15' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='487.44' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='84.07' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='270.10' y='324.78' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='461.53' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='307.22' y='99.82' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='310.83' y='244.16' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='134.58' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='125.73' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='618.65' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='432.62' y='262.48' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='409.01' y='356.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='585.26' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='501.31' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='101.19' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='287.22' y='338.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='475.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='65.32px' lengthAdjust='spacingAndGlyphs'>hue palette</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.binomialSPRT/binomial-sprt-plottype-1.svg
+++ b/tests/testthat/_snaps/independent-test-plot.binomialSPRT/binomial-sprt-plottype-1.svg
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMjcuOTB8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='27.90' y='22.78' width='686.62' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcuOTB8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='27.90' y='22.78' width='686.62' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='59.11' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='84.08' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='109.05' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.01' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.98' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='183.95' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.92' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='233.89' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='258.85' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='283.82' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='308.79' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='333.76' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='358.73' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='383.69' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='408.66' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='433.63' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='458.60' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.57' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='508.53' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.50' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.47' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='583.44' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='608.41' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='633.37' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='658.34' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.31' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='59.11' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='84.08' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='109.05' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.01' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.98' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='183.95' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.92' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='233.89' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='258.85' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='283.82' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='308.79' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='333.76' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='358.73' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='383.69' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='408.66' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='433.63' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='458.60' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.57' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='508.53' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.50' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.47' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='583.44' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='608.41' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='633.37' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='658.34' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.31' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='-658.72' y1='619.65' x2='1401.14' y2='-216.51' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='-658.72' y1='788.23' x2='1401.14' y2='-47.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='27.90' y='22.78' width='686.62' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='22.97' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.97' y='366.12' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='22.97' y='207.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='22.97' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<polyline points='25.16,521.37 27.90,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,363.09 27.90,363.09 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,204.81 27.90,204.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,46.53 27.90,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='59.11,547.85 59.11,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='183.95,547.85 183.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='308.79,547.85 308.79,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='433.63,547.85 433.63,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='558.47,547.85 558.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.31,547.85 683.31,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='59.11' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='183.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='308.79' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='433.63' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='558.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='683.31' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='371.21' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='105.18px' lengthAdjust='spacingAndGlyphs'>Number of responses</text>
+<text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='148.95px' lengthAdjust='spacingAndGlyphs'>binomial SPRT plottype 1</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.binomialSPRT/binomial-sprt.svg
+++ b/tests/testthat/_snaps/independent-test-plot.binomialSPRT/binomial-sprt.svg
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMjcuOTB8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='27.90' y='22.78' width='686.62' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcuOTB8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='27.90' y='22.78' width='686.62' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='59.11' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='84.08' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='109.05' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.01' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.98' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='183.95' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.92' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='233.89' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='258.85' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='283.82' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='308.79' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='333.76' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='358.73' cy='204.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='383.69' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='408.66' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='433.63' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='458.60' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.57' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='508.53' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.50' cy='125.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.47' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='583.44' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='608.41' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='633.37' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='658.34' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.31' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='59.11' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='84.08' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='109.05' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.01' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.98' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='183.95' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.92' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='233.89' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='258.85' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='283.82' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='308.79' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='333.76' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='358.73' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='383.69' cy='442.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='408.66' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='433.63' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='458.60' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.57' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='508.53' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.50' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.47' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='583.44' cy='363.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='608.41' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='633.37' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='658.34' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.31' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='-658.72' y1='619.65' x2='1401.14' y2='-216.51' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='-658.72' y1='788.23' x2='1401.14' y2='-47.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='27.90' y='22.78' width='686.62' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='22.97' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.97' y='366.12' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='22.97' y='207.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='22.97' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<polyline points='25.16,521.37 27.90,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,363.09 27.90,363.09 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,204.81 27.90,204.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,46.53 27.90,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='59.11,547.85 59.11,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='183.95,547.85 183.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='308.79,547.85 308.79,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='433.63,547.85 433.63,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='558.47,547.85 558.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.31,547.85 683.31,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='59.11' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='183.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='308.79' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='433.63' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='558.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='683.31' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='371.21' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='105.18px' lengthAdjust='spacingAndGlyphs'>Number of responses</text>
+<text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='88.04px' lengthAdjust='spacingAndGlyphs'>binomial SPRT</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-1.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-1.svg
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='63.78' cy='194.91' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='369.29' cy='135.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.53' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='63.78' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='369.29' cy='313.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.53' cy='76.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='435.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='27.86' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='138.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<polyline points='30.05,432.34 32.79,432.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,283.95 32.79,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,135.56 32.79,135.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='185.99,547.85 185.99,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='360.56,547.85 360.56,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='535.14,547.85 535.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='709.72,547.85 709.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='185.99' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='360.56' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='535.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text x='709.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>110</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='105.18px' lengthAdjust='spacingAndGlyphs'>Number of responses</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='145.30px' lengthAdjust='spacingAndGlyphs'>binomial exact plottype 1</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-2.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-2.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8NjI2Ljk5fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='37.69' y='22.78' width='589.30' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8NjI2Ljk5fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='37.69' y='22.78' width='589.30' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='64.47,521.37 75.19,521.37 85.90,521.37 96.62,521.37 107.33,521.37 118.05,521.37 128.76,521.37 139.48,521.37 150.19,521.37 160.91,521.37 171.62,521.37 182.33,521.37 193.05,521.37 203.76,521.37 214.48,521.37 225.19,521.37 235.91,521.37 246.62,521.37 257.34,521.37 268.05,521.37 278.77,521.37 289.48,521.37 300.19,521.37 310.91,521.37 321.62,521.37 332.34,521.37 343.05,521.37 353.77,521.37 364.48,521.37 375.20,521.37 385.91,521.37 396.63,521.37 407.34,521.37 418.05,521.37 428.77,521.37 439.48,521.37 450.20,521.37 460.91,521.37 471.63,521.37 482.34,521.37 493.06,521.37 503.77,521.37 514.49,521.37 525.20,521.37 535.91,521.37 546.63,521.37 557.34,521.37 568.06,521.37 578.77,521.37 589.49,521.37 600.20,521.37 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='64.47,512.27 75.19,510.50 85.90,508.48 96.62,506.19 107.33,503.60 118.05,500.70 128.76,497.46 139.48,493.87 150.19,489.92 160.91,485.59 171.62,480.86 182.33,475.74 193.05,470.21 203.76,464.28 214.48,457.93 225.19,451.18 235.91,444.03 246.62,436.49 257.34,428.57 268.05,420.28 278.77,411.66 289.48,402.71 300.19,393.45 310.91,383.93 321.62,374.15 332.34,364.16 343.05,353.98 353.77,343.65 364.48,333.19 375.20,322.64 385.91,312.03 396.63,301.40 407.34,290.78 418.05,280.20 428.77,269.68 439.48,259.27 450.20,248.98 460.91,238.85 471.63,228.89 482.34,219.14 493.06,209.61 503.77,200.31 514.49,191.28 525.20,182.52 535.91,174.04 546.63,165.86 557.34,157.98 568.06,150.41 578.77,143.15 589.49,136.21 600.20,129.58 ' style='stroke-width: 1.07; stroke-dasharray: 2.85,2.85; stroke-linecap: butt;' />
+<polyline points='64.47,46.53 75.19,48.29 85.90,50.31 96.62,52.60 107.33,55.19 118.05,58.09 128.76,61.33 139.48,64.92 150.19,68.87 160.91,73.20 171.62,77.93 182.33,83.05 193.05,88.58 203.76,94.51 214.48,100.86 225.19,107.61 235.91,114.76 246.62,122.30 257.34,130.22 268.05,138.51 278.77,147.13 289.48,156.08 300.19,165.34 310.91,174.86 321.62,184.64 332.34,194.63 343.05,204.81 353.77,215.14 364.48,225.60 375.20,236.15 385.91,246.76 396.63,257.39 407.34,268.01 418.05,278.60 428.77,289.11 439.48,299.52 450.20,309.81 460.91,319.95 471.63,329.90 482.34,339.65 493.06,349.19 503.77,358.48 514.49,367.51 525.20,376.27 535.91,384.75 546.63,392.93 557.34,400.81 568.06,408.38 578.77,415.64 589.49,422.58 600.20,429.21 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,2.85; stroke-linecap: butt;' />
+<rect x='37.69' y='22.78' width='589.30' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='32.76' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='32.76' y='403.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='32.76' y='282.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='32.76' y='161.44' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='32.76' y='40.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='34.95,521.37 37.69,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,400.38 37.69,400.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,279.40 37.69,279.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,158.41 37.69,158.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,37.42 37.69,37.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='64.47,547.85 64.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='198.41,547.85 198.41,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='332.34,547.85 332.34,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='466.27,547.85 466.27,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='600.20,547.85 600.20,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='64.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.100</text>
+<text x='198.41' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.125</text>
+<text x='332.34' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.150</text>
+<text x='466.27' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.175</text>
+<text x='600.20' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.200</text>
+<text x='332.34' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='122.92px' lengthAdjust='spacingAndGlyphs'>Underlying response rate</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='37.92px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<rect x='637.95' y='250.36' width='76.57' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='637.95' y='259.07' style='font-size: 11.00px; font-family: sans;' textLength='44.64px' lengthAdjust='spacingAndGlyphs'>Outcome</text>
+<rect x='637.95' y='265.69' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='639.68' y1='274.33' x2='653.50' y2='274.33' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='637.95' y='282.97' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='639.68' y1='291.61' x2='653.50' y2='291.61' style='stroke-width: 1.07; stroke-dasharray: 2.85,2.85; stroke-linecap: butt;' />
+<rect x='637.95' y='300.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='639.68' y1='308.89' x2='653.50' y2='308.89' style='stroke-width: 1.07; stroke-dasharray: 5.69,2.85; stroke-linecap: butt;' />
+<text x='660.71' y='277.36' style='font-size: 8.80px; font-family: sans;' textLength='53.81px' lengthAdjust='spacingAndGlyphs'>Indeterminate</text>
+<text x='660.71' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='38.64px' lengthAdjust='spacingAndGlyphs'>Reject H0</text>
+<text x='660.71' y='311.92' style='font-size: 8.80px; font-family: sans;' textLength='38.64px' lengthAdjust='spacingAndGlyphs'>Reject H1</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='145.30px' lengthAdjust='spacingAndGlyphs'>binomial exact plottype 2</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-3.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-3.svg
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='35.24' y='22.78' width='679.28' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='35.24' y='22.78' width='679.28' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='66.11' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.53' cy='279.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.64' cy='346.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='66.11' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.53' cy='410.72' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.64' cy='360.80' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='35.24' y='22.78' width='679.28' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='455.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='30.31' y='299.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='144.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='32.50,452.30 35.24,452.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,296.90 35.24,296.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.49 35.24,141.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.88,547.85 187.88,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='361.83,547.85 361.83,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='535.78,547.85 535.78,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='709.74,547.85 709.74,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='187.88' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='361.83' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='535.78' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text x='709.74' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>110</text>
+<text x='374.88' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='69.12px' lengthAdjust='spacingAndGlyphs'>Rate at bound</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='145.30px' lengthAdjust='spacingAndGlyphs'>binomial exact plottype 3</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-6.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-6.svg
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='63.78,521.37 76.18,501.37 88.57,481.32 100.97,461.26 113.36,441.21 125.76,421.21 138.15,401.31 150.55,381.55 162.94,361.98 175.34,342.63 187.73,323.56 200.13,304.81 212.52,286.42 224.92,268.45 237.31,250.93 249.71,233.92 262.10,217.45 274.50,201.57 286.89,186.32 299.29,171.73 311.68,157.83 324.08,144.66 336.47,132.25 348.87,120.63 361.26,109.81 373.66,99.81 386.05,90.66 398.45,82.36 410.84,74.93 423.24,68.36 435.63,62.67 448.03,57.84 460.42,53.89 472.82,50.79 485.21,48.54 497.61,47.12 510.00,46.53 522.40,46.73 534.79,47.71 547.19,49.46 559.58,51.93 571.98,55.11 584.37,58.96 596.77,63.46 609.16,68.58 621.56,74.28 633.95,80.54 646.35,87.31 658.74,94.57 671.14,102.29 683.53,110.42 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='456.38' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='27.86' y='352.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='27.86' y='249.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='27.86' y='145.44' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>85</text>
+<text x='27.86' y='41.80' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>90</text>
+<polyline points='30.05,453.35 32.79,453.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,349.71 32.79,349.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,246.06 32.79,246.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,142.41 32.79,142.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,38.77 32.79,38.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='63.78,547.85 63.78,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='218.72,547.85 218.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='373.66,547.85 373.66,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='528.60,547.85 528.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.53,547.85 683.53,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='63.78' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.100</text>
+<text x='218.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.125</text>
+<text x='373.66' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.150</text>
+<text x='528.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.175</text>
+<text x='683.53' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.200</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>p</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='107.03px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='145.30px' lengthAdjust='spacingAndGlyphs'>binomial exact plottype 6</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-default.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsBinomialExact/binomial-exact-plottype-default.svg
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='63.78' cy='194.91' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='369.29' cy='135.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.53' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='63.78' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='369.29' cy='313.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='683.53' cy='76.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='435.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='27.86' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='138.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<polyline points='30.05,432.34 32.79,432.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,283.95 32.79,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,135.56 32.79,135.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='185.99,547.85 185.99,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='360.56,547.85 360.56,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='535.14,547.85 535.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='709.72,547.85 709.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='185.99' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='360.56' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='535.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text x='709.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>110</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='105.18px' lengthAdjust='spacingAndGlyphs'>Number of responses</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='177.59px' lengthAdjust='spacingAndGlyphs'>binomial exact plottype default</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/gssurv-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/gssurv-base-false.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='35.24' y='22.78' width='586.85' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='35.24' y='22.78' width='586.85' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='61.91,46.53 68.18,46.55 74.68,46.59 81.40,46.65 88.36,46.73 95.56,46.84 103.02,47.00 110.74,47.22 118.73,47.52 127.01,47.92 135.57,48.47 144.44,49.19 153.62,50.13 163.13,51.34 172.97,52.90 183.16,54.86 193.71,57.32 204.62,60.36 215.93,64.07 227.63,68.56 239.75,73.93 252.29,80.27 265.27,87.68 278.72,96.24 292.63,106.02 307.04,117.07 321.96,129.42 337.40,143.05 353.39,157.94 369.94,174.02 387.07,191.19 404.81,209.32 423.17,228.25 442.18,247.79 461.86,267.73 482.24,287.86 503.33,307.95 525.17,327.77 547.78,347.11 571.18,365.77 595.41,383.57 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,46.53 68.18,46.55 74.68,46.59 81.40,46.65 88.36,46.73 95.56,46.85 103.02,47.02 110.74,47.25 118.73,47.58 127.01,48.04 135.57,48.66 144.44,49.50 153.62,50.63 163.13,52.15 172.97,54.15 183.16,56.77 193.71,60.17 204.62,64.51 215.93,70.01 227.63,76.86 239.75,85.30 252.29,95.53 265.27,107.74 278.72,122.08 292.63,138.63 307.04,157.40 321.96,178.30 337.40,201.15 353.39,225.64 369.94,251.39 387.07,277.93 404.81,304.73 423.17,331.25 442.18,356.95 461.86,381.34 482.24,404.00 503.33,424.62 525.17,442.97 547.78,458.97 571.18,472.61 595.41,483.99 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,46.53 68.18,46.55 74.68,46.59 81.40,46.65 88.36,46.73 95.56,46.85 103.02,47.02 110.74,47.26 118.73,47.59 127.01,48.06 135.57,48.70 144.44,49.59 153.62,50.81 163.13,52.47 172.97,54.71 183.16,57.73 193.71,61.75 204.62,67.06 215.93,73.97 227.63,82.84 239.75,94.03 252.29,107.87 265.27,124.65 278.72,144.53 292.63,167.52 307.04,193.46 321.96,221.93 337.40,252.34 353.39,283.92 369.94,315.77 387.07,346.96 404.81,376.59 423.17,403.90 442.18,428.30 461.86,449.45 482.24,467.21 503.33,481.66 525.17,493.07 547.78,501.78 571.18,508.24 595.41,512.88 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<polyline points='61.91,97.78 68.18,107.77 74.68,119.04 81.40,131.60 88.36,145.44 95.56,160.54 103.02,176.81 110.74,194.15 118.73,212.42 127.01,231.46 135.57,251.08 144.44,271.07 153.62,291.21 163.13,311.27 172.97,331.02 183.16,350.26 193.71,368.79 204.62,386.43 215.93,403.05 227.63,418.51 239.75,432.75 252.29,445.70 265.27,457.37 278.72,467.74 292.63,476.88 307.04,484.82 321.96,491.66 337.40,497.48 353.39,502.37 369.94,506.44 387.07,509.78 404.81,512.50 423.17,514.69 442.18,516.43 461.86,517.80 482.24,518.86 503.33,519.68 525.17,520.30 547.78,520.77 571.18,521.12 595.41,521.37 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,46.64 68.18,46.75 74.68,46.93 81.40,47.20 88.36,47.63 95.56,48.27 103.02,49.22 110.74,50.59 118.73,52.55 127.01,55.26 135.57,58.97 144.44,63.90 153.62,70.33 163.13,78.54 172.97,88.80 183.16,101.33 193.71,116.30 204.62,133.81 215.93,153.83 227.63,176.23 239.75,200.74 252.29,226.97 265.27,254.42 278.72,282.52 292.63,310.66 307.04,338.22 321.96,364.62 337.40,389.35 353.39,412.01 369.94,432.32 387.07,450.13 404.81,465.40 423.17,478.21 442.18,488.73 461.86,497.17 482.24,503.81 503.33,508.92 525.17,512.76 547.78,515.59 571.18,517.63 595.41,519.08 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,46.53 68.18,46.55 74.68,46.59 81.40,46.65 88.36,46.73 95.56,46.85 103.02,47.02 110.74,47.26 118.73,47.59 127.01,48.06 135.57,48.70 144.44,49.59 153.62,50.81 163.13,52.47 172.97,54.71 183.16,57.73 193.71,61.75 204.62,67.06 215.93,73.97 227.63,82.84 239.75,94.03 252.29,107.87 265.27,124.65 278.72,144.53 292.63,167.52 307.04,193.46 321.96,221.93 337.40,252.34 353.39,283.92 369.94,315.77 387.07,346.96 404.81,376.59 423.17,403.90 442.18,428.30 461.86,449.45 482.24,467.21 503.33,481.66 525.17,493.07 547.78,501.78 571.18,508.24 595.41,512.88 ' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='586.85' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='525.02' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='429.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='334.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='239.71' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='144.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='49.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,521.99 35.24,521.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,426.89 35.24,426.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,331.78 35.24,331.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,236.68 35.24,236.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.58 35.24,141.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,46.47 35.24,46.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='168.61,547.85 168.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='310.88,547.85 310.88,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='453.15,547.85 453.15,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='595.41,547.85 595.41,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='168.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='310.88' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='453.15' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='595.41' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='328.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.92px' lengthAdjust='spacingAndGlyphs'>Hazard ratio</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<rect x='633.05' y='219.94' width='40.97' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='228.65' style='font-size: 11.00px; font-family: sans;' textLength='40.97px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
+<rect x='633.05' y='235.27' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='243.91' x2='648.60' y2='243.91' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='252.55' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='261.19' x2='648.60' y2='261.19' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<rect x='633.05' y='269.83' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='278.47' x2='648.60' y2='278.47' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='246.94' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='655.81' y='264.22' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='655.81' y='281.50' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<rect x='633.05' y='298.07' width='81.47' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='306.78' style='font-size: 11.00px; font-family: sans;' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>Probability</text>
+<rect x='633.05' y='313.40' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='322.04' x2='648.60' y2='322.04' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<rect x='633.05' y='330.68' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='339.32' x2='648.60' y2='339.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='325.07' style='font-size: 8.80px; font-family: sans;' textLength='58.71px' lengthAdjust='spacingAndGlyphs'>1-Lower bound</text>
+<text x='655.81' y='342.35' style='font-size: 8.80px; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.18px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/gssurv-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/gssurv-base-true.svg
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='666.40,485.71 639.88,485.53 614.26,485.29 589.51,484.97 565.60,484.54 542.51,483.97 520.21,483.24 498.66,482.29 477.85,481.09 457.75,479.58 438.33,477.70 419.58,475.39 401.46,472.58 383.96,469.20 367.06,465.18 350.73,460.45 334.96,454.96 319.73,448.65 305.01,441.48 290.80,433.43 277.07,424.47 263.80,414.64 250.99,403.95 238.62,392.48 226.67,380.29 215.12,367.49 203.97,354.19 193.20,340.54 182.79,326.69 172.74,312.77 163.03,298.96 153.66,285.41 144.60,272.25 135.85,259.63 127.40,247.65 119.23,236.41 111.35,225.98 103.73,216.41 96.37,207.73 89.26,199.95 82.40,193.05 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='199.20' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='199.20' y1='502.56' x2='199.20' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='354.93' y1='502.56' x2='354.93' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='510.67' y1='502.56' x2='510.67' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='199.20' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='354.93' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='510.67' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='288.20px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Hazard ratio</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='224.81px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<line x1='689.76' y1='486.13' x2='689.76' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='486.13' x2='696.96' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='453.28' x2='696.96' y2='453.28' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='420.43' x2='696.96' y2='420.43' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='387.57' x2='696.96' y2='387.57' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='354.72' x2='696.96' y2='354.72' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='321.87' x2='696.96' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='289.01' x2='696.96' y2='289.01' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='256.16' x2='696.96' y2='256.16' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='223.31' x2='696.96' y2='223.31' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='190.45' x2='696.96' y2='190.45' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='157.60' x2='696.96' y2='157.60' style='stroke-width: 0.75;' />
+<text transform='translate(715.68,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(715.68,453.28) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(715.68,420.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(715.68,387.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(715.68,354.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(715.68,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(715.68,289.01) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(715.68,256.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(715.68,223.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(715.68,190.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(715.68,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='59.04' y1='486.13' x2='59.04' y2='157.60' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='486.13' x2='51.84' y2='486.13' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='453.28' x2='51.84' y2='453.28' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='420.43' x2='51.84' y2='420.43' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='387.57' x2='51.84' y2='387.57' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='354.72' x2='51.84' y2='354.72' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='321.87' x2='51.84' y2='321.87' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='289.01' x2='51.84' y2='289.01' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='256.16' x2='51.84' y2='256.16' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='223.31' x2='51.84' y2='223.31' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='190.45' x2='51.84' y2='190.45' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='157.60' x2='51.84' y2='157.60' style='stroke-width: 0.75; stroke: #DF536B;' />
+<text transform='translate(41.76,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,453.28) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(41.76,420.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,387.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(41.76,354.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(41.76,289.01) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,256.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(41.76,223.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,190.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(41.76,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='666.40,390.50 639.88,378.20 614.26,365.31 589.51,351.95 565.60,338.25 542.51,324.37 520.21,310.47 498.66,296.69 477.85,283.19 457.75,270.11 438.33,257.59 419.58,245.72 401.46,234.61 383.96,224.33 367.06,214.91 350.73,206.38 334.96,198.74 319.73,191.98 305.01,186.07 290.80,180.95 277.07,176.57 263.80,172.86 250.99,169.76 238.62,167.19 226.67,165.09 215.12,163.40 203.97,162.04 193.20,160.96 182.79,160.12 172.74,159.47 163.03,158.98 153.66,158.60 144.60,158.32 135.85,158.11 127.40,157.96 119.23,157.85 111.35,157.77 103.73,157.72 96.37,157.68 89.26,157.65 82.40,157.64 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='666.40,459.88 639.88,452.02 614.26,442.59 589.51,431.54 565.60,418.86 542.51,404.61 520.21,388.96 498.66,372.10 477.85,354.35 457.75,336.03 438.33,317.51 419.58,299.17 401.46,281.38 383.96,264.46 367.06,248.68 350.73,234.24 334.96,221.27 319.73,209.83 305.01,199.93 290.80,191.49 277.07,184.42 263.80,178.60 250.99,173.86 238.62,170.06 226.67,167.06 215.12,164.72 203.97,162.90 193.20,161.52 182.79,160.47 172.74,159.69 163.03,159.11 153.66,158.68 144.60,158.37 135.85,158.14 127.40,157.98 119.23,157.86 111.35,157.78 103.73,157.72 96.37,157.68 89.26,157.65 82.40,157.64 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='666.40,479.84 639.88,476.64 614.26,472.17 589.51,466.15 565.60,458.27 542.51,448.28 520.21,436.01 498.66,421.41 477.85,404.54 457.75,385.68 438.33,365.21 419.58,343.66 401.46,321.65 383.96,299.84 367.06,278.82 350.73,259.15 334.96,241.23 319.73,225.35 305.01,211.61 290.80,200.02 277.07,190.45 263.80,182.73 250.99,176.60 238.62,171.82 226.67,168.16 215.12,165.38 203.97,163.29 193.20,161.74 182.79,160.59 172.74,159.75 163.03,159.14 153.66,158.70 144.60,158.37 135.85,158.14 127.40,157.98 119.23,157.86 111.35,157.78 103.73,157.72 96.37,157.68 89.26,157.65 82.40,157.64 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<rect x='59.04' y='59.04' width='81.29' height='57.60' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='69.84' y1='87.84' x2='91.44' y2='87.84' style='stroke-width: 0.75;' />
+<line x1='69.84' y1='102.24' x2='91.44' y2='102.24' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<text x='99.68' y='73.44' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='51.38px' lengthAdjust='spacingAndGlyphs'>Boundary</text>
+<text x='102.24' y='91.97' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='102.24' y='106.37' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='133.13' y='90.59' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='133.13' y='104.99' text-anchor='end' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<polyline points='666.40,484.12 639.88,483.12 614.26,481.71 589.51,479.76 565.60,477.10 542.51,473.57 520.21,468.99 498.66,463.15 477.85,455.89 457.75,447.03 438.33,436.48 419.58,424.18 401.46,410.15 383.96,394.49 367.06,377.41 350.73,359.17 334.96,340.13 319.73,320.69 305.01,301.27 290.80,282.30 277.07,264.18 263.80,247.25 250.99,231.77 238.62,217.94 226.67,205.84 215.12,195.50 203.97,186.84 193.20,179.76 182.79,174.08 172.74,169.64 163.03,166.23 153.66,163.67 144.60,161.80 135.85,160.45 127.40,159.49 119.23,158.84 111.35,158.40 103.73,158.10 96.37,157.91 89.26,157.79 82.40,157.72 ' style='stroke-width: 0.75;' />
+<polyline points='666.40,479.84 639.88,476.64 614.26,472.17 589.51,466.15 565.60,458.27 542.51,448.28 520.21,436.01 498.66,421.41 477.85,404.54 457.75,385.68 438.33,365.21 419.58,343.66 401.46,321.65 383.96,299.84 367.06,278.82 350.73,259.15 334.96,241.23 319.73,225.35 305.01,211.61 290.80,200.02 277.07,190.45 263.80,182.73 250.99,176.60 238.62,171.82 226.67,168.16 215.12,165.38 203.97,163.29 193.20,161.74 182.79,160.59 172.74,159.75 163.03,159.14 153.66,158.70 144.60,158.37 135.85,158.14 127.40,157.98 119.23,157.86 111.35,157.78 103.73,157.72 96.37,157.68 89.26,157.65 82.40,157.64 ' style='stroke-width: 0.75;' />
+<text x='182.79' y='343.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='319.73' y='324.98' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='383.96' y='304.13' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.01px' lengthAdjust='spacingAndGlyphs'>Final</text>
+<text x='457.75' y='274.40' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='419.58' y='303.47' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-1-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-1-base-false.svg
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='30.83' y='22.78' width='626.00' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='59.28' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>3.25</text>
+<text x='201.56' y='69.11' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.99</text>
+<text x='343.83' y='88.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.69</text>
+<text x='486.10' y='109.75' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.37</text>
+<text x='628.38' y='132.86' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='59.28' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-3.25</text>
+<text x='201.56' y='465.41' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.99</text>
+<text x='343.83' y='445.87' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.69</text>
+<text x='486.10' y='424.77' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.37</text>
+<text x='628.38' y='401.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<polyline points='59.28,478.20 201.56,460.51 343.83,440.98 486.10,419.87 628.38,396.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='59.28,46.53 201.56,64.22 343.83,83.75 486.10,104.85 628.38,127.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='59.28' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='201.56' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='343.83' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='486.10' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='628.38' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='25.90' y='530.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='25.90' y='398.11' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='25.90' y='265.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='132.68' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,527.79 30.83,527.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,395.08 30.83,395.08 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,262.36 30.83,262.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,129.65 30.83,129.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='56.03,547.85 56.03,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='195.04,547.85 195.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.05,547.85 334.05,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='473.07,547.85 473.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.08,547.85 612.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='56.03' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='195.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='334.05' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='473.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='612.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='343.83' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.93px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='99.04px' lengthAdjust='spacingAndGlyphs'>Normal critical value</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.44px' lengthAdjust='spacingAndGlyphs'>Normal test statistics at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-1-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-1-base-true.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,75.47 241.67,90.77 374.40,107.66 507.13,125.91 639.85,145.90 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='105.91' y1='502.56' x2='624.66' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='105.91' y1='502.56' x2='105.91' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='235.59' y1='502.56' x2='235.59' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='365.28' y1='502.56' x2='365.28' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='494.97' y1='502.56' x2='494.97' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='624.66' y1='502.56' x2='624.66' y2='509.76' style='stroke-width: 0.75;' />
+<text x='105.91' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='235.59' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='365.28' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='494.97' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='624.66' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<line x1='59.04' y1='491.69' x2='59.04' y2='89.97' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='491.69' x2='51.84' y2='491.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='434.30' x2='51.84' y2='434.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='376.91' x2='51.84' y2='376.91' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='319.52' x2='51.84' y2='319.52' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='262.13' x2='51.84' y2='262.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='204.74' x2='51.84' y2='204.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='147.36' x2='51.84' y2='147.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='89.97' x2='51.84' y2='89.97' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,491.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text transform='translate(41.76,434.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text transform='translate(41.76,376.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text transform='translate(41.76,319.52) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text transform='translate(41.76,262.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,204.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,147.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text transform='translate(41.76,89.97) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='200.12px' lengthAdjust='spacingAndGlyphs'>Normal test statistics at bounds</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.38px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='108.04px' lengthAdjust='spacingAndGlyphs'>Normal critical value</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,448.80 241.67,433.50 374.40,416.60 507.13,398.36 639.85,378.36 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='79.60' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>3.25</text>
+<text x='241.67' y='94.90' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.99</text>
+<text x='374.40' y='111.80' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.69</text>
+<text x='507.13' y='130.04' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.37</text>
+<text x='639.85' y='150.04' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='108.95' y='452.93' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-3.25</text>
+<text x='241.67' y='437.63' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.99</text>
+<text x='374.40' y='420.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.69</text>
+<text x='507.13' y='402.49' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.37</text>
+<text x='639.85' y='382.50' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<text x='108.95' y='490.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='241.67' y='490.26' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='374.40' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='507.13' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='639.85' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.70px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-2-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-2-base-true.svg
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,485.90 97.00,485.83 111.60,485.74 126.20,485.64 140.80,485.50 155.40,485.33 170.00,485.12 184.60,484.87 199.20,484.56 213.80,484.18 228.40,483.72 243.00,483.17 257.60,482.51 272.20,481.72 286.80,480.79 301.40,479.70 316.00,478.42 330.60,476.93 345.20,475.20 359.80,473.20 374.40,470.92 389.00,468.32 403.60,465.37 418.20,462.04 432.80,458.31 447.40,454.15 462.00,449.53 476.60,444.44 491.20,438.84 505.80,432.73 520.40,426.09 535.00,418.92 549.60,411.22 564.20,402.99 578.80,394.24 593.40,384.99 608.00,375.26 622.60,365.09 637.20,354.51 651.80,343.55 666.40,332.28 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='228.40' y1='502.56' x2='228.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='374.40' y1='502.56' x2='374.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='520.40' y1='502.56' x2='520.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='228.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='374.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='520.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='288.20px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+<text x='371.68' y='557.14' style='font-size: 12.00px; font-family: sans;' textLength='5.44px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='224.81px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<line x1='59.04' y1='486.13' x2='59.04' y2='75.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='486.13' x2='51.84' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='445.07' x2='51.84' y2='445.07' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='404.00' x2='51.84' y2='404.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='362.93' x2='51.84' y2='362.93' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='321.87' x2='51.84' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='280.80' x2='51.84' y2='280.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='239.73' x2='51.84' y2='239.73' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='198.67' x2='51.84' y2='198.67' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='157.60' x2='51.84' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='116.53' x2='51.84' y2='116.53' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='75.47' x2='51.84' y2='75.47' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(41.76,445.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(41.76,404.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,362.93) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(41.76,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(41.76,239.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,198.67) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(41.76,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,116.53) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(41.76,75.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='689.76' y1='486.13' x2='689.76' y2='75.47' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='486.13' x2='696.96' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='445.07' x2='696.96' y2='445.07' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='404.00' x2='696.96' y2='404.00' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='362.93' x2='696.96' y2='362.93' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='321.87' x2='696.96' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='280.80' x2='696.96' y2='280.80' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='239.73' x2='696.96' y2='239.73' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='198.67' x2='696.96' y2='198.67' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='157.60' x2='696.96' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='116.53' x2='696.96' y2='116.53' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='75.47' x2='696.96' y2='75.47' style='stroke-width: 0.75;' />
+<text transform='translate(715.68,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(715.68,445.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(715.68,404.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(715.68,362.93) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(715.68,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(715.68,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(715.68,239.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(715.68,198.67) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(715.68,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(715.68,116.53) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(715.68,75.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,485.38 97.00,485.10 111.60,484.74 126.20,484.26 140.80,483.64 155.40,482.84 170.00,481.82 184.60,480.53 199.20,478.92 213.80,476.92 228.40,474.47 243.00,471.48 257.60,467.90 272.20,463.63 286.80,458.60 301.40,452.73 316.00,445.95 330.60,438.21 345.20,429.46 359.80,419.66 374.40,408.82 389.00,396.94 403.60,384.05 418.20,370.23 432.80,355.56 447.40,340.15 462.00,324.14 476.60,307.67 491.20,290.91 505.80,274.03 520.40,257.23 535.00,240.66 549.60,224.51 564.20,208.93 578.80,194.05 593.40,180.01 608.00,166.88 622.60,154.74 637.20,143.65 651.80,133.60 666.40,124.61 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,484.21 97.00,483.42 111.60,482.35 126.20,480.91 140.80,479.02 155.40,476.56 170.00,473.41 184.60,469.43 199.20,464.49 213.80,458.43 228.40,451.12 243.00,442.45 257.60,432.30 272.20,420.61 286.80,407.35 301.40,392.56 316.00,376.30 330.60,358.71 345.20,339.99 359.80,320.35 374.40,300.10 389.00,279.52 403.60,258.96 418.20,238.73 432.80,219.14 447.40,200.47 462.00,182.96 476.60,166.80 491.20,152.11 505.80,138.98 520.40,127.43 535.00,117.42 549.60,108.90 564.20,101.75 578.80,95.84 593.40,91.05 608.00,87.22 622.60,84.21 637.20,81.87 651.80,80.10 666.40,78.76 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,481.63 97.00,479.65 111.60,476.97 126.20,473.39 140.80,468.70 155.40,462.70 170.00,455.15 184.60,445.86 199.20,434.65 213.80,421.41 228.40,406.09 243.00,388.72 257.60,369.44 272.20,348.49 286.80,326.18 301.40,302.93 316.00,279.20 330.60,255.49 345.20,232.30 359.80,210.08 374.40,189.25 389.00,170.12 403.60,152.94 418.20,137.81 432.80,124.79 447.40,113.81 462.00,104.75 476.60,97.43 491.20,91.63 505.80,87.15 520.40,83.75 535.00,81.23 549.60,79.40 564.20,78.10 578.80,77.20 593.40,76.58 608.00,76.17 622.60,75.90 637.20,75.73 651.80,75.62 666.40,75.56 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,475.87 97.00,471.38 111.60,465.37 126.20,457.55 140.80,447.61 155.40,435.30 170.00,420.45 184.60,402.99 199.20,383.00 213.80,360.69 228.40,336.45 243.00,310.79 257.60,284.33 272.20,257.77 286.80,231.79 301.40,207.05 316.00,184.10 330.60,163.38 345.20,145.15 359.80,129.55 374.40,116.53 389.00,105.97 403.60,97.61 418.20,91.18 432.80,86.36 447.40,82.84 462.00,80.34 476.60,78.61 491.20,77.45 505.80,76.69 520.40,76.20 535.00,75.89 549.60,75.71 564.20,75.60 578.80,75.54 593.40,75.51 608.00,75.49 622.60,75.48 637.20,75.47 651.80,75.47 666.40,75.47 ' style='stroke-width: 0.75;' />
+<text x='564.20' y='413.38' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='491.20' y='295.20' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='389.00' y='283.82' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 3</text>
+<text x='330.60' y='259.78' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 4</text>
+<text x='272.20' y='262.06' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.01px' lengthAdjust='spacingAndGlyphs'>Final</text>
+<text x='126.20' y='79.86' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='126.20' y='80.05' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='111.60' y='80.69' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 3</text>
+<text x='111.60' y='81.84' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 4</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-3-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-3-base-true.svg
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,75.47 241.67,140.96 374.40,172.95 507.13,194.02 639.85,210.15 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='105.91' y1='502.56' x2='624.66' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='105.91' y1='502.56' x2='105.91' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='235.59' y1='502.56' x2='235.59' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='365.28' y1='502.56' x2='365.28' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='494.97' y1='502.56' x2='494.97' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='624.66' y1='502.56' x2='624.66' y2='509.76' style='stroke-width: 0.75;' />
+<text x='105.91' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='235.59' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='365.28' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='494.97' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='624.66' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<line x1='59.04' y1='430.46' x2='59.04' y2='93.81' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='430.46' x2='51.84' y2='430.46' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='346.30' x2='51.84' y2='346.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='262.13' x2='51.84' y2='262.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='177.97' x2='51.84' y2='177.97' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='93.81' x2='51.84' y2='93.81' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,430.46) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text transform='translate(41.76,346.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text transform='translate(41.76,262.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,177.97) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,93.81) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='172.12px' lengthAdjust='spacingAndGlyphs'>Treatment effect at bounds</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.38px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,448.80 241.67,383.31 374.40,351.32 507.13,330.24 639.85,314.11 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='79.66' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.22</text>
+<text x='241.67' y='145.09' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.44</text>
+<text x='374.40' y='177.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.06</text>
+<text x='507.13' y='198.16' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.81</text>
+<text x='639.85' y='214.29' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.62</text>
+<text x='108.95' y='452.99' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.22</text>
+<text x='241.67' y='387.44' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.44</text>
+<text x='374.40' y='355.45' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.06</text>
+<text x='507.13' y='334.38' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.81</text>
+<text x='639.85' y='318.25' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.62</text>
+<text x='108.95' y='490.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='241.67' y='490.26' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='374.40' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='507.13' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='639.85' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.70px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-4-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-4-base-false.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='47.55' y='22.78' width='609.28' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='75.24' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='259.87' y='51.49' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='444.51' y='54.89' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='35.60px' lengthAdjust='spacingAndGlyphs'>0.992</text>
+<text x='629.14' y='87.58' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.92</text>
+<text x='75.24' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='259.87' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='444.51' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='629.14' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<polyline points='75.24,498.76 259.87,498.76 444.51,498.76 629.14,498.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='75.24,46.53 259.87,46.59 444.51,50.00 629.14,82.68 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='75.24' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+<text x='259.87' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='444.51' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=61</text>
+<text x='629.14' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='42.62' y='501.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='42.62' y='388.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='42.62' y='275.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='42.62' y='162.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='42.62' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='44.81,498.76 47.55,498.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,385.70 47.55,385.70 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,272.64 47.55,272.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,159.58 47.55,159.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,46.53 47.55,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='71.02,547.85 71.02,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='251.42,547.85 251.42,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='431.82,547.85 431.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.22,547.85 612.22,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='71.02' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='251.42' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='431.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='612.22' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='352.19' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(18.18,347.15) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(18.18,246.86) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(18.18,241.60) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='12.54px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(18.18,229.06) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,229.01) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.16px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(18.18,223.80) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='3.06px' lengthAdjust='spacingAndGlyphs'> </text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='47.55' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='286.19px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-4-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-4-base-true.svg
@@ -1,0 +1,100 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,450.42 285.92,450.42 462.88,450.42 639.85,450.42 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='104.89' y1='502.56' x2='623.64' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='104.89' y1='502.56' x2='104.89' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='191.35' y1='502.56' x2='191.35' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='277.81' y1='502.56' x2='277.81' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='364.27' y1='502.56' x2='364.27' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='450.73' y1='502.56' x2='450.73' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='537.18' y1='502.56' x2='537.18' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='623.64' y1='502.56' x2='623.64' y2='509.76' style='stroke-width: 0.75;' />
+<text x='104.89' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='191.35' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='277.81' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='364.27' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='450.73' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='537.18' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='623.64' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<line x1='59.04' y1='450.42' x2='59.04' y2='93.32' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='450.42' x2='51.84' y2='450.42' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='379.00' x2='51.84' y2='379.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='307.58' x2='51.84' y2='307.58' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='236.16' x2='51.84' y2='236.16' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='164.74' x2='51.84' y2='164.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='93.32' x2='51.84' y2='93.32' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,450.42) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(41.76,379.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,307.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,236.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,164.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,93.32) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='312.21px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(10.47,349.75) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='109.40px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(10.47,240.34) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(10.47,234.60) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='13.68px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(10.47,220.92) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(4.87,220.87) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.63px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(10.47,215.19) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,93.32 285.92,93.38 462.88,96.06 639.85,121.87 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='285.92' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='462.88' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='639.85' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='108.95' y='93.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='285.92' y='93.38' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='462.88' y='96.06' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='639.85' y='121.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='260.57' y='489.24' style='font-size: 12.00px; font-family: sans;' textLength='37.35px' lengthAdjust='spacingAndGlyphs'>Reject </text>
+<text x='297.92' y='489.24' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='306.59' y='491.46' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='108.95' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='285.92' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='462.88' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='639.85' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='108.95' y='97.45' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='285.92' y='97.51' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='462.88' y='100.20' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.992</text>
+<text x='639.85' y='126.00' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.92</text>
+<text x='261.90' y='276.19' style='font-size: 12.00px; font-family: sans;' textLength='48.04px' lengthAdjust='spacingAndGlyphs'>Continue</text>
+<text x='260.57' y='85.71' style='font-size: 12.00px; font-family: sans;' textLength='37.35px' lengthAdjust='spacingAndGlyphs'>Reject </text>
+<text x='297.92' y='85.71' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='306.59' y='87.93' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='108.95' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+<text x='285.92' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='462.88' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=61</text>
+<text x='639.85' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='108.95' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-5-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-5-base-true.svg
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,486.13 97.00,485.33 111.60,484.44 126.20,483.45 140.80,482.36 155.40,481.16 170.00,479.83 184.60,478.37 199.20,476.74 213.80,474.95 228.40,472.97 243.00,470.78 257.60,468.36 272.20,465.68 286.80,462.72 301.40,459.46 316.00,455.85 330.60,451.85 345.20,447.44 359.80,442.57 374.40,437.18 389.00,431.23 403.60,424.65 418.20,417.37 432.80,409.34 447.40,400.45 462.00,390.64 476.60,379.79 491.20,367.80 505.80,354.55 520.40,339.90 535.00,323.72 549.60,305.83 564.20,286.06 578.80,264.21 593.40,240.07 608.00,213.38 622.60,183.89 637.20,151.30 651.80,115.28 666.40,75.47 ' style='stroke-width: 0.38;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='199.20' y1='502.56' x2='199.20' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='316.00' y1='502.56' x2='316.00' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='432.80' y1='502.56' x2='432.80' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='549.60' y1='502.56' x2='549.60' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='199.20' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='316.00' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='432.80' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='549.60' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='59.04' y1='486.13' x2='59.04' y2='75.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='486.13' x2='51.84' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='404.00' x2='51.84' y2='404.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='321.87' x2='51.84' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='239.73' x2='51.84' y2='239.73' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='157.60' x2='51.84' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='75.47' x2='51.84' y2='75.47' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.000</text>
+<text transform='translate(41.76,404.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.005</text>
+<text transform='translate(41.76,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.010</text>
+<text transform='translate(41.76,239.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.015</text>
+<text transform='translate(41.76,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.020</text>
+<text transform='translate(41.76,75.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.025</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='142.52px' lengthAdjust='spacingAndGlyphs'>Spending function plot</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='161.43px' lengthAdjust='spacingAndGlyphs'>Proportion of total sample size</text>
+<text transform='translate(10.47,310.76) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text transform='translate(10.47,303.56) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>-spending</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-6-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-6-base-false.svg
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41OQ=='>
+    <rect x='37.69' y='22.78' width='676.83' height='521.81' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41OQ==)'>
+<rect x='37.69' y='22.78' width='676.83' height='521.81' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='68.45,46.50 83.84,46.81 99.22,47.74 114.60,49.35 129.98,51.70 145.37,54.90 160.75,59.06 176.13,64.30 191.51,70.75 206.90,78.51 222.28,87.67 237.66,98.30 253.04,110.40 268.43,123.96 283.81,138.89 299.19,155.08 314.57,172.37 329.96,190.55 345.34,209.40 360.72,228.70 376.10,248.20 391.49,267.69 406.87,286.97 422.25,305.86 437.63,324.22 453.02,341.93 468.40,358.91 483.78,375.12 499.16,390.53 514.55,405.14 529.93,418.95 545.31,431.99 560.70,444.30 576.08,455.91 591.46,466.86 606.84,477.19 622.23,486.94 637.61,496.14 652.99,504.85 668.37,513.08 683.76,520.87 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='37.69' y='22.78' width='676.83' height='521.81' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='32.76' y='494.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='32.76' y='349.85' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='32.76' y='205.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='32.76' y='61.11' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='34.95,491.19 37.69,491.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,346.82 37.69,346.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,202.45 37.69,202.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,58.08 37.69,58.08 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.45,547.33 68.45,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='222.28,547.33 222.28,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='376.10,547.33 376.10,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='529.93,547.33 529.93,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.76,547.33 683.76,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.45' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='222.28' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='376.10' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='529.93' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='683.76' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='373.61' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(13.05,283.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='107.03px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='331.70px' lengthAdjust='spacingAndGlyphs'>Expected sample size by underlying treatment difference</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-6-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-6-base-true.svg
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,75.47 97.00,75.73 111.60,76.54 126.20,77.93 140.80,79.97 155.40,82.74 170.00,86.34 184.60,90.88 199.20,96.46 213.80,103.17 228.40,111.11 243.00,120.31 257.60,130.79 272.20,142.52 286.80,155.45 301.40,169.47 316.00,184.43 330.60,200.17 345.20,216.49 359.80,233.19 374.40,250.08 389.00,266.96 403.60,283.64 418.20,300.00 432.80,315.89 447.40,331.22 462.00,345.92 476.60,359.95 491.20,373.30 505.80,385.94 520.40,397.90 535.00,409.19 549.60,419.85 564.20,429.90 578.80,439.37 593.40,448.32 608.00,456.76 622.60,464.73 637.20,472.26 651.80,479.39 666.40,486.13 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='228.40' y1='502.56' x2='228.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='374.40' y1='502.56' x2='374.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='520.40' y1='502.56' x2='520.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='228.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='374.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='520.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<line x1='59.04' y1='460.43' x2='59.04' y2='85.49' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='460.43' x2='51.84' y2='460.43' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='397.94' x2='51.84' y2='397.94' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='335.45' x2='51.84' y2='335.45' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='272.96' x2='51.84' y2='272.96' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='210.47' x2='51.84' y2='210.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='147.98' x2='51.84' y2='147.98' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='85.49' x2='51.84' y2='85.49' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,460.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(41.76,397.94) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(41.76,335.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,272.96) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text transform='translate(41.76,210.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,147.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text transform='translate(41.76,85.49) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='361.85px' lengthAdjust='spacingAndGlyphs'>Expected sample size by underlying treatment difference</text>
+<text x='371.68' y='557.14' style='font-size: 12.00px; font-family: sans;' textLength='5.44px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='116.76px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-7-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-7-base-true.svg
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,134.24 241.67,96.09 374.40,78.82 507.13,75.47 639.85,84.06 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='105.91' y1='502.56' x2='624.66' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='105.91' y1='502.56' x2='105.91' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='235.59' y1='502.56' x2='235.59' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='365.28' y1='502.56' x2='365.28' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='494.97' y1='502.56' x2='494.97' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='624.66' y1='502.56' x2='624.66' y2='509.76' style='stroke-width: 0.75;' />
+<text x='105.91' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='235.59' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='365.28' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='494.97' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='624.66' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<line x1='59.04' y1='437.98' x2='59.04' y2='86.29' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='437.98' x2='51.84' y2='437.98' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='350.06' x2='51.84' y2='350.06' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='262.13' x2='51.84' y2='262.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='174.21' x2='51.84' y2='174.21' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='86.29' x2='51.84' y2='86.29' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,437.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text transform='translate(41.76,350.06) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text transform='translate(41.76,262.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,174.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,86.29) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='123.30px' lengthAdjust='spacingAndGlyphs'>B-values at bounds</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.38px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>B-value</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,390.03 241.67,428.18 374.40,445.45 507.13,448.80 639.85,440.21 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='138.31' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.45</text>
+<text x='241.67' y='100.22' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.89</text>
+<text x='374.40' y='82.95' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.08</text>
+<text x='507.13' y='79.66' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.12</text>
+<text x='639.85' y='88.19' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='108.95' y='394.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.45</text>
+<text x='241.67' y='432.31' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.89</text>
+<text x='374.40' y='449.58' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.08</text>
+<text x='507.13' y='452.99' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.12</text>
+<text x='639.85' y='444.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<text x='108.95' y='490.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='241.67' y='490.26' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='374.40' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='507.13' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='639.85' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.70px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-power-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/plottype-power-base-false.svg
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41OQ=='>
+    <rect x='35.24' y='22.78' width='586.85' height='521.81' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41OQ==)'>
+<rect x='35.24' y='22.78' width='586.85' height='521.81' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='61.91,46.77 75.25,46.71 88.59,46.66 101.93,46.62 115.26,46.59 128.60,46.57 141.94,46.55 155.28,46.54 168.61,46.53 181.95,46.52 195.29,46.52 208.63,46.51 221.96,46.51 235.30,46.51 248.64,46.51 261.98,46.51 275.31,46.50 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,47.38 75.25,47.14 88.59,46.96 101.93,46.83 115.26,46.74 128.60,46.67 141.94,46.62 155.28,46.59 168.61,46.56 181.95,46.54 195.29,46.53 208.63,46.52 221.96,46.52 235.30,46.51 248.64,46.51 261.98,46.51 275.31,46.51 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,48.72 75.25,48.06 88.59,47.58 101.93,47.24 115.26,47.00 128.60,46.84 141.94,46.73 155.28,46.65 168.61,46.60 181.95,46.57 195.29,46.55 208.63,46.53 221.96,46.52 235.30,46.51 248.64,46.51 261.98,46.51 275.31,46.51 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,51.71 75.25,50.07 88.59,48.90 101.93,48.10 115.26,47.55 128.60,47.18 141.94,46.93 155.28,46.77 168.61,46.67 181.95,46.61 195.29,46.57 208.63,46.54 221.96,46.53 235.30,46.52 248.64,46.51 261.98,46.51 275.31,46.51 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,58.37 75.25,54.58 88.59,51.89 101.93,50.02 115.26,48.75 128.60,47.92 141.94,47.37 155.28,47.03 168.61,46.82 181.95,46.69 195.29,46.61 208.63,46.57 221.96,46.54 235.30,46.52 248.64,46.51 261.98,46.51 275.31,46.51 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<polyline points='61.91,520.87 75.25,520.79 88.59,520.69 101.93,520.57 115.26,520.41 128.60,520.22 141.94,519.98 155.28,519.68 168.61,519.32 181.95,518.88 195.29,518.35 208.63,517.72 221.96,516.95 235.30,516.05 248.64,514.97 261.98,513.71 275.31,512.23 288.65,510.50 301.99,508.50 315.33,506.20 328.66,503.56 342.00,500.56 355.34,497.15 368.68,493.30 382.01,488.99 395.35,484.18 408.69,478.84 422.03,472.95 435.36,466.48 448.70,459.42 462.04,451.75 475.38,443.46 488.71,434.56 502.05,425.05 515.39,414.94 528.73,404.25 542.06,393.00 555.40,381.24 568.74,369.01 582.08,356.35 595.41,343.32 ' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,520.27 75.25,519.95 88.59,519.53 101.93,518.98 115.26,518.26 128.60,517.34 141.94,516.16 155.28,514.67 168.61,512.81 181.95,510.50 195.29,507.66 208.63,504.21 221.96,500.07 235.30,495.13 248.64,489.32 261.98,482.53 275.31,474.70 288.65,465.75 301.99,455.64 315.33,444.32 328.66,431.78 342.00,418.05 355.34,403.16 368.68,387.19 382.01,370.23 395.35,352.42 408.69,333.91 422.03,314.87 435.36,295.50 448.70,276.00 462.04,256.58 475.38,237.43 488.71,218.77 502.05,200.76 515.39,183.56 528.73,167.33 542.06,152.16 555.40,138.13 568.74,125.30 582.08,113.69 595.41,103.30 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,518.92 75.25,518.01 88.59,516.77 101.93,515.11 115.26,512.92 128.60,510.08 141.94,506.44 155.28,501.84 168.61,496.12 181.95,489.12 195.29,480.68 208.63,470.65 221.96,458.92 235.30,445.41 248.64,430.09 261.98,412.99 275.31,394.20 288.65,373.88 301.99,352.23 315.33,329.54 328.66,306.12 342.00,282.35 355.34,258.58 368.68,235.20 382.01,212.56 395.35,190.98 408.69,170.74 422.03,152.06 435.36,135.09 448.70,119.91 462.04,106.56 475.38,94.99 488.71,85.14 502.05,76.88 515.39,70.05 528.73,64.51 542.06,60.09 555.40,56.60 568.74,53.91 582.08,51.85 595.41,50.31 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,515.93 75.25,513.65 88.59,510.55 101.93,506.41 115.26,501.00 128.60,494.06 141.94,485.33 155.28,474.59 168.61,461.64 181.95,446.34 195.29,428.63 208.63,408.56 221.96,386.28 235.30,362.05 248.64,336.27 261.98,309.40 275.31,281.98 288.65,254.57 301.99,227.76 315.33,202.09 328.66,178.01 342.00,155.91 355.34,136.04 368.68,118.56 382.01,103.51 395.35,90.82 408.69,80.34 422.03,71.88 435.36,65.19 448.70,60.01 462.04,56.08 475.38,53.17 488.71,51.05 502.05,49.55 515.39,48.50 528.73,47.79 542.06,47.31 555.40,47.00 568.74,46.81 582.08,46.68 595.41,46.61 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,509.28 75.25,504.09 88.59,497.15 101.93,488.11 115.26,476.62 128.60,462.39 141.94,445.23 155.28,425.05 168.61,401.94 181.95,376.16 195.29,348.14 208.63,318.48 221.96,287.91 235.30,257.20 248.64,227.17 261.98,198.58 275.31,172.06 288.65,148.11 301.99,127.04 315.33,109.01 328.66,93.97 342.00,81.75 355.34,72.10 368.68,64.67 382.01,59.09 395.35,55.03 408.69,52.14 422.03,50.14 435.36,48.79 448.70,47.91 462.04,47.35 475.38,47.00 488.71,46.78 502.05,46.66 515.39,46.59 528.73,46.55 542.06,46.53 555.40,46.51 568.74,46.51 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='586.85' height='521.81' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='524.17' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='429.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='334.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='239.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='144.46' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='49.53' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,521.14 35.24,521.14 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,426.22 35.24,426.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,331.29 35.24,331.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,236.36 35.24,236.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.43 35.24,141.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,46.50 35.24,46.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='61.91,547.33 61.91,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='195.29,547.33 195.29,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='328.66,547.33 328.66,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.04,547.33 462.04,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='595.41,547.33 595.41,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='61.91' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='195.29' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='328.66' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='462.04' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='595.41' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='326.17' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(13.05,283.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<rect x='633.05' y='202.39' width='81.47' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='211.11' style='font-size: 11.00px; font-family: sans;' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>Probability</text>
+<rect x='633.05' y='217.73' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='226.37' x2='648.60' y2='226.37' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<rect x='633.05' y='235.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='243.65' x2='648.60' y2='243.65' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='229.40' style='font-size: 8.80px; font-family: sans;' textLength='58.71px' lengthAdjust='spacingAndGlyphs'>1-Lower bound</text>
+<text x='655.81' y='246.68' style='font-size: 8.80px; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<rect x='633.05' y='263.25' width='40.97' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='271.96' style='font-size: 11.00px; font-family: sans;' textLength='40.97px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
+<rect x='633.05' y='278.58' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='287.22' x2='648.60' y2='287.22' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='295.86' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='304.50' x2='648.60' y2='304.50' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='313.14' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='321.78' x2='648.60' y2='321.78' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='330.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='339.06' x2='648.60' y2='339.06' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<rect x='633.05' y='347.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='356.34' x2='648.60' y2='356.34' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='290.25' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='655.81' y='307.53' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='655.81' y='324.81' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='655.81' y='342.09' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='655.81' y='359.37' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.18px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsDesign/test-type-1-plottype-2.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsDesign/test-type-1-plottype-2.svg
@@ -1,0 +1,104 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,485.90 97.00,485.83 111.60,485.74 126.20,485.64 140.80,485.50 155.40,485.33 170.00,485.12 184.60,484.87 199.20,484.56 213.80,484.18 228.40,483.72 243.00,483.17 257.60,482.51 272.20,481.72 286.80,480.79 301.40,479.70 316.00,478.42 330.60,476.93 345.20,475.20 359.80,473.20 374.40,470.92 389.00,468.32 403.60,465.37 418.20,462.04 432.80,458.31 447.40,454.15 462.00,449.53 476.60,444.44 491.20,438.84 505.80,432.73 520.40,426.09 535.00,418.92 549.60,411.22 564.20,402.99 578.80,394.24 593.40,384.99 608.00,375.26 622.60,365.09 637.20,354.51 651.80,343.55 666.40,332.28 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='228.40' y1='502.56' x2='228.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='374.40' y1='502.56' x2='374.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='520.40' y1='502.56' x2='520.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='228.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='374.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='520.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='288.20px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+<text x='371.68' y='557.14' style='font-size: 12.00px; font-family: sans;' textLength='5.44px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='224.81px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<line x1='59.04' y1='486.13' x2='59.04' y2='75.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='486.13' x2='51.84' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='445.07' x2='51.84' y2='445.07' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='404.00' x2='51.84' y2='404.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='362.93' x2='51.84' y2='362.93' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='321.87' x2='51.84' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='280.80' x2='51.84' y2='280.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='239.73' x2='51.84' y2='239.73' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='198.67' x2='51.84' y2='198.67' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='157.60' x2='51.84' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='116.53' x2='51.84' y2='116.53' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='75.47' x2='51.84' y2='75.47' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(41.76,445.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(41.76,404.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,362.93) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(41.76,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(41.76,239.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,198.67) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(41.76,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,116.53) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(41.76,75.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='689.76' y1='486.13' x2='689.76' y2='75.47' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='486.13' x2='696.96' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='445.07' x2='696.96' y2='445.07' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='404.00' x2='696.96' y2='404.00' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='362.93' x2='696.96' y2='362.93' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='321.87' x2='696.96' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='280.80' x2='696.96' y2='280.80' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='239.73' x2='696.96' y2='239.73' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='198.67' x2='696.96' y2='198.67' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='157.60' x2='696.96' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='116.53' x2='696.96' y2='116.53' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='75.47' x2='696.96' y2='75.47' style='stroke-width: 0.75;' />
+<text transform='translate(715.68,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(715.68,445.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(715.68,404.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(715.68,362.93) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(715.68,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(715.68,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(715.68,239.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(715.68,198.67) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(715.68,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(715.68,116.53) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(715.68,75.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,485.38 97.00,485.10 111.60,484.74 126.20,484.26 140.80,483.64 155.40,482.84 170.00,481.82 184.60,480.53 199.20,478.92 213.80,476.92 228.40,474.47 243.00,471.48 257.60,467.90 272.20,463.63 286.80,458.60 301.40,452.73 316.00,445.95 330.60,438.21 345.20,429.46 359.80,419.66 374.40,408.82 389.00,396.94 403.60,384.05 418.20,370.23 432.80,355.56 447.40,340.15 462.00,324.14 476.60,307.67 491.20,290.91 505.80,274.03 520.40,257.23 535.00,240.66 549.60,224.51 564.20,208.93 578.80,194.05 593.40,180.01 608.00,166.88 622.60,154.75 637.20,143.65 651.80,133.60 666.40,124.61 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,484.21 97.00,483.42 111.60,482.35 126.20,480.91 140.80,479.02 155.40,476.56 170.00,473.41 184.60,469.43 199.20,464.49 213.80,458.43 228.40,451.12 243.00,442.45 257.60,432.30 272.20,420.61 286.80,407.35 301.40,392.56 316.00,376.30 330.60,358.71 345.20,339.99 359.80,320.35 374.40,300.10 389.00,279.52 403.60,258.96 418.20,238.73 432.80,219.14 447.40,200.47 462.00,182.96 476.60,166.80 491.20,152.11 505.80,138.98 520.40,127.43 535.00,117.42 549.60,108.90 564.20,101.75 578.80,95.84 593.40,91.05 608.00,87.22 622.60,84.21 637.20,81.87 651.80,80.10 666.40,78.76 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,481.63 97.00,479.65 111.60,476.97 126.20,473.39 140.80,468.70 155.40,462.70 170.00,455.15 184.60,445.86 199.20,434.65 213.80,421.41 228.40,406.09 243.00,388.72 257.60,369.44 272.20,348.49 286.80,326.18 301.40,302.93 316.00,279.20 330.60,255.49 345.20,232.30 359.80,210.08 374.40,189.25 389.00,170.12 403.60,152.94 418.20,137.81 432.80,124.79 447.40,113.81 462.00,104.75 476.60,97.43 491.20,91.63 505.80,87.15 520.40,83.75 535.00,81.23 549.60,79.40 564.20,78.10 578.80,77.20 593.40,76.58 608.00,76.17 622.60,75.90 637.20,75.73 651.80,75.62 666.40,75.56 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,475.87 97.00,471.38 111.60,465.37 126.20,457.55 140.80,447.61 155.40,435.30 170.00,420.45 184.60,402.99 199.20,383.00 213.80,360.69 228.40,336.45 243.00,310.79 257.60,284.33 272.20,257.77 286.80,231.79 301.40,207.05 316.00,184.10 330.60,163.38 345.20,145.15 359.80,129.55 374.40,116.53 389.00,105.97 403.60,97.61 418.20,91.18 432.80,86.36 447.40,82.84 462.00,80.34 476.60,78.61 491.20,77.45 505.80,76.69 520.40,76.20 535.00,75.89 549.60,75.71 564.20,75.60 578.80,75.54 593.40,75.51 608.00,75.49 622.60,75.48 637.20,75.47 651.80,75.47 666.40,75.47 ' style='stroke-width: 0.75;' />
+<text x='564.20' y='413.38' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='491.20' y='295.20' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='389.00' y='283.82' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 3</text>
+<text x='330.60' y='259.78' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 4</text>
+<text x='272.20' y='262.06' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.01px' lengthAdjust='spacingAndGlyphs'>Final</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-1-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-1-base-false.svg
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='30.83' y='22.78' width='626.00' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='59.28' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>3.25</text>
+<text x='201.56' y='69.11' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.99</text>
+<text x='343.83' y='88.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.69</text>
+<text x='486.10' y='109.75' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.37</text>
+<text x='628.38' y='132.86' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='59.28' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-3.25</text>
+<text x='201.56' y='465.41' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.99</text>
+<text x='343.83' y='445.87' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.69</text>
+<text x='486.10' y='424.77' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.37</text>
+<text x='628.38' y='401.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<polyline points='59.28,478.20 201.56,460.51 343.83,440.98 486.10,419.87 628.38,396.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='59.28,46.53 201.56,64.22 343.83,83.75 486.10,104.85 628.38,127.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='59.28' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='201.56' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='343.83' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='486.10' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='628.38' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='25.90' y='530.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='25.90' y='398.11' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='25.90' y='265.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='132.68' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,527.79 30.83,527.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,395.08 30.83,395.08 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,262.36 30.83,262.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,129.65 30.83,129.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='56.03,547.85 56.03,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='195.04,547.85 195.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.05,547.85 334.05,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='473.07,547.85 473.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.08,547.85 612.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='56.03' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='195.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='334.05' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='473.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='612.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='343.83' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.93px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='99.04px' lengthAdjust='spacingAndGlyphs'>Normal critical value</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.44px' lengthAdjust='spacingAndGlyphs'>Normal test statistics at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-1-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-1-base-true.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,75.47 241.67,90.77 374.40,107.66 507.13,125.91 639.85,145.90 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='105.91' y1='502.56' x2='624.66' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='105.91' y1='502.56' x2='105.91' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='235.59' y1='502.56' x2='235.59' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='365.28' y1='502.56' x2='365.28' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='494.97' y1='502.56' x2='494.97' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='624.66' y1='502.56' x2='624.66' y2='509.76' style='stroke-width: 0.75;' />
+<text x='105.91' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='235.59' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='365.28' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='494.97' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='624.66' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<line x1='59.04' y1='491.69' x2='59.04' y2='89.97' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='491.69' x2='51.84' y2='491.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='434.30' x2='51.84' y2='434.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='376.91' x2='51.84' y2='376.91' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='319.52' x2='51.84' y2='319.52' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='262.13' x2='51.84' y2='262.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='204.74' x2='51.84' y2='204.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='147.36' x2='51.84' y2='147.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='89.97' x2='51.84' y2='89.97' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,491.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text transform='translate(41.76,434.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text transform='translate(41.76,376.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text transform='translate(41.76,319.52) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text transform='translate(41.76,262.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,204.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,147.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text transform='translate(41.76,89.97) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='200.12px' lengthAdjust='spacingAndGlyphs'>Normal test statistics at bounds</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.38px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='108.04px' lengthAdjust='spacingAndGlyphs'>Normal critical value</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,448.80 241.67,433.50 374.40,416.60 507.13,398.36 639.85,378.36 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='79.60' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>3.25</text>
+<text x='241.67' y='94.90' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.99</text>
+<text x='374.40' y='111.80' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.69</text>
+<text x='507.13' y='130.04' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.37</text>
+<text x='639.85' y='150.04' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='108.95' y='452.93' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-3.25</text>
+<text x='241.67' y='437.63' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.99</text>
+<text x='374.40' y='420.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.69</text>
+<text x='507.13' y='402.49' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.37</text>
+<text x='639.85' y='382.50' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<text x='108.95' y='490.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='241.67' y='490.26' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='374.40' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='507.13' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='639.85' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.70px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-2-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-2-base-true.svg
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,485.95 111.60,485.86 140.80,485.73 170.00,485.55 199.20,485.29 228.40,484.95 257.60,484.48 286.80,483.86 316.00,483.03 345.20,481.96 374.40,480.57 403.60,478.81 432.80,476.60 462.00,473.86 491.20,470.51 520.40,466.47 549.60,461.65 578.80,455.98 608.00,449.39 637.20,441.82 666.40,433.25 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='199.20' y1='502.56' x2='199.20' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='316.00' y1='502.56' x2='316.00' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='432.80' y1='502.56' x2='432.80' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='549.60' y1='502.56' x2='549.60' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='199.20' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='316.00' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='432.80' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='549.60' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='288.20px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+<text x='371.53' y='557.14' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='224.81px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<line x1='689.76' y1='486.13' x2='689.76' y2='157.60' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='486.13' x2='696.96' y2='486.13' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='453.28' x2='696.96' y2='453.28' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='420.43' x2='696.96' y2='420.43' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='387.57' x2='696.96' y2='387.57' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='354.72' x2='696.96' y2='354.72' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='321.87' x2='696.96' y2='321.87' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='289.01' x2='696.96' y2='289.01' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='256.16' x2='696.96' y2='256.16' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='223.31' x2='696.96' y2='223.31' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='190.45' x2='696.96' y2='190.45' style='stroke-width: 0.75;' />
+<line x1='689.76' y1='157.60' x2='696.96' y2='157.60' style='stroke-width: 0.75;' />
+<text transform='translate(715.68,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(715.68,453.28) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(715.68,420.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(715.68,387.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(715.68,354.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(715.68,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(715.68,289.01) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(715.68,256.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(715.68,223.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(715.68,190.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(715.68,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='59.04' y1='486.13' x2='59.04' y2='157.60' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='486.13' x2='51.84' y2='486.13' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='453.28' x2='51.84' y2='453.28' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='420.43' x2='51.84' y2='420.43' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='387.57' x2='51.84' y2='387.57' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='354.72' x2='51.84' y2='354.72' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='321.87' x2='51.84' y2='321.87' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='289.01' x2='51.84' y2='289.01' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='256.16' x2='51.84' y2='256.16' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='223.31' x2='51.84' y2='223.31' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='190.45' x2='51.84' y2='190.45' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='59.04' y1='157.60' x2='51.84' y2='157.60' style='stroke-width: 0.75; stroke: #DF536B;' />
+<text transform='translate(41.76,486.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,453.28) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text transform='translate(41.76,420.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,387.57) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text transform='translate(41.76,354.72) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,321.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(41.76,289.01) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,256.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text transform='translate(41.76,223.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,190.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text transform='translate(41.76,157.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,157.79 111.60,157.73 140.80,157.68 170.00,157.65 199.20,157.63 228.40,157.62 257.60,157.61 286.80,157.61 316.00,157.61 345.20,157.60 374.40,157.60 403.60,157.60 432.80,157.60 462.00,157.60 491.20,157.60 520.40,157.60 549.60,157.60 578.80,157.60 608.00,157.60 637.20,157.60 666.40,157.60 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='82.40,158.21 111.60,157.97 140.80,157.82 170.00,157.73 199.20,157.68 228.40,157.64 257.60,157.63 286.80,157.61 316.00,157.61 345.20,157.60 374.40,157.60 403.60,157.60 432.80,157.60 462.00,157.60 491.20,157.60 520.40,157.60 549.60,157.60 578.80,157.60 608.00,157.60 637.20,157.60 666.40,157.60 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='82.40,159.14 111.60,158.48 140.80,158.10 170.00,157.87 199.20,157.75 228.40,157.68 257.60,157.64 286.80,157.62 316.00,157.61 345.20,157.61 374.40,157.60 403.60,157.60 432.80,157.60 462.00,157.60 491.20,157.60 520.40,157.60 549.60,157.60 578.80,157.60 608.00,157.60 637.20,157.60 666.40,157.60 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='82.40,161.21 111.60,159.60 140.80,158.67 170.00,158.15 199.20,157.88 228.40,157.73 257.60,157.66 286.80,157.63 316.00,157.61 345.20,157.61 374.40,157.60 403.60,157.60 432.80,157.60 462.00,157.60 491.20,157.60 520.40,157.60 549.60,157.60 578.80,157.60 608.00,157.60 637.20,157.60 666.40,157.60 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<polyline points='82.40,165.81 111.60,162.10 140.80,159.95 170.00,158.77 199.20,158.15 228.40,157.85 257.60,157.71 286.80,157.65 316.00,157.62 345.20,157.61 374.40,157.60 403.60,157.60 432.80,157.60 462.00,157.60 491.20,157.60 520.40,157.60 549.60,157.60 578.80,157.60 608.00,157.60 637.20,157.60 666.40,157.60 ' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<rect x='59.04' y='59.04' width='81.29' height='57.60' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='69.84' y1='87.84' x2='91.44' y2='87.84' style='stroke-width: 0.75;' />
+<line x1='69.84' y1='102.24' x2='91.44' y2='102.24' style='stroke-width: 0.75; stroke: #DF536B; stroke-dasharray: 4.00,4.00;' />
+<text x='99.68' y='73.44' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='51.38px' lengthAdjust='spacingAndGlyphs'>Boundary</text>
+<text x='102.24' y='91.97' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='102.24' y='106.37' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='133.13' y='90.59' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='133.13' y='104.99' text-anchor='end' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='32.69px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<polyline points='82.40,485.53 111.60,485.16 140.80,484.60 170.00,483.76 199.20,482.53 228.40,480.76 257.60,478.30 286.80,474.93 316.00,470.45 345.20,464.61 374.40,457.20 403.60,448.01 432.80,436.90 462.00,423.80 491.20,408.74 520.40,391.84 549.60,373.36 578.80,353.63 608.00,333.12 637.20,312.31 666.40,291.73 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,484.60 111.60,483.53 140.80,481.85 170.00,479.27 199.20,475.46 228.40,470.04 257.60,462.58 286.80,452.68 316.00,440.03 345.20,424.42 374.40,405.89 403.60,384.67 432.80,361.28 462.00,336.45 491.20,311.04 520.40,286.02 549.60,262.29 578.80,240.62 608.00,221.57 637.20,205.44 666.40,192.29 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,482.53 111.60,479.86 140.80,475.65 170.00,469.31 199.20,460.19 228.40,447.69 257.60,431.39 286.80,411.15 316.00,387.22 345.20,360.32 374.40,331.53 403.60,302.23 432.80,273.88 462.00,247.79 491.20,224.95 520.40,205.95 549.60,190.91 578.80,179.61 608.00,171.52 637.20,166.03 666.40,162.48 ' style='stroke-width: 0.75;' />
+<polyline points='82.40,477.92 111.60,471.89 140.80,462.66 170.00,449.37 199.20,431.36 228.40,408.43 257.60,380.97 286.80,350.09 316.00,317.45 345.20,285.06 374.40,254.87 403.60,228.44 432.80,206.72 462.00,189.96 491.20,177.83 520.40,169.57 549.60,164.30 578.80,161.15 608.00,159.37 637.20,158.44 666.40,157.97 ' style='stroke-width: 0.75;' />
+<text x='578.80' y='463.89' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='549.60' y='377.65' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='462.00' y='340.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 3</text>
+<text x='403.60' y='306.53' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 4</text>
+<text x='316.00' y='321.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.01px' lengthAdjust='spacingAndGlyphs'>Final</text>
+<text x='140.80' y='161.97' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 1</text>
+<text x='140.80' y='162.11' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 2</text>
+<text x='140.80' y='162.39' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 3</text>
+<text x='140.80' y='162.96' text-anchor='middle' style='font-size: 12.00px; fill: #DF536B; font-family: sans;' textLength='46.68px' lengthAdjust='spacingAndGlyphs'>Interim 4</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-4-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-4-base-false.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='47.55' y='22.78' width='609.28' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='75.24' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='259.87' y='51.49' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='444.51' y='54.89' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='35.60px' lengthAdjust='spacingAndGlyphs'>0.992</text>
+<text x='629.14' y='87.58' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.92</text>
+<text x='75.24' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='259.87' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='444.51' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='629.14' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<polyline points='75.24,498.76 259.87,498.76 444.51,498.76 629.14,498.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='75.24,46.53 259.87,46.59 444.51,50.00 629.14,82.68 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='75.24' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+<text x='259.87' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='444.51' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=61</text>
+<text x='629.14' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='42.62' y='501.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='42.62' y='388.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='42.62' y='275.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='42.62' y='162.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='42.62' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='44.81,498.76 47.55,498.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,385.70 47.55,385.70 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,272.64 47.55,272.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,159.58 47.55,159.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,46.53 47.55,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='71.02,547.85 71.02,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='251.42,547.85 251.42,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='431.82,547.85 431.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.22,547.85 612.22,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='71.02' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='251.42' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='431.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='612.22' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='352.19' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(18.18,347.15) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(18.18,246.86) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(18.18,241.60) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='12.54px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(18.18,229.06) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,229.01) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.16px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(18.18,223.80) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='3.06px' lengthAdjust='spacingAndGlyphs'> </text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='47.55' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='286.19px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-4-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-4-base-true.svg
@@ -1,0 +1,100 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,450.42 285.92,450.42 462.88,450.42 639.85,450.42 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='104.89' y1='502.56' x2='623.64' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='104.89' y1='502.56' x2='104.89' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='191.35' y1='502.56' x2='191.35' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='277.81' y1='502.56' x2='277.81' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='364.27' y1='502.56' x2='364.27' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='450.73' y1='502.56' x2='450.73' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='537.18' y1='502.56' x2='537.18' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='623.64' y1='502.56' x2='623.64' y2='509.76' style='stroke-width: 0.75;' />
+<text x='104.89' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='191.35' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='277.81' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='364.27' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='450.73' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='537.18' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='623.64' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<line x1='59.04' y1='450.42' x2='59.04' y2='93.32' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='450.42' x2='51.84' y2='450.42' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='379.00' x2='51.84' y2='379.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='307.58' x2='51.84' y2='307.58' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='236.16' x2='51.84' y2='236.16' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='164.74' x2='51.84' y2='164.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='93.32' x2='51.84' y2='93.32' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,450.42) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(41.76,379.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text transform='translate(41.76,307.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text transform='translate(41.76,236.16) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text transform='translate(41.76,164.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text transform='translate(41.76,93.32) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='312.21px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>N</text>
+<text transform='translate(10.47,349.75) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='109.40px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(10.47,240.34) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(10.47,234.60) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='13.68px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(10.47,220.92) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(4.87,220.87) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='5.63px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(10.47,215.19) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,93.32 285.92,93.38 462.88,96.06 639.85,121.87 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='285.92' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='462.88' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='639.85' y='450.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='108.95' y='93.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='285.92' y='93.38' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='462.88' y='96.06' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='639.85' y='121.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='260.57' y='489.24' style='font-size: 12.00px; font-family: sans;' textLength='37.35px' lengthAdjust='spacingAndGlyphs'>Reject </text>
+<text x='297.92' y='489.24' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='306.59' y='491.46' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='108.95' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='285.92' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='462.88' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='639.85' y='454.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='108.95' y='97.45' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='285.92' y='97.51' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='462.88' y='100.20' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.992</text>
+<text x='639.85' y='126.00' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.92</text>
+<text x='261.90' y='276.19' style='font-size: 12.00px; font-family: sans;' textLength='48.04px' lengthAdjust='spacingAndGlyphs'>Continue</text>
+<text x='260.57' y='85.71' style='font-size: 12.00px; font-family: sans;' textLength='37.35px' lengthAdjust='spacingAndGlyphs'>Reject </text>
+<text x='297.92' y='85.71' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='306.59' y='87.93' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='108.95' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+<text x='285.92' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='462.88' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=61</text>
+<text x='639.85' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='108.95' y='472.41' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=20</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-6-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-6-base-false.svg
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41Ng=='>
+    <rect x='37.69' y='22.78' width='676.83' height='521.77' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41Ng==)'>
+<rect x='37.69' y='22.78' width='676.83' height='521.77' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='68.45,46.50 99.22,47.41 129.98,50.23 160.75,55.28 191.51,63.03 222.28,74.03 253.04,88.80 283.81,107.74 314.57,131.02 345.34,158.50 376.10,189.70 406.87,223.88 437.63,260.06 468.40,297.19 499.16,334.26 529.93,370.39 560.70,404.91 591.46,437.37 622.23,467.54 652.99,495.34 683.76,520.84 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='37.69' y='22.78' width='676.83' height='521.77' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='32.76' y='510.17' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='32.76' y='420.90' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='32.76' y='331.64' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text x='32.76' y='242.38' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='32.76' y='153.11' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text x='32.76' y='63.85' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='34.95,507.14 37.69,507.14 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,417.88 37.69,417.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,328.61 37.69,328.61 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,239.35 37.69,239.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,150.09 37.69,150.09 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,60.82 37.69,60.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.45,547.30 68.45,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='191.51,547.30 191.51,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='314.57,547.30 314.57,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='437.63,547.30 437.63,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='560.70,547.30 560.70,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.76,547.30 683.76,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.45' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='191.51' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='314.57' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='437.63' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='560.70' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='683.76' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='373.47' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,283.67) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='107.03px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='331.70px' lengthAdjust='spacingAndGlyphs'>Expected sample size by underlying treatment difference</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-6-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-6-base-true.svg
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='82.40,75.47 111.60,76.25 140.80,78.69 170.00,83.07 199.20,89.78 228.40,99.30 257.60,112.09 286.80,128.49 316.00,148.64 345.20,172.43 374.40,199.45 403.60,229.03 432.80,260.36 462.00,292.50 491.20,324.60 520.40,355.88 549.60,385.76 578.80,413.87 608.00,439.99 637.20,464.06 666.40,486.13 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='82.40' y1='502.56' x2='666.40' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='82.40' y1='502.56' x2='82.40' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='199.20' y1='502.56' x2='199.20' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='316.00' y1='502.56' x2='316.00' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='432.80' y1='502.56' x2='432.80' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='549.60' y1='502.56' x2='549.60' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='666.40' y1='502.56' x2='666.40' y2='509.76' style='stroke-width: 0.75;' />
+<text x='82.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='199.20' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='316.00' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='432.80' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='549.60' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='666.40' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<line x1='59.04' y1='474.27' x2='59.04' y2='87.87' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='474.27' x2='51.84' y2='474.27' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='396.99' x2='51.84' y2='396.99' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='319.71' x2='51.84' y2='319.71' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='242.43' x2='51.84' y2='242.43' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='165.15' x2='51.84' y2='165.15' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='87.87' x2='51.84' y2='87.87' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,474.27) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(41.76,396.99) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(41.76,319.71) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>70</text>
+<text transform='translate(41.76,242.43) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(41.76,165.15) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>90</text>
+<text transform='translate(41.76,87.87) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='361.85px' lengthAdjust='spacingAndGlyphs'>Expected sample size by underlying treatment difference</text>
+<text x='371.53' y='557.14' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='116.76px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-7-base-true.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-7-base-true.svg
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,134.24 241.67,96.09 374.40,78.82 507.13,75.47 639.85,84.06 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='105.91' y1='502.56' x2='624.66' y2='502.56' style='stroke-width: 0.75;' />
+<line x1='105.91' y1='502.56' x2='105.91' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='235.59' y1='502.56' x2='235.59' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='365.28' y1='502.56' x2='365.28' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='494.97' y1='502.56' x2='494.97' y2='509.76' style='stroke-width: 0.75;' />
+<line x1='624.66' y1='502.56' x2='624.66' y2='509.76' style='stroke-width: 0.75;' />
+<text x='105.91' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='235.59' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='365.28' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='494.97' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='624.66' y='528.48' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<line x1='59.04' y1='437.98' x2='59.04' y2='86.29' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='437.98' x2='51.84' y2='437.98' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='350.06' x2='51.84' y2='350.06' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='262.13' x2='51.84' y2='262.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='174.21' x2='51.84' y2='174.21' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='86.29' x2='51.84' y2='86.29' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,437.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text transform='translate(41.76,350.06) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text transform='translate(41.76,262.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,174.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text transform='translate(41.76,86.29) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
+<text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='123.30px' lengthAdjust='spacingAndGlyphs'>B-values at bounds</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='65.38px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>B-value</text>
+</g>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polyline points='108.95,390.03 241.67,428.18 374.40,445.45 507.13,448.80 639.85,440.21 ' style='stroke-width: 0.75;' />
+<text x='108.95' y='138.31' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.45</text>
+<text x='241.67' y='100.22' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.89</text>
+<text x='374.40' y='82.95' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.08</text>
+<text x='507.13' y='79.66' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.12</text>
+<text x='639.85' y='88.19' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='108.95' y='394.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.45</text>
+<text x='241.67' y='432.31' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.89</text>
+<text x='374.40' y='449.58' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.08</text>
+<text x='507.13' y='452.99' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.12</text>
+<text x='639.85' y='444.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<text x='108.95' y='490.32' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=21</text>
+<text x='241.67' y='490.26' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=41</text>
+<text x='374.40' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=62</text>
+<text x='507.13' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='29.03px' lengthAdjust='spacingAndGlyphs'>N=82</text>
+<text x='639.85' y='490.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.70px' lengthAdjust='spacingAndGlyphs'>N=103</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-power-base-false.svg
+++ b/tests/testthat/_snaps/independent-test-plot.gsProbability/plottype-power-base-false.svg
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41Ng=='>
+    <rect x='35.24' y='22.78' width='586.85' height='521.77' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41Ng==)'>
+<rect x='35.24' y='22.78' width='586.85' height='521.77' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='61.91,46.77 88.59,46.68 115.26,46.62 141.94,46.58 168.61,46.55 195.29,46.53 221.96,46.52 248.64,46.51 275.31,46.51 301.99,46.51 328.66,46.50 355.34,46.50 382.01,46.50 408.69,46.50 435.36,46.50 462.04,46.50 488.71,46.50 515.39,46.50 542.06,46.50 568.74,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,47.38 88.59,47.04 115.26,46.82 141.94,46.69 168.61,46.61 195.29,46.57 221.96,46.54 248.64,46.52 275.31,46.51 301.99,46.51 328.66,46.50 355.34,46.50 382.01,46.50 408.69,46.50 435.36,46.50 462.04,46.50 488.71,46.50 515.39,46.50 542.06,46.50 568.74,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,48.72 88.59,47.78 115.26,47.22 141.94,46.89 168.61,46.71 195.29,46.61 221.96,46.56 248.64,46.53 275.31,46.52 301.99,46.51 328.66,46.50 355.34,46.50 382.01,46.50 408.69,46.50 435.36,46.50 462.04,46.50 488.71,46.50 515.39,46.50 542.06,46.50 568.74,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,51.71 88.59,49.38 115.26,48.04 141.94,47.30 168.61,46.90 195.29,46.70 221.96,46.59 248.64,46.55 275.31,46.52 301.99,46.51 328.66,46.51 355.34,46.50 382.01,46.50 408.69,46.50 435.36,46.50 462.04,46.50 488.71,46.50 515.39,46.50 542.06,46.50 568.74,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,58.37 88.59,53.00 115.26,49.89 141.94,48.19 168.61,47.30 195.29,46.87 221.96,46.66 248.64,46.57 275.31,46.53 301.99,46.51 328.66,46.51 355.34,46.50 382.01,46.50 408.69,46.50 435.36,46.50 462.04,46.50 488.71,46.50 515.39,46.50 542.06,46.50 568.74,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<polyline points='61.91,520.84 88.59,520.71 115.26,520.53 141.94,520.26 168.61,519.90 195.29,519.40 221.96,518.73 248.64,517.82 275.31,516.63 301.99,515.08 328.66,513.07 355.34,510.53 382.01,507.34 408.69,503.39 435.36,498.55 462.04,492.71 488.71,485.75 515.39,477.55 542.06,468.03 568.74,457.10 595.41,444.72 ' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,520.24 88.59,519.71 115.26,518.90 141.94,517.68 168.61,515.90 195.29,513.36 221.96,509.80 248.64,504.93 275.31,498.45 301.99,490.02 328.66,479.31 355.34,466.03 382.01,449.99 408.69,431.07 435.36,409.31 462.04,384.89 488.71,358.19 515.39,329.70 542.06,300.06 568.74,270.00 595.41,240.27 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,518.89 88.59,517.35 115.26,514.92 141.94,511.19 168.61,505.70 195.29,497.86 221.96,487.09 248.64,472.79 275.31,454.50 301.99,431.96 328.66,405.18 355.34,374.54 382.01,340.75 408.69,304.87 435.36,268.17 462.04,232.02 488.71,197.74 515.39,166.44 542.06,138.91 568.74,115.61 595.41,96.61 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,515.90 88.59,512.06 115.26,505.97 141.94,496.81 168.61,483.63 195.29,465.57 221.96,442.03 248.64,412.78 275.31,378.22 301.99,339.35 328.66,297.76 355.34,255.45 382.01,214.49 408.69,176.79 435.36,143.80 462.04,116.35 488.71,94.63 515.39,78.29 542.06,66.61 568.74,58.68 595.41,53.55 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,509.25 88.59,500.53 115.26,487.20 141.94,468.00 168.61,441.99 195.29,408.85 221.96,369.19 248.64,324.57 275.31,277.43 301.99,230.63 328.66,187.01 355.34,148.84 382.01,117.46 408.69,93.25 435.36,75.72 462.04,63.80 488.71,56.19 515.39,51.63 542.06,49.06 568.74,47.71 595.41,47.04 ' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='586.85' height='521.77' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='524.14' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='429.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='334.30' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='239.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='144.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='49.53' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,521.11 35.24,521.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,426.19 35.24,426.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,331.27 35.24,331.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,236.35 35.24,236.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.42 35.24,141.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,46.50 35.24,46.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='61.91,547.30 61.91,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='168.61,547.30 168.61,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='275.31,547.30 275.31,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='382.01,547.30 382.01,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='488.71,547.30 488.71,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='595.41,547.30 595.41,544.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='61.91' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='168.61' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='275.31' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='382.01' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='488.71' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='595.41' y='555.55' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='326.03' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,283.67) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<rect x='633.05' y='202.38' width='81.47' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='211.09' style='font-size: 11.00px; font-family: sans;' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>Probability</text>
+<rect x='633.05' y='217.71' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='226.35' x2='648.60' y2='226.35' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<rect x='633.05' y='234.99' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='243.63' x2='648.60' y2='243.63' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='229.38' style='font-size: 8.80px; font-family: sans;' textLength='58.71px' lengthAdjust='spacingAndGlyphs'>1-Lower bound</text>
+<text x='655.81' y='246.66' style='font-size: 8.80px; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<rect x='633.05' y='263.23' width='40.97' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='271.94' style='font-size: 11.00px; font-family: sans;' textLength='40.97px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
+<rect x='633.05' y='278.56' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='287.20' x2='648.60' y2='287.20' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='295.84' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='304.48' x2='648.60' y2='304.48' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54,11.38,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='313.12' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='321.76' x2='648.60' y2='321.76' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='330.40' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='339.04' x2='648.60' y2='339.04' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<rect x='633.05' y='347.68' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='356.32' x2='648.60' y2='356.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='290.23' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='655.81' y='307.51' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='655.81' y='324.79' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='655.81' y='342.07' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='655.81' y='359.35' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.18px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plot.ssrCP/ssr-cp.svg
+++ b/tests/testthat/_snaps/independent-test-plot.ssrCP/ssr-cp.svg
@@ -1,0 +1,138 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NjYwLjk2fDU5LjA0fDQ3My43Ng=='>
+    <rect x='59.04' y='59.04' width='601.92' height='414.72' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NjYwLjk2fDU5LjA0fDQ3My43Ng==)'>
+<polyline points='81.33,458.40 90.62,458.40 99.91,458.40 109.20,458.40 118.49,458.40 127.78,458.40 137.07,458.40 146.36,458.40 155.64,458.40 164.93,458.40 174.22,458.40 183.51,458.40 192.80,458.40 202.09,458.40 211.38,458.40 220.67,458.40 229.96,458.40 239.24,458.40 248.53,458.40 257.82,458.40 267.11,458.40 276.40,458.40 285.69,458.40 294.98,458.40 304.27,458.40 313.56,458.40 322.84,458.40 332.13,458.40 341.42,458.40 350.71,458.40 360.00,458.40 369.29,458.40 378.58,458.40 387.87,458.40 397.16,458.40 406.44,328.93 415.73,328.93 425.02,328.93 434.31,328.93 443.60,328.93 452.89,328.93 462.18,328.93 471.47,328.93 480.76,328.93 490.04,328.93 499.33,74.40 508.62,146.52 517.91,203.94 527.20,250.07 536.49,328.93 545.78,328.93 555.07,328.93 564.36,328.93 573.64,328.93 582.93,328.93 592.22,328.93 601.51,328.93 610.80,328.93 620.09,458.40 629.38,458.40 638.67,458.40 ' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='59.04' y1='398.83' x2='59.04' y2='115.28' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='398.83' x2='51.84' y2='398.83' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='304.31' x2='51.84' y2='304.31' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='209.80' x2='51.84' y2='209.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='115.28' x2='51.84' y2='115.28' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,398.83) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text transform='translate(41.76,304.31) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text transform='translate(41.76,209.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text transform='translate(41.76,115.28) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text transform='translate(27.36,266.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='111.42px' lengthAdjust='spacingAndGlyphs'>Adapted sample size</text>
+<line x1='81.33' y1='516.96' x2='638.67' y2='516.96' style='stroke-width: 0.75;' />
+<line x1='81.33' y1='516.96' x2='81.33' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='127.78' y1='516.96' x2='127.78' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='174.22' y1='516.96' x2='174.22' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='220.67' y1='516.96' x2='220.67' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='267.11' y1='516.96' x2='267.11' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='313.56' y1='516.96' x2='313.56' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='360.00' y1='516.96' x2='360.00' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='406.44' y1='516.96' x2='406.44' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='452.89' y1='516.96' x2='452.89' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='499.33' y1='516.96' x2='499.33' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='545.78' y1='516.96' x2='545.78' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='592.22' y1='516.96' x2='592.22' y2='524.16' style='stroke-width: 0.75;' />
+<line x1='638.67' y1='516.96' x2='638.67' y2='524.16' style='stroke-width: 0.75;' />
+<text x='81.33' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='127.78' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='174.22' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='220.67' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='267.11' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='313.56' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='360.00' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='406.44' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.04</text>
+<text x='452.89' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.21</text>
+<text x='499.33' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.58</text>
+<text x='545.78' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.88</text>
+<text x='592.22' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.99</text>
+<text x='638.67' y='542.88' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='40.46' y='535.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>CP</text>
+<line x1='81.33' y1='488.16' x2='638.67' y2='488.16' style='stroke-width: 0.75;' />
+<line x1='81.33' y1='488.16' x2='81.33' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='127.78' y1='488.16' x2='127.78' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='174.22' y1='488.16' x2='174.22' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='220.67' y1='488.16' x2='220.67' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='267.11' y1='488.16' x2='267.11' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='313.56' y1='488.16' x2='313.56' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='360.00' y1='488.16' x2='360.00' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='406.44' y1='488.16' x2='406.44' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='452.89' y1='488.16' x2='452.89' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='499.33' y1='488.16' x2='499.33' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='545.78' y1='488.16' x2='545.78' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='592.22' y1='488.16' x2='592.22' y2='495.36' style='stroke-width: 0.75;' />
+<line x1='638.67' y1='488.16' x2='638.67' y2='495.36' style='stroke-width: 0.75;' />
+<text x='81.33' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='127.78' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-2.5</text>
+<text x='174.22' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='220.67' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.5</text>
+<text x='267.11' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='313.56' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='360.00' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='406.44' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='452.89' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='499.33' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='545.78' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='592.22' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='638.67' y='514.08' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='35.12' y='493.86' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>z</text>
+<text x='41.13' y='496.08' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<line x1='81.33' y1='545.76' x2='638.67' y2='545.76' style='stroke-width: 0.75;' />
+<line x1='81.33' y1='545.76' x2='81.33' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='127.78' y1='545.76' x2='127.78' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='174.22' y1='545.76' x2='174.22' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='220.67' y1='545.76' x2='220.67' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='267.11' y1='545.76' x2='267.11' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='313.56' y1='545.76' x2='313.56' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='360.00' y1='545.76' x2='360.00' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='406.44' y1='545.76' x2='406.44' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='452.89' y1='545.76' x2='452.89' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='499.33' y1='545.76' x2='499.33' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='545.78' y1='545.76' x2='545.78' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='592.22' y1='545.76' x2='592.22' y2='552.96' style='stroke-width: 0.75;' />
+<line x1='638.67' y1='545.76' x2='638.67' y2='552.96' style='stroke-width: 0.75;' />
+<text x='81.33' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.28</text>
+<text x='127.78' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-1.07</text>
+<text x='174.22' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.85</text>
+<text x='220.67' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.64</text>
+<text x='267.11' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.43</text>
+<text x='313.56' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='27.35px' lengthAdjust='spacingAndGlyphs'>-0.21</text>
+<text x='360.00' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='406.44' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.21</text>
+<text x='452.89' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.43</text>
+<text x='499.33' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.64</text>
+<text x='545.78' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.85</text>
+<text x='592.22' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.07</text>
+<text x='638.67' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>1.28</text>
+<text x='29.22' y='562.26' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text x='29.27' y='556.66' style='font-size: 12.00px; font-family: sans;' textLength='5.63px' lengthAdjust='spacingAndGlyphs'>^</text>
+<polyline points='36.54,563.99 39.71,552.27 ' style='stroke-width: 0.75;' />
+<text x='41.30' y='562.26' style='font-size: 12.00px; font-family: sans;' textLength='5.74px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text x='47.04' y='564.48' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotASN/plotasn-gsdesign.svg
+++ b/tests/testthat/_snaps/independent-test-plotASN/plotasn-gsdesign.svg
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41OQ=='>
+    <rect x='37.69' y='22.78' width='676.83' height='521.81' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8NzE0LjUyfDIyLjc4fDU0NC41OQ==)'>
+<rect x='37.69' y='22.78' width='676.83' height='521.81' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='68.45,46.50 83.84,46.84 99.22,47.31 114.60,47.95 129.98,48.82 145.37,49.97 160.75,51.49 176.13,53.47 191.51,55.99 206.90,59.19 222.28,63.17 237.66,68.07 253.04,74.04 268.43,81.19 283.81,89.65 299.19,99.53 314.57,110.93 329.96,123.90 345.34,138.46 360.72,154.60 376.10,172.25 391.49,191.30 406.87,211.60 422.25,232.94 437.63,255.08 453.02,277.76 468.40,300.68 483.78,323.54 499.16,346.04 514.55,367.90 529.93,388.86 545.31,408.70 560.70,427.23 576.08,444.30 591.46,459.83 606.84,473.78 622.23,486.13 637.61,496.94 652.99,506.26 668.37,514.20 683.76,520.87 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='37.69' y='22.78' width='676.83' height='521.81' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='32.76' y='516.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='32.76' y='409.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='32.76' y='302.35' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>350</text>
+<text x='32.76' y='195.44' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='32.76' y='88.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>450</text>
+<polyline points='34.95,513.15 37.69,513.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,406.24 37.69,406.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,299.32 37.69,299.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,192.41 37.69,192.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,85.49 37.69,85.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.45,547.33 68.45,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='273.55,547.33 273.55,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='478.65,547.33 478.65,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.76,547.33 683.76,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.45' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='273.55' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='478.65' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='683.76' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='373.61' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(13.05,283.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='107.03px' lengthAdjust='spacingAndGlyphs'>Expected sample size</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='331.70px' lengthAdjust='spacingAndGlyphs'>Expected sample size by underlying treatment difference</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotASN/plotasn-gsurv.svg
+++ b/tests/testthat/_snaps/independent-test-plotASN/plotasn-gsurv.svg
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='63.78,521.37 71.07,509.71 78.61,497.21 86.42,483.86 94.50,469.65 102.87,454.55 111.53,438.53 120.50,421.57 129.79,403.62 139.40,384.66 149.35,364.66 159.65,343.59 170.32,321.47 181.36,298.33 192.79,274.25 204.63,249.38 216.88,223.91 229.56,198.15 242.70,172.50 256.29,147.45 270.37,123.60 284.94,101.65 300.02,82.36 315.64,66.49 331.80,54.81 348.54,47.98 365.87,46.53 383.80,50.77 402.38,60.80 421.60,76.46 441.50,97.31 462.11,122.71 483.44,151.83 505.53,183.74 528.39,217.43 552.06,251.95 576.56,286.40 601.93,320.01 628.20,352.17 655.38,382.41 683.53,410.44 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='489.10' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='27.86' y='373.10' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='27.86' y='257.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='27.86' y='141.09' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>70</text>
+<polyline points='30.05,486.08 32.79,486.08 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,370.07 32.79,370.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,254.06 32.79,254.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,138.06 32.79,138.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.73,547.85 187.73,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='353.00,547.85 353.00,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='518.27,547.85 518.27,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.53,547.85 683.53,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='187.73' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='353.00' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='518.27' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='683.53' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.92px' lengthAdjust='spacingAndGlyphs'>Hazard ratio</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='133.94px' lengthAdjust='spacingAndGlyphs'>Expected number of events</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='316.30px' lengthAdjust='spacingAndGlyphs'>Expected number of events by underlying hazard ratio</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotBval/plotbval.svg
+++ b/tests/testthat/_snaps/independent-test-plotBval/plotbval.svg
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='30.83' y='22.78' width='626.00' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='59.28' y='119.38' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.45</text>
+<text x='201.56' y='75.26' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.89</text>
+<text x='343.83' y='55.30' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.08</text>
+<text x='486.10' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.12</text>
+<text x='628.38' y='61.36' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='59.28' y='415.14' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-1.45</text>
+<text x='201.56' y='459.25' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-1.89</text>
+<text x='343.83' y='479.22' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.08</text>
+<text x='486.10' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.12</text>
+<text x='628.38' y='473.16' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<polyline points='59.28,410.25 201.56,454.36 343.83,474.33 486.10,478.20 628.38,468.26 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='59.28,114.48 201.56,70.37 343.83,50.40 486.10,46.53 628.38,56.46 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='59.28' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=164</text>
+<text x='201.56' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=328</text>
+<text x='343.83' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=492</text>
+<text x='486.10' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=656</text>
+<text x='628.38' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=819</text>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='25.90' y='468.72' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='25.90' y='367.06' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='25.90' y='265.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='163.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='25.90' y='62.07' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,465.69 30.83,465.69 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,364.03 30.83,364.03 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,262.36 30.83,262.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,160.70 30.83,160.70 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,59.04 30.83,59.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='90.78,547.85 90.78,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='264.55,547.85 264.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='438.32,547.85 438.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.08,547.85 612.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='90.78' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='264.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='438.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>600</text>
+<text x='612.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>800</text>
+<text x='343.83' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.93px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>B-value</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='113.03px' lengthAdjust='spacingAndGlyphs'>B-values at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotHR/plothr.svg
+++ b/tests/testthat/_snaps/independent-test-plotHR/plothr.svg
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='35.24' y='22.78' width='621.59' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='35.24' y='22.78' width='621.59' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='63.49' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.35</text>
+<text x='346.03' y='376.03' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.53</text>
+<text x='628.58' y='297.09' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.67</text>
+<text x='63.49' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.09</text>
+<text x='346.03' y='224.24' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.79</text>
+<text x='628.58' y='297.09' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.67</text>
+<polyline points='63.49,46.53 346.03,219.34 628.58,292.20 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='63.49,478.20 346.03,371.13 628.58,292.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='63.49' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=33</text>
+<text x='346.03' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=65</text>
+<text x='628.58' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='34.42px' lengthAdjust='spacingAndGlyphs'>N=97</text>
+<rect x='35.24' y='22.78' width='621.59' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='449.63' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='333.31' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='216.99' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='100.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,446.60 35.24,446.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,330.28 35.24,330.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,213.96 35.24,213.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,97.64 35.24,97.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='132.69,547.85 132.69,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='308.57,547.85 308.57,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='484.44,547.85 484.44,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='132.69' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='308.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='484.44' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='346.03' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.93px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='122.91px' lengthAdjust='spacingAndGlyphs'>Approximate hazard ratio</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='209.15px' lengthAdjust='spacingAndGlyphs'>Approximate hazard ratio at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotRR/plotrr.svg
+++ b/tests/testthat/_snaps/independent-test-plotRR/plotrr.svg
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMjcuOTB8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='27.90' y='22.78' width='628.93' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcuOTB8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='27.90' y='22.78' width='628.93' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='56.49' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>4.74</text>
+<text x='342.37' y='298.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.54</text>
+<text x='628.24' y='378.74' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.82</text>
+<text x='56.49' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.88</text>
+<text x='342.37' y='424.13' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.41</text>
+<text x='628.24' y='378.74' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>1.82</text>
+<polyline points='56.49,478.20 342.37,419.24 628.24,373.84 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='56.49,46.53 342.37,293.20 628.24,373.84 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='56.49' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.357</text>
+<text x='342.37' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.713</text>
+<text x='628.24' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='40.74px' lengthAdjust='spacingAndGlyphs'>r=1.07</text>
+<rect x='27.90' y='22.78' width='628.93' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='22.97' y='468.23' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='22.97' y='356.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='22.97' y='244.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='22.97' y='132.08' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='25.16,465.20 27.90,465.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,353.15 27.90,353.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,241.11 27.90,241.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,129.06 27.90,129.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='171.42,547.85 171.42,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='331.74,547.85 331.74,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='492.06,547.85 492.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='652.39,547.85 652.39,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='171.42' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='331.74' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='492.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='652.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='342.37' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Information relative to fixed sample design</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='106.39px' lengthAdjust='spacingAndGlyphs'>Approximate risk ratio</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='189.32px' lengthAdjust='spacingAndGlyphs'>Approximate risk ratio at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotgsCP/plotgscp-test-type-1.svg
+++ b/tests/testthat/_snaps/independent-test-plotgsCP/plotgscp-test-type-1.svg
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuNTV8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='47.55' y='22.78' width='666.97' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuNTV8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='47.55' y='22.78' width='666.97' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='77.87,46.53 684.20,60.26 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<text x='77.87' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='684.20' y='65.15' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.97</text>
+<text x='77.87' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.337</text>
+<text x='684.20' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.675</text>
+<rect x='47.55' y='22.78' width='666.97' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='42.62' y='501.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='42.62' y='388.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='42.62' y='275.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='42.62' y='162.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='42.62' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='44.81,498.76 47.55,498.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,385.70 47.55,385.70 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,272.64 47.55,272.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,159.58 47.55,159.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,46.53 47.55,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='190.61,547.85 190.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='370.38,547.85 370.38,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='550.15,547.85 550.15,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='190.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='370.38' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='550.15' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='381.03' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='172.44px' lengthAdjust='spacingAndGlyphs'>Sample size relative to fixed design</text>
+<text transform='translate(18.18,347.15) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(18.18,246.86) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(18.18,241.60) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='12.54px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(18.18,229.06) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,229.01) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.16px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(18.18,223.80) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='3.06px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='47.55' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='286.19px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotgsCP/plotgscp-test-type-2.svg
+++ b/tests/testthat/_snaps/independent-test-plotgsCP/plotgscp-test-type-2.svg
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='47.55' y='22.78' width='609.28' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuNTV8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='75.24' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='629.14' y='65.15' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>0.97</text>
+<text x='75.24' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='629.14' y='503.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='7.91px' lengthAdjust='spacingAndGlyphs'>0</text>
+<polyline points='75.24,498.76 629.14,498.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='75.24,46.53 629.14,60.26 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='75.24' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.337</text>
+<text x='629.14' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='48.65px' lengthAdjust='spacingAndGlyphs'>r=0.675</text>
+<rect x='47.55' y='22.78' width='609.28' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='42.62' y='501.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='42.62' y='388.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='42.62' y='275.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='42.62' y='162.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='42.62' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='44.81,498.76 47.55,498.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,385.70 47.55,385.70 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,272.64 47.55,272.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,159.58 47.55,159.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.81,46.53 47.55,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='178.24,547.85 178.24,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='342.46,547.85 342.46,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='506.68,547.85 506.68,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='178.24' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='342.46' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='506.68' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='352.19' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='172.44px' lengthAdjust='spacingAndGlyphs'>Sample size relative to fixed design</text>
+<text transform='translate(18.18,347.15) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>Conditional power at</text>
+<text transform='translate(18.18,246.86) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(18.18,241.60) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='12.54px' lengthAdjust='spacingAndGlyphs'> = </text>
+<text transform='translate(18.18,229.06) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.26px' lengthAdjust='spacingAndGlyphs'>θ</text>
+<text transform='translate(13.05,229.01) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='5.16px' lengthAdjust='spacingAndGlyphs'>^</text>
+<text transform='translate(18.18,223.80) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='3.06px' lengthAdjust='spacingAndGlyphs'> </text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='47.55' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='286.19px' lengthAdjust='spacingAndGlyphs'>Conditional power at interim stopping boundaries</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotgsPower/gspower-test-type-1.svg
+++ b/tests/testthat/_snaps/independent-test-plotgsPower/gspower-test-type-1.svg
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjI5LjkxfDIyLjc4fDU0NC41OQ=='>
+    <rect x='35.24' y='22.78' width='594.68' height='521.81' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjI5LjkxfDIyLjc4fDU0NC41OQ==)'>
+<rect x='35.24' y='22.78' width='594.68' height='521.81' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='62.27,520.87 75.78,520.85 89.30,520.82 102.81,520.78 116.33,520.72 129.85,520.64 143.36,520.53 156.88,520.38 170.39,520.19 183.91,519.93 197.42,519.59 210.94,519.15 224.45,518.58 237.97,517.86 251.48,516.95 265.00,515.81 278.51,514.40 292.03,512.66 305.55,510.53 319.06,507.97 332.58,504.89 346.09,501.24 359.61,496.94 373.12,491.92 386.64,486.12 400.15,479.47 413.67,471.92 427.18,463.41 440.70,453.91 454.21,443.40 467.73,431.88 481.24,419.36 494.76,405.87 508.28,391.46 521.79,376.21 535.31,360.21 548.82,343.57 562.34,326.42 575.85,308.90 589.37,291.15 602.88,273.35 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='62.27,518.05 75.78,516.77 89.30,515.02 102.81,512.66 116.33,509.53 129.85,505.47 143.36,500.28 156.88,493.76 170.39,485.71 183.91,475.97 197.42,464.37 210.94,450.81 224.45,435.22 237.97,417.62 251.48,398.10 265.00,376.82 278.51,354.04 292.03,330.08 305.55,305.32 319.06,280.18 332.58,255.10 346.09,230.52 359.61,206.86 373.12,184.47 386.64,163.66 400.15,144.66 413.67,127.62 427.18,112.59 440.70,99.59 454.21,88.52 467.73,79.27 481.24,71.68 494.76,65.55 508.28,60.69 521.79,56.91 535.31,54.02 548.82,51.85 562.34,50.24 575.85,49.07 589.37,48.24 602.88,47.66 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='62.27,509.06 75.78,503.83 89.30,496.84 102.81,487.73 116.33,476.16 129.85,461.85 143.36,444.60 156.88,424.34 170.39,401.17 183.91,375.35 197.42,347.32 210.94,317.68 224.45,287.15 237.97,256.52 251.48,226.59 265.00,198.10 278.51,171.70 292.03,147.85 305.55,126.88 319.06,108.92 332.58,93.94 346.09,81.77 359.61,72.14 373.12,64.72 386.64,59.15 400.15,55.08 413.67,52.19 427.18,50.18 440.70,48.82 454.21,47.93 467.73,47.36 481.24,47.01 494.76,46.79 508.28,46.66 521.79,46.59 535.31,46.55 548.82,46.52 562.34,46.51 575.85,46.51 589.37,46.50 602.88,46.50 ' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='594.68' height='521.81' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='523.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='429.07' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='334.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='239.30' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='144.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='49.53' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,520.92 35.24,520.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,426.04 35.24,426.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,331.15 35.24,331.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,236.27 35.24,236.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.38 35.24,141.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,46.50 35.24,46.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='62.27,547.33 62.27,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='242.47,547.33 242.47,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='422.68,547.33 422.68,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='602.88,547.33 602.88,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='62.27' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='242.47' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='422.68' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='602.88' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='330.08' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(13.05,283.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<rect x='640.87' y='228.31' width='73.65' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='640.87' y='237.03' style='font-size: 11.00px; font-family: sans;' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>Probability</text>
+<rect x='640.87' y='243.65' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='642.60' y1='252.29' x2='656.42' y2='252.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='663.63' y='255.32' style='font-size: 8.80px; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<rect x='640.87' y='271.89' width='40.97' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='640.87' y='280.60' style='font-size: 11.00px; font-family: sans;' textLength='40.97px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
+<rect x='640.87' y='287.22' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='642.60' y1='295.86' x2='656.42' y2='295.86' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<rect x='640.87' y='304.50' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='642.60' y1='313.14' x2='656.42' y2='313.14' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<rect x='640.87' y='321.78' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='642.60' y1='330.42' x2='656.42' y2='330.42' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='663.63' y='298.89' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='663.63' y='316.17' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='663.63' y='333.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.18px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotgsPower/gspower-test-type-2.svg
+++ b/tests/testthat/_snaps/independent-test-plotgsPower/gspower-test-type-2.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41OQ=='>
+    <rect x='35.24' y='22.78' width='586.85' height='521.81' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjIyLjA5fDIyLjc4fDU0NC41OQ==)'>
+<rect x='35.24' y='22.78' width='586.85' height='521.81' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='61.91,46.55 75.25,46.54 88.59,46.52 101.93,46.52 115.26,46.51 128.60,46.51 141.94,46.51 155.28,46.50 168.61,46.50 181.95,46.50 195.29,46.50 208.63,46.50 221.96,46.50 235.30,46.50 248.64,46.50 261.98,46.50 275.31,46.50 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,49.37 75.25,48.46 88.59,47.81 101.93,47.36 115.26,47.06 128.60,46.86 141.94,46.73 155.28,46.64 168.61,46.59 181.95,46.55 195.29,46.53 208.63,46.52 221.96,46.51 235.30,46.51 248.64,46.50 261.98,46.50 275.31,46.50 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,58.36 75.25,54.55 88.59,51.84 101.93,49.96 115.26,48.70 128.60,47.86 141.94,47.33 155.28,46.99 168.61,46.79 181.95,46.66 195.29,46.59 208.63,46.55 221.96,46.53 235.30,46.52 248.64,46.51 261.98,46.51 275.31,46.50 288.65,46.50 301.99,46.50 315.33,46.50 328.66,46.50 342.00,46.50 355.34,46.50 368.68,46.50 382.01,46.50 395.35,46.50 408.69,46.50 422.03,46.50 435.36,46.50 448.70,46.50 462.04,46.50 475.38,46.50 488.71,46.50 502.05,46.50 515.39,46.50 528.73,46.50 542.06,46.50 555.40,46.50 568.74,46.50 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<polyline points='61.91,520.87 75.25,520.85 88.59,520.82 101.93,520.78 115.26,520.72 128.60,520.64 141.94,520.53 155.28,520.38 168.61,520.19 181.95,519.93 195.29,519.59 208.63,519.15 221.96,518.58 235.30,517.86 248.64,516.95 261.98,515.81 275.31,514.40 288.65,512.66 301.99,510.53 315.33,507.97 328.66,504.89 342.00,501.24 355.34,496.94 368.68,491.92 382.01,486.12 395.35,479.47 408.69,471.92 422.03,463.41 435.36,453.91 448.70,443.40 462.04,431.88 475.38,419.36 488.71,405.87 502.05,391.46 515.39,376.21 528.73,360.21 542.06,343.57 555.40,326.42 568.74,308.90 582.08,291.15 595.41,273.35 ' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<polyline points='61.91,518.05 75.25,516.77 88.59,515.02 101.93,512.66 115.26,509.53 128.60,505.47 141.94,500.28 155.28,493.76 168.61,485.71 181.95,475.97 195.29,464.37 208.63,450.81 221.96,435.22 235.30,417.62 248.64,398.10 261.98,376.82 275.31,354.04 288.65,330.08 301.99,305.32 315.33,280.18 328.66,255.10 342.00,230.52 355.34,206.86 368.68,184.47 382.01,163.66 395.35,144.66 408.69,127.62 422.03,112.60 435.36,99.59 448.70,88.52 462.04,79.27 475.38,71.68 488.71,65.55 502.05,60.70 515.39,56.91 528.73,54.02 542.06,51.85 555.40,50.24 568.74,49.08 582.08,48.25 595.41,47.66 ' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<polyline points='61.91,509.06 75.25,503.83 88.59,496.84 101.93,487.73 115.26,476.16 128.60,461.85 141.94,444.60 155.28,424.34 168.61,401.17 181.95,375.35 195.29,347.32 208.63,317.68 221.96,287.15 235.30,256.52 248.64,226.59 261.98,198.10 275.31,171.70 288.65,147.85 301.99,126.88 315.33,108.92 328.66,93.94 342.00,81.77 355.34,72.14 368.68,64.72 382.01,59.16 395.35,55.09 408.69,52.19 422.03,50.18 435.36,48.83 448.70,47.93 462.04,47.36 475.38,47.01 488.71,46.79 502.05,46.66 515.39,46.59 528.73,46.55 542.06,46.53 555.40,46.51 568.74,46.51 582.08,46.50 595.41,46.50 ' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='586.85' height='521.81' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='523.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='429.07' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='334.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='239.30' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='144.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='49.53' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,520.92 35.24,520.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,426.04 35.24,426.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,331.15 35.24,331.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,236.27 35.24,236.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,141.39 35.24,141.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,46.50 35.24,46.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='61.91,547.33 61.91,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.75,547.33 239.75,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='417.58,547.33 417.58,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='595.41,547.33 595.41,544.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='61.91' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='239.75' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='417.58' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='595.41' y='555.58' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='326.17' y='568.10' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<text transform='translate(13.05,283.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='206.07px' lengthAdjust='spacingAndGlyphs'>Cumulative Boundary Crossing Probability</text>
+<rect x='633.05' y='219.67' width='40.97' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='228.39' style='font-size: 11.00px; font-family: sans;' textLength='40.97px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
+<rect x='633.05' y='235.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='243.65' x2='648.60' y2='243.65' style='stroke-width: 2.13; stroke-dasharray: 2.85,8.54; stroke-linecap: butt;' />
+<rect x='633.05' y='252.29' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='260.93' x2='648.60' y2='260.93' style='stroke-width: 2.13; stroke-dasharray: 11.38,11.38; stroke-linecap: butt;' />
+<rect x='633.05' y='269.57' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='278.21' x2='648.60' y2='278.21' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='246.68' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='655.81' y='263.96' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='655.81' y='281.24' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<rect x='633.05' y='297.81' width='81.47' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='633.05' y='306.52' style='font-size: 11.00px; font-family: sans;' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>Probability</text>
+<rect x='633.05' y='313.14' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='321.78' x2='648.60' y2='321.78' style='stroke-width: 2.13; stroke: #DF536B; stroke-linecap: butt;' />
+<rect x='633.05' y='330.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='634.78' y1='339.06' x2='648.60' y2='339.06' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='655.81' y='324.81' style='font-size: 8.80px; font-family: sans;' textLength='58.71px' lengthAdjust='spacingAndGlyphs'>1-Lower bound</text>
+<text x='655.81' y='342.09' style='font-size: 8.80px; font-family: sans;' textLength='50.89px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.18px' lengthAdjust='spacingAndGlyphs'>Boundary crossing probabilities by effect size</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotgsZ/plotgsz.svg
+++ b/tests/testthat/_snaps/independent-test-plotgsZ/plotgsz.svg
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='30.83' y='22.78' width='626.00' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzAuODN8NjU2LjgzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='59.28' y='51.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>3.25</text>
+<text x='201.56' y='69.11' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.99</text>
+<text x='343.83' y='88.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.69</text>
+<text x='486.10' y='109.75' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.37</text>
+<text x='628.38' y='132.86' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='27.69px' lengthAdjust='spacingAndGlyphs'>2.03</text>
+<text x='59.28' y='483.10' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-3.25</text>
+<text x='201.56' y='465.41' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.99</text>
+<text x='343.83' y='445.87' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.69</text>
+<text x='486.10' y='424.77' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.37</text>
+<text x='628.38' y='401.65' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='32.43px' lengthAdjust='spacingAndGlyphs'>-2.03</text>
+<polyline points='59.28,478.20 201.56,460.51 343.83,440.98 486.10,419.87 628.38,396.76 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polyline points='59.28,46.53 201.56,64.22 343.83,83.75 486.10,104.85 628.38,127.97 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='59.28' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=164</text>
+<text x='201.56' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=328</text>
+<text x='343.83' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=492</text>
+<text x='486.10' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=656</text>
+<text x='628.38' y='526.27' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='42.33px' lengthAdjust='spacingAndGlyphs'>N=819</text>
+<rect x='30.83' y='22.78' width='626.00' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='25.90' y='530.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='25.90' y='398.11' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='25.90' y='265.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='132.68' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,527.79 30.83,527.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,395.08 30.83,395.08 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,262.36 30.83,262.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,129.65 30.83,129.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='90.78,547.85 90.78,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='264.55,547.85 264.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='438.32,547.85 438.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='612.08,547.85 612.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='90.78' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='264.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='438.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>600</text>
+<text x='612.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>800</text>
+<text x='343.83' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='59.93px' lengthAdjust='spacingAndGlyphs'>Sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='99.04px' lengthAdjust='spacingAndGlyphs'>Normal critical value</text>
+<rect x='667.79' y='259.00' width='46.73' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='667.79' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='31.81px' lengthAdjust='spacingAndGlyphs'>Bound</text>
+<rect x='667.79' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='282.97' x2='683.34' y2='282.97' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='667.79' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.52' y1='300.25' x2='683.34' y2='300.25' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='690.55' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Lower</text>
+<text x='690.55' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.97px' lengthAdjust='spacingAndGlyphs'>Upper</text>
+<text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.44px' lengthAdjust='spacingAndGlyphs'>Normal test statistics at bounds</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotsf/plotgscp-test-type-4.svg
+++ b/tests/testthat/_snaps/independent-test-plotsf/plotgscp-test-type-4.svg
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDAuMTN8NjU3LjA3fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='40.13' y='22.78' width='616.94' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDAuMTN8NjU3LjA3fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='40.13' y='22.78' width='616.94' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='68.18,521.37 82.20,521.37 96.22,521.37 110.24,521.37 124.26,521.37 138.28,521.37 152.30,521.37 166.32,521.37 180.35,521.36 194.37,521.33 208.39,521.23 222.41,521.01 236.43,520.56 250.45,519.77 264.47,518.49 278.50,516.58 292.52,513.88 306.54,510.25 320.56,505.53 334.58,499.62 348.60,492.40 362.62,483.79 376.64,473.72 390.67,462.15 404.69,449.04 418.71,434.38 432.73,418.16 446.75,400.40 460.77,381.11 474.79,360.33 488.82,338.09 502.84,314.44 516.86,289.42 530.88,263.09 544.90,235.49 558.92,206.68 572.94,176.73 586.96,145.68 600.99,113.59 615.01,80.52 629.03,46.53 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='68.18,521.37 82.20,517.56 96.22,513.55 110.24,509.34 124.26,504.92 138.28,500.26 152.30,495.37 166.32,490.22 180.35,484.82 194.37,479.13 208.39,473.16 222.41,466.87 236.43,460.27 250.45,453.33 264.47,446.03 278.50,438.35 292.52,430.29 306.54,421.81 320.56,412.89 334.58,403.52 348.60,393.66 362.62,383.31 376.64,372.42 390.67,360.97 404.69,348.94 418.71,336.28 432.73,322.98 446.75,309.00 460.77,294.30 474.79,278.85 488.82,262.61 502.84,245.53 516.86,227.57 530.88,208.70 544.90,188.86 558.92,168.00 572.94,146.07 586.96,123.02 600.99,98.79 615.01,73.31 629.03,46.53 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<rect x='40.13' y='22.78' width='616.94' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='35.20' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='35.20' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='35.20' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='35.20' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='35.20' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='37.39,521.37 40.13,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,402.66 40.13,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,283.95 40.13,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,165.24 40.13,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,46.53 40.13,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.18,547.85 68.18,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='208.39,547.85 208.39,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='348.60,547.85 348.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='488.82,547.85 488.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='629.03,547.85 629.03,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.18' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='208.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='348.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='488.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='629.03' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='348.60' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='147.98px' lengthAdjust='spacingAndGlyphs'>Proportion of total sample size</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='110.70px' lengthAdjust='spacingAndGlyphs'>Proportion of spending</text>
+<rect x='668.03' y='259.00' width='46.49' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='668.03' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='46.49px' lengthAdjust='spacingAndGlyphs'>Spending</text>
+<rect x='668.03' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.76' y1='282.97' x2='683.58' y2='282.97' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='668.03' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='669.76' y1='300.25' x2='683.58' y2='300.25' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<text x='690.79' y='284.95' style='font-size: 8.80px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text x='690.79' y='302.51' style='font-size: 8.80px; font-family: sans;' textLength='4.08px' lengthAdjust='spacingAndGlyphs'>β</text>
+<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='130.64px' lengthAdjust='spacingAndGlyphs'>Spending function plot</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotsf/plotsf-test-type-1.svg
+++ b/tests/testthat/_snaps/independent-test-plotsf/plotsf-test-type-1.svg
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuNzF8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='47.71' y='22.78' width='666.81' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuNzF8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='47.71' y='22.78' width='666.81' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='78.02,521.37 93.18,521.37 108.33,521.37 123.49,521.37 138.64,521.37 153.80,521.37 168.95,521.37 184.11,521.37 199.26,521.36 214.42,521.33 229.57,521.23 244.72,521.01 259.88,520.56 275.03,519.77 290.19,518.49 305.34,516.58 320.50,513.88 335.65,510.25 350.81,505.53 365.96,499.62 381.12,492.40 396.27,483.79 411.43,473.72 426.58,462.15 441.74,449.04 456.89,434.38 472.05,418.16 487.20,400.40 502.35,381.11 517.51,360.33 532.66,338.09 547.82,314.44 562.97,289.42 578.13,263.09 593.28,235.49 608.44,206.68 623.59,176.73 638.75,145.68 653.90,113.59 669.06,80.52 684.21,46.53 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='47.71' y='22.78' width='666.81' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='42.78' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.000</text>
+<text x='42.78' y='429.43' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.005</text>
+<text x='42.78' y='334.46' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.010</text>
+<text x='42.78' y='239.49' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.015</text>
+<text x='42.78' y='144.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.020</text>
+<text x='42.78' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.025</text>
+<polyline points='44.97,521.37 47.71,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.97,426.40 47.71,426.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.97,331.43 47.71,331.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.97,236.46 47.71,236.46 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.97,141.49 47.71,141.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='44.97,46.53 47.71,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='78.02,547.85 78.02,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='229.57,547.85 229.57,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='381.12,547.85 381.12,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='532.66,547.85 532.66,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='684.21,547.85 684.21,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='78.02' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='229.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='381.12' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='532.66' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='684.21' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='381.12' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='147.98px' lengthAdjust='spacingAndGlyphs'>Proportion of total sample size</text>
+<text transform='translate(13.45,311.41) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='6.60px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text transform='translate(13.45,304.81) rotate(-90)' style='font-size: 11.00px; font-family: sans;' textLength='48.32px' lengthAdjust='spacingAndGlyphs'>-spending</text>
+<text x='47.71' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='130.64px' lengthAdjust='spacingAndGlyphs'>Spending function plot</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/independent-test-plotsf/plotsf-test-type-5.svg
+++ b/tests/testthat/_snaps/independent-test-plotsf/plotsf-test-type-5.svg
@@ -1,0 +1,118 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODIuODB8NjU1LjIwfDY0LjgwfDQ4Ni4wMA=='>
+    <rect x='82.80' y='64.80' width='572.40' height='421.20' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODIuODB8NjU1LjIwfDY0LjgwfDQ4Ni4wMA==)'>
+<polyline points='104.00,470.40 117.25,470.40 130.50,470.40 143.75,470.40 157.00,470.40 170.25,470.40 183.50,470.40 196.75,470.40 210.00,470.39 223.25,470.36 236.50,470.29 249.75,470.10 263.00,469.73 276.25,469.08 289.50,468.04 302.75,466.47 316.00,464.25 329.25,461.26 342.50,457.39 355.75,452.53 369.00,446.60 382.25,439.53 395.50,431.27 408.75,421.76 422.00,410.99 435.25,398.95 448.50,385.63 461.75,371.04 475.00,355.20 488.25,338.13 501.50,319.87 514.75,300.44 528.00,279.90 541.25,258.27 554.50,235.60 567.75,211.94 581.00,187.34 594.25,161.84 607.50,135.48 620.75,108.32 634.00,80.40 ' style='stroke-width: 0.38;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='104.00' y1='486.00' x2='634.00' y2='486.00' style='stroke-width: 0.75;' />
+<line x1='104.00' y1='486.00' x2='104.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='210.00' y1='486.00' x2='210.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='316.00' y1='486.00' x2='316.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='422.00' y1='486.00' x2='422.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='528.00' y1='486.00' x2='528.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='634.00' y1='486.00' x2='634.00' y2='493.20' style='stroke-width: 0.75;' />
+<text x='104.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='210.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='316.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='422.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='528.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='634.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<line x1='82.80' y1='470.40' x2='82.80' y2='80.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='470.40' x2='75.60' y2='470.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='392.40' x2='75.60' y2='392.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='314.40' x2='75.60' y2='314.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='236.40' x2='75.60' y2='236.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='158.40' x2='75.60' y2='158.40' style='stroke-width: 0.75;' />
+<line x1='82.80' y1='80.40' x2='75.60' y2='80.40' style='stroke-width: 0.75;' />
+<text transform='translate(65.52,470.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.000</text>
+<text transform='translate(65.52,392.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.005</text>
+<text transform='translate(65.52,314.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.010</text>
+<text transform='translate(65.52,236.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.015</text>
+<text transform='translate(65.52,158.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.020</text>
+<text transform='translate(65.52,80.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='30.03px' lengthAdjust='spacingAndGlyphs'>0.025</text>
+<polygon points='82.80,486.00 655.20,486.00 655.20,64.80 82.80,64.80 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<defs>
+  <clipPath id='cpMjguODB8NjkxLjIwfDI4LjgwfDU0Ny4yMA=='>
+    <rect x='28.80' y='28.80' width='662.40' height='518.40' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjguODB8NjkxLjIwfDI4LjgwfDU0Ny4yMA==)'>
+<text x='369.00' y='51.76' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='142.52px' lengthAdjust='spacingAndGlyphs'>Spending function plot</text>
+<text x='369.00' y='540.72' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='161.43px' lengthAdjust='spacingAndGlyphs'>Proportion of total sample size</text>
+<text transform='translate(34.23,305.36) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text transform='translate(34.23,298.16) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>-spending</text>
+</g>
+<g clip-path='url(#cpODIuODB8NjU1LjIwfDY0LjgwfDQ4Ni4wMA==)'>
+<rect x='104.00' y='80.40' width='227.90' height='58.50' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<line x1='114.80' y1='94.80' x2='136.40' y2='94.80' style='stroke-width: 0.38;' />
+<line x1='114.80' y1='109.20' x2='136.40' y2='109.20' style='stroke-width: 0.38; stroke-dasharray: 4.00,4.00;' />
+<text x='147.20' y='98.93' style='font-size: 12.00px; font-family: sans;' textLength='69.39px' lengthAdjust='spacingAndGlyphs'>Upper bound</text>
+<text x='147.20' y='113.33' style='font-size: 12.00px; font-family: sans;' textLength='69.39px' lengthAdjust='spacingAndGlyphs'>Lower bound</text>
+<polyline points='104.00,470.40 117.25,467.27 130.50,463.98 143.75,460.52 157.00,456.89 170.25,453.06 183.50,449.04 196.75,444.82 210.00,440.38 223.25,435.71 236.50,430.80 249.75,425.64 263.00,420.22 276.25,414.51 289.50,408.52 302.75,402.22 316.00,395.59 329.25,388.63 342.50,381.30 355.75,373.61 369.00,365.51 382.25,357.01 395.50,348.06 408.75,338.66 422.00,328.78 435.25,318.38 448.50,307.46 461.75,295.98 475.00,283.90 488.25,271.21 501.50,257.87 514.75,243.84 528.00,229.10 541.25,213.60 554.50,197.30 567.75,180.17 581.00,162.16 594.25,143.23 607.50,123.32 620.75,102.40 634.00,80.40 ' style='stroke-width: 0.38; stroke-dasharray: 4.00,4.00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='104.00' y1='486.00' x2='634.00' y2='486.00' style='stroke-width: 0.75;' />
+<line x1='104.00' y1='486.00' x2='104.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='210.00' y1='486.00' x2='210.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='316.00' y1='486.00' x2='316.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='422.00' y1='486.00' x2='422.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='528.00' y1='486.00' x2='528.00' y2='493.20' style='stroke-width: 0.75;' />
+<line x1='634.00' y1='486.00' x2='634.00' y2='493.20' style='stroke-width: 0.75;' />
+<text x='104.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='210.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='316.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='422.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='528.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='634.00' y='511.92' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polygon points='82.80,486.00 655.20,486.00 655.20,64.80 82.80,64.80 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<g clip-path='url(#cpMjguODB8NjkxLjIwfDI4LjgwfDU0Ny4yMA==)'>
+<text x='369.00' y='51.76' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='142.52px' lengthAdjust='spacingAndGlyphs'>Spending function plot</text>
+<text x='369.00' y='540.72' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='161.43px' lengthAdjust='spacingAndGlyphs'>Proportion of total sample size</text>
+<text transform='translate(34.23,305.36) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text transform='translate(34.23,298.16) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>-spending</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='655.20' y1='470.40' x2='655.20' y2='80.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='470.40' x2='662.40' y2='470.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='392.40' x2='662.40' y2='392.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='314.40' x2='662.40' y2='314.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='236.40' x2='662.40' y2='236.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='158.40' x2='662.40' y2='158.40' style='stroke-width: 0.75;' />
+<line x1='655.20' y1='80.40' x2='662.40' y2='80.40' style='stroke-width: 0.75;' />
+<text transform='translate(681.12,470.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text transform='translate(681.12,392.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.02</text>
+<text transform='translate(681.12,314.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.04</text>
+<text transform='translate(681.12,236.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.06</text>
+<text transform='translate(681.12,158.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.08</text>
+<text transform='translate(681.12,80.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text transform='translate(702.72,288.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='120.76px' lengthAdjust='spacingAndGlyphs'>Proportion of spending</text>
+</g>
+<g clip-path='url(#cpODIuODB8NjU1LjIwfDY0LjgwfDQ4Ni4wMA==)'>
+</g>
+</svg>

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -994,40 +994,6 @@ Validate_comp_sprt_bnd <- function(alpha, beta, p0, p1, nmin, nmax) {
 }
 
 #-------------------------------------------------------------------------------
-#save_gg_plot() : Function to save plots created with ggplot2 package and saved
-#                 with ggsave() function.
-#
-# plot	: Plot to save, defaults to last plot displayed.
-# path	:  Path of the directory to save plot to: path and filename are 
-#        combined to create the fully qualified file name.
-# width : the width of the device (in inches).
-# height: the height of the device (in inches).
-# dpi	  : Plot resolution.
-
-# Plot size in units ("in", "cm", or "mm")
-#-------------------------------------------------------------------------------
-save_gg_plot <- function(code, width = 4, height = 4) {
-  path <- tempfile(fileext = ".png")
-  ggplot2::ggsave(path, plot = code, width = width, height = height, dpi = 72, units = "in")
-  path
-}
-
-#-------------------------------------------------------------------------------
-# save_gr_plot(): Function to save plots created with graphics package and saved
-#                 with png() function.
-# width: the width of the device (in pixels).
-# height: the height of the device (in pixels).
-#-------------------------------------------------------------------------------
-save_gr_plot <- function(code, width = 400, height = 400) {
-  path <- tempfile(fileext = ".png")
-  png(path, width = width, height = height)
-  oldpar <- par(no.readonly = TRUE)
-  on.exit(par(oldpar))
-  code
-  invisible(dev.off())
-  path
-}
-#-------------------------------------------------------------------------------
 #ssrCP : ssrCP() adapts 2-stage group sequential designs to 2-stage sample size
 # re-estimation designs based on interim analysis conditional power.
 

--- a/tests/testthat/test-independent-test-hGraph.R
+++ b/tests/testthat/test-independent-test-hGraph.R
@@ -1,43 +1,24 @@
-#-------------------------------------------------------------------------------
-# hGraph : hGraph() plots a multiplicity graph defined by user inputs. The graph
-#          can also be used with the **gMCPLite** package to evaluate a set of 
-#          nominal p-values for the tests of the hypotheses in the graph
-#-------------------------------------------------------------------------------
-
-testthat::test_that("test : checking basic graph layout", {
-  x <- hGraph() 
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_1.png")
+testthat::test_that("hGraph: Basic graph layout", {
+  x <- hGraph()
+  vdiffr::expect_doppelganger("basic layout", x)
 })
 
-
-testthat::test_that("test : checking note clockwise ordering", {
+testthat::test_that("hGraph: Note clockwise ordering", {
   x <- hGraph(5)
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_2.png")
+  vdiffr::expect_doppelganger("clockwise order", x)
 })
 
-
-testthat::test_that("test : Add colors (default is 3 gray shades)", {
+testthat::test_that("hGraph: Add colors (default is 3 gray shades)", {
   x <- hGraph(3, fill = 1:3)
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_3.png")
+  vdiffr::expect_doppelganger("gray shades", x)
 })
 
-
-testthat::test_that("test : Use a hue palette ", {
+testthat::test_that("hGraph: Use a hue palette", {
   x <- hGraph(4, fill = factor(1:4), palette = scales::hue_pal(l = 75)(4))
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_4.png")
+  vdiffr::expect_doppelganger("hue palette", x)
 })
 
-
-# different alpha allocation, hypothesis names and transitions
-testthat::test_that("test: different alpha allocation, hypothesis names and transitions", {
+testthat::test_that("hGraph: Different alpha allocation, hypotheses names, and transitions", {
   alphaHypotheses <- c(.005, .007, .013)
   nameHypotheses <- c("ORR", "PFS", "OS")
   m <- matrix(c(
@@ -46,37 +27,35 @@ testthat::test_that("test: different alpha allocation, hypothesis names and tran
     1, 0, 0
   ), nrow = 3, byrow = TRUE)
   x <- hGraph(3, alphaHypotheses = alphaHypotheses, nameHypotheses = nameHypotheses, m = m)
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_5.png")
-})
 
+  vdiffr::expect_doppelganger("alpha allocation hypotheses names transitions", x)
+})
 
 # Custom position and size of ellipses, change text to multi-line text
 # Adjust box width
 # add legend in middle of plot
-testthat::test_that("test: Custom position and size of ellipses, change text to multi-line text", {
+testthat::test_that("hGraph: Custom position and size of ellipses, change text to multi-line text", {
   cbPalette <- c(
     "#999999", "#E69F00", "#56B4E9", "#009E73",
-    "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
+    "#F0E442", "#0072B2", "#D55E00", "#CC79A7"
+  )
   x <- hGraph(3,
     x = sqrt(0:2), y = c(1, 3, 1.5), size = 6, halfWid = .3,
     halfHgt = .3, trhw = 0.6,
     palette = cbPalette[2:4], fill = c(1, 2, 2),
     legend.position = c(.95, .45), legend.name = "Legend:",
     labels = c("Group 1", "Group 2"),
-    nameHypotheses = c("H1:\n Long name", "H2:\n Longer name", "H3:\n Longest name"))
-  
-  save_plot_obj <- save_gg_plot(x)
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_hGraph_6.png")
+    nameHypotheses = c("H1:\n Long name", "H2:\n Longer name", "H3:\n Longest name")
+  )
+
+  vdiffr::expect_doppelganger("custom ellipses multiline", x)
 })
 
+testthat::test_that("hGraph: Number of digits to show for alphaHypotheses", {
+  x <- hGraph(
+    nHypotheses = 3, size = 5, halfWid = 1.25, trhw = 0.25,
+    radianStart = pi / 2, offset = pi / 20, arrowsize = .03, digits = 3
+  )
 
-testthat::test_that("test: number of digits to show for alphaHypotheses", {
-    x <- hGraph(nHypotheses = 3, size = 5, halfWid = 1.25, trhw = 0.25,
-               radianStart = pi/2, offset = pi/20, arrowsize = .03, digits = 3)
-    save_plot_obj <- save_gg_plot(x)
-    local_edition(3)
-    expect_snapshot_file(save_plot_obj, "plot_hGraph_7.png")
+  vdiffr::expect_doppelganger("alpha digits", x)
 })

--- a/tests/testthat/test-independent-test-plot.binomialSPRT.R
+++ b/tests/testthat/test-independent-test-plot.binomialSPRT.R
@@ -1,9 +1,4 @@
-# --------------------------------------------
-# Test plot.binomialSPRT function
-#----------------------------------------------
-
-testthat::test_that(desc = "Test: plot.binomialSPRT graphs are correctly rendered ", 
-                    code = {
+testthat::test_that("plot.binomialSPRT: plots are correctly rendered", {
   plotBSPRT <- binomialSPRT(
     p0 = 0.05,
     p1 = 0.25,
@@ -13,17 +8,13 @@ testthat::test_that(desc = "Test: plot.binomialSPRT graphs are correctly rendere
     maxn = 35
   )
 
-  save_plot_obj <- save_gg_plot(plot.binomialSPRT(plotBSPRT))
-  
-  local_edition(3)
-
-  testthat::expect_snapshot_file(save_plot_obj, "plotbinomialSPRT.png")
+  vdiffr::expect_doppelganger(
+    "binomial SPRT",
+    plot.binomialSPRT(plotBSPRT)
+  )
 })
 
-
-testthat::test_that(desc = "Test: plot.binomialSPRT graphs are correctly rendered, 
-                      plottype = 1 ", 
-                    code = {
+testthat::test_that("plot.binomialSPRT: plots are correctly rendered, plottype = 1", {
   plotBSPRT <- binomialSPRT(
     p0 = 0.05,
     p1 = 0.25,
@@ -33,9 +24,8 @@ testthat::test_that(desc = "Test: plot.binomialSPRT graphs are correctly rendere
     maxn = 35
   )
 
-  save_plot_obj <- save_gg_plot(plot.binomialSPRT(plotBSPRT, plottype = 1))
-  
-  local_edition(3)
-
-  testthat::expect_snapshot_file(save_plot_obj, "plotbinomialSPRT_plottype_1.png")
+  vdiffr::expect_doppelganger(
+    "binomial SPRT plottype 1",
+    plot.binomialSPRT(plotBSPRT, plottype = 1)
+  )
 })

--- a/tests/testthat/test-independent-test-plot.gsBinomialExact.R
+++ b/tests/testthat/test-independent-test-plot.gsBinomialExact.R
@@ -1,11 +1,5 @@
-# --------------------------------------------
-# Test plot.gsBinomialExact function
-#----------------------------------------------
-
-testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are 
-                            correctly rendered, plottype=1", 
-                    code = {
-  plotBE_plottype_1 <- gsBinomialExact(
+testthat::test_that("plot.gsBinomialExact: plots are correctly rendered, plottype = 1", {
+  x <- gsBinomialExact(
     k = 3,
     theta = c(0.1, 0.2),
     n.I = c(36, 71, 107),
@@ -13,17 +7,14 @@ testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are
     b = c(13, 15, 18)
   )
 
-  save_plot_obj <- save_gg_plot(plot.gsBinomialExact(plotBE_plottype_1, plottype = 1))
-  local_edition(3)
-
-  testthat::expect_snapshot_file(save_plot_obj, "plotBinomialExact_1.png")
+  vdiffr::expect_doppelganger(
+    "binomial exact plottype 1",
+    plot.gsBinomialExact(x, plottype = 1)
+  )
 })
 
-
-testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are 
-                            correctly rendered, plottype = 2 ", 
-                    code = {
-  plotBE_plottype_2 <- gsBinomialExact(
+testthat::test_that("plot.gsBinomialExact: plots are correctly rendered, plottype = 2", {
+  x <- gsBinomialExact(
     k = 3,
     theta = c(0.1, 0.2),
     n.I = c(36, 71, 107),
@@ -31,17 +22,14 @@ testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are
     b = c(13, 15, 18)
   )
 
-  save_plot_obj <- save_gg_plot(plot.gsBinomialExact(plotBE_plottype_2, plottype = 2))
-  local_edition(3)
-  
-  testthat::expect_snapshot_file(save_plot_obj, "plotBinomialExact_2.png")
+  vdiffr::expect_doppelganger(
+    "binomial exact plottype 2",
+    plot.gsBinomialExact(x, plottype = 2)
+  )
 })
 
-
-testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are 
-                            correctly rendered, plottype = 6", 
-                    code = {
-  plotBE_plottype_2 <- gsBinomialExact(
+testthat::test_that("plot.gsBinomialExact: plots are correctly rendered, plottype = 6", {
+  x <- gsBinomialExact(
     k = 3,
     theta = c(0.1, 0.2),
     n.I = c(36, 71, 107),
@@ -49,17 +37,14 @@ testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are
     b = c(13, 15, 18)
   )
 
-  save_plot_obj <- save_gg_plot(plot.gsBinomialExact(plotBE_plottype_2, plottype = 6))
-  local_edition(3)
-  
-  testthat::expect_snapshot_file(save_plot_obj, "plotBinomialExact_6.png")
+  vdiffr::expect_doppelganger(
+    "binomial exact plottype 6",
+    plot.gsBinomialExact(x, plottype = 6)
+  )
 })
 
-
-testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are 
-                    correctly rendered, plottype = 3", 
-                    code = {
-  plotBE_plottype_2 <- gsBinomialExact(
+testthat::test_that("plot.gsBinomialExact: plots are correctly rendered, plottype = 3", {
+  x <- gsBinomialExact(
     k = 3,
     theta = c(0.1, 0.2),
     n.I = c(36, 71, 107),
@@ -67,18 +52,14 @@ testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are
     b = c(13, 15, 18)
   )
 
-  save_plot_obj <- save_gg_plot(plot.gsBinomialExact(plotBE_plottype_2, plottype = 3))
-  local_edition(3)
-  
-  testthat::expect_snapshot_file(save_plot_obj, "plotBinomialExact_3.png")
+  vdiffr::expect_doppelganger(
+    "binomial exact plottype 3",
+    plot.gsBinomialExact(x, plottype = 3)
+  )
 })
 
-
-
-testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are 
-                            correctly rendered, for plottype set to default", 
-                    code = {
-  plot_BE <- gsBinomialExact(
+testthat::test_that("plot.gsBinomialExact: plots are correctly rendered, for plottype set to default", {
+  x <- gsBinomialExact(
     k = 3,
     theta = c(0.1, 0.2),
     n.I = c(36, 71, 107),
@@ -86,8 +67,8 @@ testthat::test_that(desc = "test: checking plot.gsBinomialExact graphs are
     b = c(13, 15, 18)
   )
 
-  save_plot_obj <- save_gg_plot(plot.gsBinomialExact(plot_BE))
-  local_edition(3)
-  
-  testthat::expect_snapshot_file(save_plot_obj, "plotBinomialExact.png")
+  vdiffr::expect_doppelganger(
+    "binomial exact plottype default",
+    plot.gsBinomialExact(x)
+  )
 })

--- a/tests/testthat/test-independent-test-plot.gsDesign.R
+++ b/tests/testthat/test-independent-test-plot.gsDesign.R
@@ -1,120 +1,133 @@
-# --------------------------------------------
-# Test plot.gsDesign function
-## save_gg_plot() is used for storing plots created using ggplot2 package,
-## whereas save_gr_plot() is used with plots created using graphics package.
-#----------------------------------------------
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 1 and base R plotting package set to TRUE", code = {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 1 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 1, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plotgsds1.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 1 base TRUE",
+    plot.gsDesign(x, plottype = 1, base = TRUE)
+  )
 })
 
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 1 and base R plotting package set to FALSE.", code = {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 1 and base set to FALSE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gg_plot(plot.gsDesign(x, plottype = 1, base = FALSE))
-  expect_snapshot_file(save_plot_obj, "plotgsds2.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 1 base FALSE",
+    plot.gsDesign(x, plottype = 1, base = FALSE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype = power and base R plotting package set to FALSE.", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype = power and base set to FALSE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gg_plot(plot.gsDesign(x, plottype = "power", base = FALSE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_3.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype power base FALSE",
+    plot.gsDesign(x, plottype = "power", base = FALSE)
+  )
 })
 
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 2 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 2 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 2, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_4.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 2 base TRUE",
+    plot.gsDesign(x, plottype = 2, base = TRUE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 3 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 3 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 3, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_5.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 3 base TRUE",
+    plot.gsDesign(x, plottype = 3, base = TRUE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 4 and base R plotting package set to FALSE", {
+test_that("plot.gsDesign: graphs are correctly rendered for plottype 4 and base set to FALSE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gg_plot(plot.gsDesign(x, plottype = 4, base = FALSE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_6.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 4 base FALSE",
+    plot.gsDesign(x, plottype = 4, base = FALSE)
+  )
 })
 
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 4 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 4 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 4, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_7.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 4 base TRUE",
+    plot.gsDesign(x, plottype = 4, base = TRUE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 5 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 5 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 5, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_8.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 5 base TRUE",
+    plot.gsDesign(x, plottype = 5, base = TRUE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 6 and base R plotting package set to FALSE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 6 and base set to FALSE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gg_plot(plot.gsDesign(x, plottype = 6, base = FALSE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_9.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 6 base FALSE",
+    plot.gsDesign(x, plottype = 6, base = FALSE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 6 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 6 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 6, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_11.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 6 base TRUE",
+    plot.gsDesign(x, plottype = 6, base = TRUE)
+  )
 })
 
-test_that("Test plot.gsDesign graphs are correctly rendered for plottype 7 and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for plottype 7 and base set to TRUE", {
   x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(x, plottype = 7, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_12.png")
+
+  vdiffr::expect_doppelganger(
+    "plottype 7 base TRUE",
+    plot.gsDesign(x, plottype = 7, base = TRUE)
+  )
 })
 
-
-test_that("Test plot.gsDesign graphs are correctly rendered for gsSurvR and base R plotting package set to TRUE", {
+test_that("plot.gsDesign: plots are correctly rendered for gsSurv objects and base set to TRUE", {
   z <- gsSurv(
     k = 3, sfl = sfPower, sflpar = .5,
     lambdaC = log(2) / 6, hr = .5, eta = log(2) / 40,
     gamma = 1, T = 36, minfup = 12
   )
 
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(z, plottype = 2, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdsa_3.png")
+  vdiffr::expect_doppelganger(
+    "gsSurv base TRUE",
+    plot.gsDesign(z, plottype = 2, base = TRUE)
+  )
 })
 
-
-test_that("Test plotgsDesign graphs are correctly rendered for gSurv and base R plotting package set to False", {
+test_that("plot.gsDesign: plots are correctly rendered for gSurv objects and base set to FALSE", {
   z <- gsSurv(
     k = 3, sfl = sfPower, sflpar = .5,
     lambdaC = log(2) / 6, hr = .5, eta = log(2) / 40,
     gamma = 1, T = 36, minfup = 12
   )
-  save_plot_obj <- save_gg_plot(plot.gsDesign(z, plottype = 2, base = FALSE))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdsa_4.png")
+
+  vdiffr::expect_doppelganger(
+    "gsSurv base FALSE",
+    plot.gsDesign(z, plottype = 2, base = FALSE)
+  )
 })
 
-test_that("Test plot.gsDesign graphs are correctly rendered for testtype 1 and plottype 2", {
+test_that("plot.gsDesign: plots are correctly rendered for test.type 1 and plottype 2", {
   y <- gsDesign(k = 5, test.type = 1, n.fix = 1)
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsDesign(y, plottype = 2, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdsa_8.png")
+
+  vdiffr::expect_doppelganger(
+    "test type 1 plottype 2",
+    plot.gsDesign(y, plottype = 2, base = TRUE)
+  )
 })

--- a/tests/testthat/test-independent-test-plot.gsProbability.R
+++ b/tests/testthat/test-independent-test-plot.gsProbability.R
@@ -1,72 +1,65 @@
-# --------------------------------------------
-# Test plot.gsProbability function
-## save_gg_plot() is used for storing plots created using ggplot2 package,
-## whereas save_gr_plot() is used with plots created using graphics package.
-#----------------------------------------------
-
 x <- gsDesign(k = 5, test.type = 2, n.fix = 100)
+y <- gsProbability(k = 5, theta = seq(0, .5, .025), x$n.I, x$lower$bound, x$upper$bound)
 
-y <- gsProbability(k = 5, theta = seq(0, .5, .025), x$n.I, 
-                   x$lower$bound, x$upper$bound)
-
-
-test_that("Test plotgsProbability graphs are correctly rendered for plottype 1 and base R plotting package set to TRUE ", {
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsProbability(y, plottype = 1, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdp_1.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and base set to TRUE", {
+  vdiffr::expect_doppelganger(
+    "plottype 1 base TRUE",
+    plot.gsProbability(y, plottype = 1, base = TRUE)
+  )
 })
 
-
-test_that("Test plot gsProbability graphs are correctly rendered for plottype 1 and base R plotting package set to FALSE", {
-  save_plot_obj <- save_gg_plot(plot.gsProbability(y, plottype = 1, base = FALSE))
-
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdp_2.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and base set to FALSE", {
+  vdiffr::expect_doppelganger(
+    "plottype 1 base FALSE",
+    plot.gsProbability(y, plottype = 1, base = FALSE)
+  )
 })
 
-
-test_that("Test plot gsProbability graphs are correctly rendered for plottype power and base R plotting package set to FALSE", {
-  save_plot_obj <- save_gg_plot(plot.gsProbability(y, plottype = "power", base = FALSE))
-
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdp_3.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype power and base set to FALSE", {
+  vdiffr::expect_doppelganger(
+    "plottype power base FALSE",
+    plot.gsProbability(y, plottype = "power", base = FALSE)
+  )
 })
 
-
-test_that("Test plot gsProbability graphs are correctly rendered for plottype 2 and base R plotting package set to TRUE", {
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsProbability(y, plottype = 2, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdp_4.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 2 and base set to TRUE", {
+  vdiffr::expect_doppelganger(
+    "plottype 2 base TRUE",
+    plot.gsProbability(y, plottype = 2, base = TRUE)
+  )
 })
 
-
-test_that("Test plot gsProbability graphs are correctly rendered for plottype 4 and base R plotting package set to FALSE", {
-  save_plot_obj <- save_gg_plot(plot.gsProbability(y, plottype = 4, base = FALSE))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_6.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and base set to FALSE", {
+  vdiffr::expect_doppelganger(
+    "plottype 4 base FALSE",
+    plot.gsProbability(y, plottype = 4, base = FALSE)
+  )
 })
 
-test_that("Test plot gsProbability graphs are correctly rendered for plottype 4 and base R plotting package set to TRUE", {
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsProbability(x, plottype = 4, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_7.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and base set to TRUE", {
+  vdiffr::expect_doppelganger(
+    "plottype 4 base TRUE",
+    plot.gsProbability(x, plottype = 4, base = TRUE)
+  )
 })
 
-
-test_that("Test plot gsProbability graphs are correctly rendered for plottype 6 and base R plotting package set to FALSE", {
-  save_plot_obj <- save_gg_plot(plot.gsProbability(y, plottype = 6, base = FALSE))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsds_9.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 6 and base set to FALSE", {
+  vdiffr::expect_doppelganger(
+    "plottype 6 base FALSE",
+    plot.gsProbability(y, plottype = 6, base = FALSE)
+  )
 })
 
-test_that("Test gsProbability graphs are correctly rendered for plottype 6 and base R plotting package set to TRUE", {
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsProbability(y, plottype = 6, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdpa_1.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 6 and base set to TRUE", {
+  vdiffr::expect_doppelganger(
+    "plottype 6 base TRUE",
+    plot.gsProbability(y, plottype = 6, base = TRUE)
+  )
 })
 
-test_that("Test plotgsProbability graphs are correctly rendered for plottype 7 and base R plotting package set to TRUE", {
-  local_edition(3)
-  save_plot_obj <- save_gr_plot(plot.gsProbability(y, plottype = 7, base = TRUE))
-  expect_snapshot_file(save_plot_obj, "plot_plotgsdpa_2.png")
+test_that("plot.gsProbability: plots are correctly rendered for plottype 7 and base set to TRUE", {
+  vdiffr::expect_doppelganger(
+    "plottype 7 base TRUE",
+    plot.gsProbability(y, plottype = 7, base = TRUE)
+  )
 })

--- a/tests/testthat/test-independent-test-plot.ssrCP.R
+++ b/tests/testthat/test-independent-test-plot.ssrCP.R
@@ -1,16 +1,17 @@
-#----------------------
-# plot.ssrCP
-#---------------------
+testthat::test_that("plot.ssrCP: plots are correctly rendered", {
+  ssr_cp_des <- ssrCP(
+    z1 = seq(-3, 3, 0.1), theta = NULL, maxinc = 2,
+    overrun = 0, beta = 0.1, cpadj = c(0.5, 1 - 0.2),
+    x = gsDesign(k = 2, delta = 0.2), z2 = z2NC
+  )
 
-testthat::test_that("Test: plot.ssrCP graphs are correctly rendered ", {
-  ssr.cp.des <- ssrCP(z1 = seq(-3, 3, 0.1), theta = NULL, maxinc = 2,
-                      overrun = 0, beta = 0.1, cpadj = c(0.5, 1 - 0.2),
-                      x = gsDesign(k = 2, delta = 0.2), z2 = z2NC)
+  plot_ssr_cp <- function(x) {
+    plot.ssrCP(
+      x = x, z1ticks = NULL,
+      mar = c(7, 4, 4, 4) + 0.1,
+      ylab = "Adapted sample size", xlaboffset = -0.2, lty = 1, col = 1
+    )
+  }
 
-  save_plot_obj <- save_gr_plot(plot.ssrCP(x = ssr.cp.des, z1ticks = NULL, 
-                                       mar = c(7, 4, 4, 4) + 0.1,
-    ylab = "Adapted sample size", xlaboffset = -0.2, lty = 1, col = 1))
-
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_ssrCP_1.png")
+  vdiffr::expect_doppelganger("ssr CP", plot_ssr_cp(ssr_cp_des))
 })

--- a/tests/testthat/test-independent-test-plotASN.R
+++ b/tests/testthat/test-independent-test-plotASN.R
@@ -63,17 +63,10 @@ test_that( desc = "check expected sample sizes", code = {
   }
 )
 
-
-# save_gg_plot() will be used when storing plot objects created with graphics package.
-
-test_that("Test plotASN graphs for gSurv are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotASN(x))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotastn_1.png")
+test_that("plotASN: plots for gSurv objects are correctly rendered", {
+  vdiffr::expect_doppelganger("plotASN gSurv", plotASN(x))
 })
 
-test_that("Test plotASN graphs for gsDesign are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotASN(xx))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotastn_3.png")
+test_that("plotASN: plots for gsDesign objects are correctly rendered", {
+  vdiffr::expect_doppelganger("plotASN gsDesign", plotASN(xx))
 })

--- a/tests/testthat/test-independent-test-plotBval.R
+++ b/tests/testthat/test-independent-test-plotBval.R
@@ -47,13 +47,6 @@ test_that(
   }
 )
 
-
-
-
-## save_gg_plot() function will be used when storing plot objects created with graphics package.
-
-test_that("Test plotBval graphs are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotBval(x))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotBval_1.png")
+test_that("plotBval: plots are correctly rendered", {
+  vdiffr::expect_doppelganger("plotBval", plotBval(x))
 })

--- a/tests/testthat/test-independent-test-plotHR.R
+++ b/tests/testthat/test-independent-test-plotHR.R
@@ -43,9 +43,6 @@ test_that(
   }
 )
 
-
-test_that("Test plotHR graphs are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotHR(xgs))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotHR_1.png")
+test_that("plotHR: plots are correctly rendered", {
+  vdiffr::expect_doppelganger("plotHR", plotHR(xgs))
 })

--- a/tests/testthat/test-independent-test-plotRR.R
+++ b/tests/testthat/test-independent-test-plotRR.R
@@ -44,10 +44,6 @@ test_that(
   }
 )
 
-
-
-test_that("Test plotRR graphs are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotRR(x))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotRR_1.png")
+test_that("plotRR: plots are correctly rendered", {
+  vdiffr::expect_doppelganger("plotRR", plotRR(x))
 })

--- a/tests/testthat/test-independent-test-plotgsCP.R
+++ b/tests/testthat/test-independent-test-plotgsCP.R
@@ -33,25 +33,26 @@ test_that(desc = "check plot data values for sample size,",
     expect_lte(abs(nplot[2] - x$n.I[2]), 1e-6)
 })
 
+test_that("plotgsCP: plots are correctly rendered, test.type = 1", {
+  x <- gsDesign(
+    k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
 
-test_that(desc = "Test plotgsCP graphs are correctly rendered, test.type = 1",
-          code = {
-    x <- gsDesign(k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
-                  delta1 = 0.3, sfu = sfLDOF)
-
-    save_plot_obj <- save_gg_plot(plotgsCP(x = x))
-    local_edition(3)
-    expect_snapshot_file(save_plot_obj, "plotgsCP_1.png")
+  vdiffr::expect_doppelganger(
+    "plotgsCP test type 1",
+    plotgsCP(x = x)
+  )
 })
 
+test_that("plotgsCP: plots are correctly rendered, test.type = 2", {
+  x <- gsDesign(
+    k = 3, test.type = 2, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
 
-test_that(
-  desc = "Test plotgsCP graphs are correctly rendered, test.type = 2",
-  code = {
-    x <- gsDesign(k = 3, test.type = 2, alpha = 0.025, beta = 0.1,
-                  delta1 = 0.3, sfu = sfLDOF)
-
-    save_plot_obj <- save_gg_plot(plotgsCP(x = x))
-    local_edition(3)
-    expect_snapshot_file(save_plot_obj, "plotgsCP_2.png")
+  vdiffr::expect_doppelganger(
+    "plotgsCP test type 2",
+    plotgsCP(x = x)
+  )
 })

--- a/tests/testthat/test-independent-test-plotgsPower.R
+++ b/tests/testthat/test-independent-test-plotgsPower.R
@@ -30,20 +30,17 @@ test_that(desc = 'check plot data values,
    expect_lte(abs(res$Probability[3] - 0.12486698), 1e-3)
  })
 
+test_that("plotgsPower: plots are correctly rendered, test.type = 1", {
+  x <- gsDesign(
+    k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
 
-
-test_that(desc = 'Test: plotgsPower graphs are correctly rendered,test.type = 1', 
-          code = {
-      x <- gsDesign(k = 3, test.type = 1, alpha = 0.025,beta = 0.1, 
-                    delta1 = 0.3, sfu = sfLDOF)
-      
-      save_plot_obj <- save_gg_plot( plotgsPower(x = x))
-      
-      local_edition(3)
-      
-      expect_snapshot_file(save_plot_obj, "plotgsPower_1.png")
+  vdiffr::expect_doppelganger(
+    "gsPower test type 1",
+    plotgsPower(x = x)
+  )
 })
-
 
 test_that(desc = 'check plot data values,
                  source: Probability Calculations done using East 6.5', 
@@ -90,17 +87,16 @@ test_that(desc = 'check plot data values,
    expect_lte(abs(res - 0.99808417), 1e-3)
  })
 
+test_that("plotgsPower: plots are correctly rendered, test.type = 2", {
+  x <- gsDesign(
+    k = 3, test.type = 2, alpha = 0.025,
+    beta = 0.1, delta1 = 0.3, sfu = sfLDOF
+  )
 
-test_that(desc = 'Test: plotgsPower graphs are correctly rendered,test.type = 1', 
-          code = {
-  x <- gsDesign(k = 3, test.type = 2, alpha = 0.025, 
-                beta = 0.1, delta1 = 0.3, sfu = sfLDOF)
-  
-  save_plot_obj <- save_gg_plot(plotgsPower(x = x))
-  
-  local_edition(3)
-  
-  expect_snapshot_file(save_plot_obj, "plotgsPower_2.png")
+  vdiffr::expect_doppelganger(
+    "gsPower test type 2",
+    plotgsPower(x = x)
+  )
 })
 
 test_that(desc = 'Test: plotgsPower graphs can use offset arg for Future Analysis legend',

--- a/tests/testthat/test-independent-test-plotgsZ.R
+++ b/tests/testthat/test-independent-test-plotgsZ.R
@@ -51,9 +51,6 @@ test_that(
   }
 )
 
-
-test_that("Test plotgsZ graphs are correctly rendered ", {
-  save_plot_obj <- save_gg_plot(plotgsZ(x))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plot_plotgsz_1.png")
+test_that("plotgsZ: plots are correctly rendered", {
+  vdiffr::expect_doppelganger("plotgsZ", plotgsZ(x))
 })

--- a/tests/testthat/test-independent-test-plotsf.R
+++ b/tests/testthat/test-independent-test-plotsf.R
@@ -31,36 +31,38 @@ test_that(desc = 'check plot data values,
    expect_lte(abs(res$spend - 0.00965528), 1e-4)
 })
 
+test_that("plotsf: plots are correctly rendered, test.type = 1", {
+  x <- gsDesign(
+    k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
 
-test_that(desc = "Test plotsf graphs are correctly rendered,test.type = 1",
-          code = {
-    x <- gsDesign(k = 3, test.type = 1, alpha = 0.025, beta = 0.1,
-                  delta1 = 0.3, sfu = sfLDOF)
-
-    save_plot_obj <- save_gg_plot(plotsf(x = x))
-    local_edition(3)
-    expect_snapshot_file(save_plot_obj, "plotsf_1.png")
-
+  vdiffr::expect_doppelganger(
+    "plotsf test type 1",
+    plotsf(x = x)
+  )
 })
 
-test_that(desc = "Test plotsf graphs are correctly rendered,test.type = 5",
-          code = {
-  x <- gsDesign(k = 3, test.type = 5, alpha = 0.025, beta = 0.1,
-                delta1 = 0.3, sfu = sfLDOF)
-  
-  save_plot_obj <- save_gr_plot(plotsf(x = x, base = TRUE))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plotsf_2.png")
-  
+test_that("plotsf: plots are correctly rendered, test.type = 5", {
+  x <- gsDesign(
+    k = 3, test.type = 5, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
+
+  vdiffr::expect_doppelganger(
+    "plotsf test type 5",
+    plotsf(x = x, base = TRUE)
+  )
 })
 
-test_that(desc = "Test plotgsCP graphs are correctly rendered,test.type = 4",
-          code = {
-  x <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
-                delta1 = 0.3, sfu = sfLDOF)
-  
-  save_plot_obj <- save_gg_plot(plotsf(x = x, base = FALSE))
-  local_edition(3)
-  expect_snapshot_file(save_plot_obj, "plotsf_3.png")
-  
+test_that("plotgsCP: plots are correctly rendered, test.type = 4", {
+  x <- gsDesign(
+    k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
+    delta1 = 0.3, sfu = sfLDOF
+  )
+
+  vdiffr::expect_doppelganger(
+    "plotgsCP test type 4",
+    plotsf(x = x, base = FALSE)
+  )
 })


### PR DESCRIPTION
Fixes #175 

This PR refactors all graphical snapshot tests to use `vdiffr::expect_doppelganger()` which saves and compares to reproducible SVG outputs, and add the snapshot SVG files to the repo.

Note that `.Rbuildignore` still has `tests/testthat/_snaps/` ignored. This means the snapshot won't be available for comparison when running `R CMD check` and the snapshot tests will always pass. Making the snapshots available and tracked in the repo is still useful though because they can be compared to in development mode, such as when running `devtools::test()`.