### PR TITLE
Use CODECOV_TOKEN to fix code coverage uploads

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -23,23 +24,33 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,7 +2,6 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: test-coverage.yaml
 
@@ -38,6 +39,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: github.event.repository.fork == false
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/gsDesign)](https://CRAN.R-project.org/package=gsDesign)
-[![Codecov test coverage](https://codecov.io/gh/keaven/gsDesign/branch/master/graph/badge.svg)](https://app.codecov.io/gh/keaven/gsDesign?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/keaven/gsDesign/graph/badge.svg)](https://app.codecov.io/gh/keaven/gsDesign)
 [![pkgdown](https://github.com/keaven/gsDesign/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/keaven/gsDesign/actions/workflows/pkgdown.yaml)
 [![R-CMD-check](https://github.com/keaven/gsDesign/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/keaven/gsDesign/actions/workflows/R-CMD-check.yaml)
 [![shinyapps.io](https://img.shields.io/badge/Shiny-shinyapps.io-blue)](https://rinpharma.shinyapps.io/gsdesign/)


### PR DESCRIPTION
The coverage reports haven't been uploaded to Codecov for many months. The most recent upload from a commit was on [July 12, 2024](https://app.codecov.io/gh/keaven/gsDesign/commit/91cde4ec70aeaa281580a510f18849c584893a21), and the most recent upload from a PR was on [Aug 7, 2024](https://app.codecov.io/gh/keaven/gsDesign/pull/166).

This is because Codecov started requiring an authentication token for uploads(https://github.com/r-lib/actions/issues/834). This results in the error below, copy-pasted from the [CI run](https://github.com/keaven/gsDesign/actions/runs/12932962568/job/36070433439#step:5:205) for the most recent commit https://github.com/keaven/gsDesign/commit/1fe9deba8bf0915688b8cfda270d933d7156fb94 (from yesterday)

```R
[1] "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 696s."
```

**Solution:**
* @keaven already copy-pasted the Codecov upload token and saved it as a repository secret named `CODECOV_TOKEN`
* This PR updates `test-coverage.yaml` to use `CODECOV_TOKEN` for authentication
* I ran `usethis::use_github_action("test-coverage")` to use the latest workflow from [r-lib/actions](https://github.com/r-lib/actions/blob/8c5e6e8ce51d61333e02ab03086864925f7d9a67/examples/test-coverage.yaml)
* I only made a few minor modifications to the default template:
  * Removed the branch restrictions so that the test coverage is calculated and uploaded to Codecov from any branch, which allows you to track the test coverage prior to opening a PR
  * Added the worklow trigger `workflow_dispatch:` so that you can manually trigger the workflow to run from any branch at any time
  * Added the condition `if: github.event.repository.fork == false` to the step to upload the coverage results to Codecov. This prevents the workflow from failing on a fork where `CODECOV_TOKEN` is undefined
