### PR TITLE
Add details for function argument `r` to documentation

### DIFF
--- a/R/gsCP.R
+++ b/R/gsCP.R
@@ -60,10 +60,13 @@
 #' @param zi interim z-value at analysis i (scalar)
 #' @param j specific analysis for which prediction is being made; must be
 #' \code{>i} and no more than \code{x$k}
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param total The default of \code{total=TRUE} produces the combined
 #' probability for all planned analyses after the interim analysis specified in
 #' \code{i}. Otherwise, information on each analysis is provided separately.
@@ -331,10 +334,13 @@ gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c
 #' \code{zi} and interim sample size/statistical information of
 #' \code{x$n.I[i]}). Otherwise, conditional power is computed assuming the
 #' input scalar value \code{theta}.
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @return A list containing two vectors, \code{CPlo} and \code{CPhi}.
 #' \item{CPlo}{A vector of length \code{x$k-1} with conditional powers of
 #' crossing upper bounds given interim test statistics at each lower bound}

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -29,10 +29,13 @@
 #' @param tol Tolerance for error (scalar; default is 0.000001). Normally this
 #' will not be changed by the user.  This does not translate directly to number
 #' of digits of accuracy, so use extra decimal places.
-#' @param r Single integer value controlling grid for numerical integration as
-#' in Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param printerr If this scalar argument set to 1, this will print messages
 #' from underlying C program.  Mainly intended to notify user when an output
 #' solution does not match input specifications.  This is not intended to stop
@@ -305,10 +308,13 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #' @param tol Tolerance for error (default is 0.000001). Normally this will not
 #' be changed by the user.  This does not translate directly to number of
 #' digits of accuracy, so use extra decimal places.
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param n.I Used for re-setting bounds when timing of analyses changes from
 #' initial design; see examples.
 #' @param maxn.IPlan Used for re-setting bounds when timing of analyses changes
@@ -573,8 +579,13 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 #' analysis, vector of length k.
 #' @param b Upper bound cutoffs (z-values) for futility at each analysis;
 #' vector of length k.
-#' @param r Control for grid as in Jennison and Turnbull (2000); default is 18,
-#' range is 1 to 80.  Normally this will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param d If not \code{NULL}, this should be an object of type
 #' \code{gsDesign} returned by a call to \code{gsDesign()}.  When this is
 #' specified, the values of \code{k}, \code{n.I}, \code{a}, \code{b}, and
@@ -731,10 +742,13 @@ gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0
 #' @param i analysis at which interim z-values are given; must be from 1 to
 #' \code{x$k}
 #' @param zi interim z-value at analysis \code{i} (scalar)
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @return \item{zi}{The input vector \code{zi}.} \item{theta}{The input vector
 #' \code{theta}.} \item{density}{A matrix with \code{length(zi)} rows and
 #' \code{length(theta)} columns.  The subdensity function for \code{z[j]},

--- a/R/gsSurv.R
+++ b/R/gsSurv.R
@@ -864,10 +864,13 @@ KT <- function(alpha = .025, sided = 1, beta = .1,
 #' @param sflpar Real value, default is \eqn{-2}, which, with the default
 #' Hwang-Shih-DeCani spending function, specifies a less conservative spending
 #' rate than the default for the upper bound.
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80. Larger values
-#' provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param usTime Default is NULL in which case upper bound spending time is
 #' determined by \code{timing}. Otherwise, this should be a vector of length
 #' \code{k} with the spending time at each analysis (see Details in help for \code{gsDesign}).

--- a/R/gsSurvCalendar.R
+++ b/R/gsSurvCalendar.R
@@ -85,11 +85,13 @@
 #' @param ratio Randomization ratio of experimental treatment
 #'   divided by control; normally a scalar, but may be a vector with
 #'   length equal to number of strata.
-#' @param r Integer value controlling grid for numerical
-#'   integration as in Jennison and Turnbull (2000); default is 18,
-#'   range is 1 to 80. Larger values provide larger number of grid
-#'   points and greater accuracy. Normally \code{r} will not be changed by
-#'   the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#'   integration grid points. Default is 18, as recommended by Jennison and
+#'   Turnbull (2000). Grid points are spread out in the tails for accurate
+#'   probability calculations. Larger values provide more grid points and greater
+#'   accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#'   accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#'   not changed by users.
 #' @param tol Tolerance for error passed to the \code{\link{gsDesign}} function.
 #'
 #' @export

--- a/R/ssrCP.R
+++ b/R/ssrCP.R
@@ -126,10 +126,13 @@ n2sizediff <- function(z1, target, beta = .1, z2 = z2NC,
 #' @param delta Natural parameter values for power calculation; see
 #' \code{\link{gsDesign}} for a description of how this is related to
 #' \code{theta}.
-#' @param r Integer value controlling grid for numerical integration as in
-#' Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-#' values provide larger number of grid points and greater accuracy.  Normally
-#' \code{r} will not be changed by the user.
+#' @param r Integer value (>= 1 and <= 80) controlling the number of numerical
+#' integration grid points. Default is 18, as recommended by Jennison and
+#' Turnbull (2000). Grid points are spread out in the tails for accurate
+#' probability calculations. Larger values provide more grid points and greater
+#' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+#' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+#' not changed by users.
 #' @param n2 stage 2 sample size to be used in computing sufficient statistic
 #' when combining stage 1 and 2 test statistics.
 #' @param z1ticks Test statistic values at which tick marks are to be made on

--- a/man/gsBound.Rd
+++ b/man/gsBound.Rd
@@ -22,10 +22,13 @@ assuming mean of 0.}
 will not be changed by the user.  This does not translate directly to number
 of digits of accuracy, so use extra decimal places.}
 
-\item{r}{Single integer value controlling grid for numerical integration as
-in Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{printerr}{If this scalar argument set to 1, this will print messages
 from underlying C program.  Mainly intended to notify user when an output

--- a/man/gsBoundCP.Rd
+++ b/man/gsBoundCP.Rd
@@ -17,10 +17,13 @@ estimated treatment effect assuming a test statistic at that boundary
 \code{x$n.I[i]}). Otherwise, conditional power is computed assuming the
 input scalar value \code{theta}.}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 }
 \value{
 A list containing two vectors, \code{CPlo} and \code{CPhi}.

--- a/man/gsCP.Rd
+++ b/man/gsCP.Rd
@@ -52,10 +52,13 @@ value of \eqn{\theta}{theta} based on the interim test statistic
 
 \item{zi}{interim z-value at analysis i (scalar)}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{wgts}{Weights to be used with grid points in \code{theta}. Length can
 be one if weights are equal, otherwise should be the same length as

--- a/man/gsDensity.Rd
+++ b/man/gsDensity.Rd
@@ -17,10 +17,13 @@ density function is to be computed.}
 
 \item{zi}{interim z-value at analysis \code{i} (scalar)}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 }
 \value{
 \item{zi}{The input vector \code{zi}.} \item{theta}{The input vector

--- a/man/gsDesign.Rd
+++ b/man/gsDesign.Rd
@@ -112,10 +112,13 @@ rate than the default for the upper bound.}
 be changed by the user.  This does not translate directly to number of
 digits of accuracy, so use extra decimal places.}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{n.I}{Used for re-setting bounds when timing of analyses changes from
 initial design; see examples.}

--- a/man/gsProbability.Rd
+++ b/man/gsProbability.Rd
@@ -24,8 +24,13 @@ analysis, vector of length k.}
 \item{b}{Upper bound cutoffs (z-values) for futility at each analysis;
 vector of length k.}
 
-\item{r}{Control for grid as in Jennison and Turnbull (2000); default is 18,
-range is 1 to 80.  Normally this will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{d}{If not \code{NULL}, this should be an object of type
 \code{gsDesign} returned by a call to \code{gsDesign()}.  When this is

--- a/man/gsSurvCalendar.Rd
+++ b/man/gsSurvCalendar.Rd
@@ -137,11 +137,13 @@ and \code{minfup}.}
 divided by control; normally a scalar, but may be a vector with
 length equal to number of strata.}
 
-\item{r}{Integer value controlling grid for numerical
-integration as in Jennison and Turnbull (2000); default is 18,
-range is 1 to 80. Larger values provide larger number of grid
-points and greater accuracy. Normally \code{r} will not be changed by
-the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{tol}{Tolerance for error passed to the \code{\link{gsDesign}} function.}
 }

--- a/man/nSurv.Rd
+++ b/man/nSurv.Rd
@@ -214,10 +214,13 @@ details, spending functions, manual and examples.}
 Hwang-Shih-DeCani spending function, specifies a less conservative spending
 rate than the default for the upper bound.}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80. Larger values
-provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 
 \item{usTime}{Default is NULL in which case upper bound spending time is
 determined by \code{timing}. Otherwise, this should be a vector of length

--- a/man/ssrCP.Rd
+++ b/man/ssrCP.Rd
@@ -107,10 +107,13 @@ x-axis; automatically calculated under default of \code{NULL}}
 \code{\link{gsDesign}} for a description of how this is related to
 \code{theta}.}
 
-\item{r}{Integer value controlling grid for numerical integration as in
-Jennison and Turnbull (2000); default is 18, range is 1 to 80.  Larger
-values provide larger number of grid points and greater accuracy.  Normally
-\code{r} will not be changed by the user.}
+\item{r}{Integer value (>= 1 and <= 80) controlling the number of numerical
+integration grid points. Default is 18, as recommended by Jennison and
+Turnbull (2000). Grid points are spread out in the tails for accurate
+probability calculations. Larger values provide more grid points and greater
+accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
+accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
+not changed by users.}
 }
 \value{
 \code{ssrCP} returns a list with the following items: \item{x}{As


### PR DESCRIPTION
Closes #40 

This PR adds further details to the parameter `r` for controlling numerical integration grid points, and improves the flow of the original documentation, in all relevant functions.