### PR TITLE
Replace data.frame(cbind()) with data.frame()

### DIFF
--- a/R/gsBinomial.R
+++ b/R/gsBinomial.R
@@ -176,17 +176,17 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
     if (is.null(n)) {
       n <- ((z.alpha * sigma0 + z.beta * sigma1) / (p1 - p2 - delta0))^2
       if (outtype == 2) {
-        return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio *
-          n / (ratio + 1))))
+        return(data.frame(n1 = n / (ratio + 1), n2 = ratio *
+          n / (ratio + 1)))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = beta, Power = 1 - beta,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(n = n)
@@ -196,17 +196,17 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
       pwr <- stats::pnorm(-(stats::qnorm(1 - alpha / sided) - sqrt(n) *
         ((p1 - p2 - delta0) / sigma0)) * sigma0 / sigma1)
       if (outtype == 2) {
-        return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio *
-          n / (ratio + 1), Power = pwr)))
+        return(data.frame(n1 = n / (ratio + 1), n2 = ratio *
+          n / (ratio + 1), Power = pwr))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = 1 - pwr, Power = pwr,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(Power = pwr)
@@ -232,19 +232,19 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
     if (is.null(n)) {
       n <- ((z.alpha * sigma0 + z.beta * sigma1) / (p1 - p2 * RR))^2
       if (outtype == 2) {
-        return(data.frame(cbind(
+        return(data.frame(
           n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1)
-        )))
+        ))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = beta, Power = 1 - beta,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(n = n)
@@ -254,17 +254,17 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
       pwr <- stats::pnorm(-(stats::qnorm(1 - alpha / sided) - sqrt(n) *
         ((p1 - p2 * RR) / sigma0)) * sigma0 / sigma1)
       if (outtype == 2) {
-        return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio *
-          n / (ratio + 1), Power = pwr)))
+        return(data.frame(n1 = n / (ratio + 1), n2 = ratio *
+          n / (ratio + 1), Power = pwr))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = 1 - pwr, Power = pwr,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(Power = pwr)
@@ -288,17 +288,17 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
     if (is.null(n)) {
       n <- ((z.alpha * sigma0 + z.beta * sigma1) / log(OR / p2 * (1 - p2) * p1 / (1 - p1)))^2
       if (outtype == 2) {
-        return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio *
-          n / (ratio + 1))))
+        return(data.frame(n1 = n / (ratio + 1), n2 = ratio *
+          n / (ratio + 1)))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = beta, Power = 1 - beta,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(n = n)
@@ -309,17 +309,17 @@ nBinomial <- function(p1, p2, alpha = 0.025, beta = 0.1, delta0 = 0, ratio = 1, 
         (log(OR / p2 * (1 - p2) * p1 / (1 - p1)) / sigma0)) *
         sigma0 / sigma1)
       if (outtype == 2) {
-        return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio *
-          n / (ratio + 1), Power = pwr)))
+        return(data.frame(n1 = n / (ratio + 1), n2 = ratio *
+          n / (ratio + 1), Power = pwr))
       }
       else if (outtype == 3) {
-        return(data.frame(cbind(
+        return(data.frame(
           n = n, n1 = n / (ratio + 1),
           n2 = ratio * n / (ratio + 1), alpha = alpha,
           sided = sided, beta = 1 - pwr, Power = pwr,
           sigma0 = sigma0, sigma1 = sigma1, p1 = p1,
           p2 = p2, delta0 = delta0, p10 = p10, p20 = p20
-        )))
+        ))
       }
       else {
         return(Power = pwr)

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -384,7 +384,8 @@ gsBoundSummary0 <- function(
     } else {
       Futility <- NULL
     }
-    pp <- data.frame(Efficacy, Futility, i = 1:(x$k - 1))
+    # cbind() required here to drop Futility column when it is NULL
+    pp <- data.frame(cbind(Efficacy, Futility, i = 1:(x$k - 1)))
     pp$Value <- "PP"
   }
   # start a frame for other statistics

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -357,7 +357,7 @@ gsBoundSummary0 <- function(
   if (x$test.type > 1) {
     pframe2 <- NULL
     for (i in 1:length(x$theta)) pframe2 <- rbind(pframe2, data.frame("Futility" = cumsum(x$lower$prob[, i])))
-    pframe <- data.frame(cbind("Value" = pframe[, 1], pframe2, pframe[, -1]))
+    pframe <- data.frame("Value" = pframe[, 1], pframe2, pframe[, -1])
   }
   # conditional power at bound, theta=hat(theta)
   cp <- data.frame(gsBoundCP(x, r = r))
@@ -384,17 +384,17 @@ gsBoundSummary0 <- function(
     } else {
       Futility <- NULL
     }
-    pp <- data.frame(cbind(Efficacy, Futility, i = 1:(x$k - 1)))
+    pp <- data.frame(Efficacy, Futility, i = 1:(x$k - 1))
     pp$Value <- "PP"
   }
   # start a frame for other statistics
   # z at bounds
   statframe <- data.frame("Value" = "Z", "Efficacy" = x$upper$bound, i = 1:x$k)
-  if (x$test.type > 1) statframe <- data.frame(cbind(statframe, "Futility" = x$lower$bound))
+  if (x$test.type > 1) statframe <- data.frame(statframe, "Futility" = x$lower$bound)
   # add nominal p-values at each bound
   tem <- data.frame("Value" = "p (1-sided)", "Efficacy" = stats::pnorm(x$upper$bound, lower.tail = FALSE), i = 1:x$k)
-  if (x$test.type == 2) tem <- data.frame(cbind(tem, "Futility" = stats::pnorm(x$lower$bound, lower.tail = TRUE)))
-  if (x$test.type > 2) tem <- data.frame(cbind(tem, "Futility" = stats::pnorm(x$lower$bound, lower.tail = FALSE)))
+  if (x$test.type == 2) tem <- data.frame(tem, "Futility" = stats::pnorm(x$lower$bound, lower.tail = TRUE))
+  if (x$test.type > 2) tem <- data.frame(tem, "Futility" = stats::pnorm(x$lower$bound, lower.tail = FALSE))
   statframe <- rbind(statframe, tem)
   # delta values at bounds
   tem <- data.frame("Value" = paste("~", deltaname, " at bound", sep = ""), "Efficacy" = deltaefficacy, i = 1:x$k)

--- a/R/gsSurv.R
+++ b/R/gsSurv.R
@@ -1383,10 +1383,10 @@ xtable.gsSurv <- function(x, caption = NULL, label = NULL, align = NULL, digits 
       paste(eff[neff], "\\\\ \\hline \\multicolumn{4}{p{", fnwid, "}}{\\footnotesize", footnote, "}")
   }
   if (x$test.type != 1) {
-    xxtab <- data.frame(cbind(an, stat, fut, eff))
+    xxtab <- data.frame(an, stat, fut, eff)
     colnames(xxtab) <- c("Analysis", "Value", "Futility", "Efficacy")
   } else {
-    xxtab <- data.frame(cbind(an, stat, eff))
+    xxtab <- data.frame(an, stat, eff)
     colnames(xxtab) <- c("Analysis", "Value", "Efficacy")
   }
   return(xtable::xtable(xxtab,

--- a/R/nEvents.R
+++ b/R/nEvents.R
@@ -9,24 +9,24 @@ nEvents <- function(hr = .6, alpha = .025, beta = .1, ratio = 1, sided = 1, hr0 
   if (n[1] == 0) {
     n <- (stats::qnorm(1 - alpha / sided) + stats::qnorm(1 - beta))^2 / delta^2
     if (tbl) {
-      n <- data.frame(cbind(
+      n <- data.frame(
         hr = hr, n = ceiling(n), alpha = alpha,
         sided = sided, beta = beta,
         Power = 1 - beta, delta = delta, ratio = ratio,
         hr0 = hr0, se = 1 / c / sqrt(ceiling(n))
-      ))
+      )
     }
     return(n)
   }
   else {
     pwr <- stats::pnorm(-(stats::qnorm(1 - alpha / sided) - sqrt(n) * delta))
     if (tbl) {
-      pwr <- data.frame(cbind(
+      pwr <- data.frame(
         hr = hr, n = n, alpha = alpha,
         sided = sided, beta = 1 - pwr,
         Power = pwr, delta = delta, ratio = ratio,
         hr0 = hr0, se = sqrt(1 / n) / c
-      ))
+      )
     }
     return(pwr)
   }

--- a/R/nNormal.R
+++ b/R/nNormal.R
@@ -110,14 +110,14 @@ nNormal <- function(delta1 = 1, sd = 1.7, sd2 = NULL, alpha = .025,
   if (is.null(n)) {
     n <- ((stats::qnorm(alpha / sided) + stats::qnorm(beta)) / theta1)^2
     if (outtype == 2) {
-      return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1))))
+      return(data.frame(n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1)))
     }
     else if (outtype == 3) {
-      return(data.frame(cbind(
+      return(data.frame(
         n = n, n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1),
         alpha = alpha, sided = sided, beta = beta, Power = 1 - beta,
         sd = sd, sd2 = sd2, delta1 = delta1, delta0 = delta0, se = se / sqrt(n)
-      )))
+      ))
     }
     else {
       return(n = n)
@@ -125,13 +125,13 @@ nNormal <- function(delta1 = 1, sd = 1.7, sd2 = NULL, alpha = .025,
   } else {
     powr <- stats::pnorm(sqrt(n) * theta1 - stats::qnorm(1 - alpha / sided))
     if (outtype == 2) {
-      return(data.frame(cbind(n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1), Power = powr)))
+      return(data.frame(n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1), Power = powr))
     } else if (outtype == 3) {
-      return(data.frame(cbind(
+      return(data.frame(
         n = n, n1 = n / (ratio + 1), n2 = ratio * n / (ratio + 1),
         alpha = alpha, sided = sided, beta = 1 - powr, Power = powr,
         sd = sd, sd2 = sd2, delta1 = delta1, delta0 = delta0, se = se / sqrt(n)
-      )))
+      ))
     }
     else {
       (return(Power = powr))

--- a/R/ssrCP.R
+++ b/R/ssrCP.R
@@ -268,9 +268,9 @@ n2sizediff <- function(z1, target, beta = .1, z2 = z2NC,
 #' )
 #' # combine data frames from these designs
 #' y <- rbind(
-#'   data.frame(cbind(xx$dat, Test = "Normal combination")),
-#'   data.frame(cbind(xxZ$dat, Test = "Sufficient statistic")),
-#'   data.frame(cbind(xxFisher$dat, Test = "Fisher combination"))
+#'   data.frame(xx$dat, Test = "Normal combination"),
+#'   data.frame(xxZ$dat, Test = "Sufficient statistic"),
+#'   data.frame(xxFisher$dat, Test = "Fisher combination")
 #' )
 #' # plot stage 2 statistic required for positive combination test
 #' ggplot2::ggplot(data = y, ggplot2::aes(x = z1, y = z2, col = Test)) + 
@@ -288,8 +288,8 @@ n2sizediff <- function(z1, target, beta = .1, z2 = z2NC,
 #' )
 #' # combine data frames for the 2 designs
 #' y <- rbind(
-#'   data.frame(cbind(xx$dat, "CP effect size" = "Obs. at IA")),
-#'   data.frame(cbind(xxtheta1$dat, "CP effect size" = "Alt. hypothesis"))
+#'   data.frame(xx$dat, "CP effect size" = "Obs. at IA"),
+#'   data.frame(xxtheta1$dat, "CP effect size" = "Alt. hypothesis")
 #' )
 #' # plot stage 2 sample size by design
 #' ggplot2::ggplot(data = y, ggplot2::aes(x = z1, y = n2, col = CP.effect.size)) + 
@@ -299,8 +299,8 @@ n2sizediff <- function(z1, target, beta = .1, z2 = z2NC,
 #' y2 <- Power.ssrCP(x = xxtheta1)
 #' # combine data frames for the 2 designs
 #' y3 <- rbind(
-#'   data.frame(cbind(y1, "CP effect size" = "Obs. at IA")),
-#'   data.frame(cbind(y2, "CP effect size" = "Alt. hypothesis"))
+#'   data.frame(y1, "CP effect size" = "Obs. at IA"),
+#'   data.frame(y2, "CP effect size" = "Alt. hypothesis")
 #' )
 #' # plot expected sample size by design and effect size
 #' ggplot2::ggplot(data = y3, ggplot2::aes(x = delta, y = en, col = CP.effect.size)) + 

--- a/R/xtable.R
+++ b/R/xtable.R
@@ -99,7 +99,7 @@ xtable.gsDesign <- function(x, caption = NULL, label = NULL, align = NULL, digit
       fnwid, "}}{\\footnotesize", footnote, "}"
     )
   }
-  x <- data.frame(cbind(an, stat, fut, eff))
+  x <- data.frame(an, stat, fut, eff)
   colnames(x) <- c("Analysis", "Value", "Futility", "Efficacy")
   xtable::xtable(x, caption = caption, label = label, align = align, digits = digits, display = display, ...)
 }


### PR DESCRIPTION
I noticed the use of the pattern [`data.frame(cbind())`]( https://github.com/search?q=repo%3Akeaven%2FgsDesign%20data.frame(cbind(&type=code ) throughout the package, which seemed redundant to me. Surprisingly, this pattern is also common across [R packages on GitHub](https://github.com/search?utf8=%E2%9C%93&q=data.frame%28cbind+language%3AR&type=code). I've done various investigations to confirm that `data.frame(cbind())` and `data.frame()` are equivalent, at least for the uses in this package.

When combining vectors, the results are identical. When combining vectors and matrices, the results are identical unless the matrix has unnamed columns, in which case the auto-generated column names are slightly different. As far as I can tell, the columns are always named in this package.


<details>
<summary>Example code combining vectors and matrices
</summary>

```R
# Vectors only
vec1 <- 1
vec2 <- 1:2

# cbind() returns a matrix
cbind(vec1, vec2)
##      vec1 vec2
## [1,]    1    1
## [2,]    1    2
class(cbind(vec1, vec2))
## [1] "matrix" "array" 

# data.frame() returns a data frame
data.frame(vec1, vec2)
##   vec1 vec2
## 1    1    1
## 2    1    2
class(data.frame(vec1, vec2))
## [1] "data.frame"

# data.frame(cbind()) is equivalent to data.frame() when only using vectors
data.frame(cbind(vec1, vec2))
##   vec1 vec2
## 1    1    1
## 2    1    2
class(data.frame(cbind(vec1, vec2)))
## [1] "data.frame"

# Vectors and matrices
mat1 <- matrix(1:4, nrow = 2)
mat2 <- matrix(1:4, nrow = 2, dimnames = list(1:2, c("col1", "col2")))

# cbind() leaves missing column names as empty strings
cbind(vec1, vec2, mat1, mat2)
##   vec1 vec2     col1 col2
## 1    1    1 1 3    1    3
## 2    1    2 2 4    2    4
class(cbind(vec1, vec2, mat1, mat2))
## [1] "matrix" "array" 

# data.frame() converts missing column names to X#
data.frame(vec1, vec2, mat1, mat2)
##   vec1 vec2 X1 X2 col1 col2
## 1    1    1  1  3    1    3
## 2    1    2  2  4    2    4
class(data.frame(vec1, vec2, mat1, mat2))
## [1] "data.frame"

# data.frame(cbind()) converts missing column names to V#
data.frame(cbind(vec1, vec2, mat1, mat2))
##   vec1 vec2 V3 V4 col1 col2
## 1    1    1  1  3    1    3
## 2    1    2  2  4    2    4
class(data.frame(cbind(vec1, vec2, mat1, mat2)))
## [1] "data.frame"
```

</details>

Lastly, when using `data.frame(cbind())` when the first argument is already a data frame, this ends up calling `cbind.data.frame()` (via S3 dispatch), which is just a simple wrapper around `data.frame()` anyways, so it is essentially calling `data.frame(data.frame())`:

```R
body(cbind.data.frame)
## data.frame(..., check.names = FALSE)
```

I was also worried about the effect of `stringsAsFactors`. In R 4.0 the default was changed to `FALSE`, but {gsDesign} supports R >= 3.5, when it was still `TRUE`. However, `data.frame(cbind())` and `data.frame()` behave the same in regards to the default value of `stringsAsFactors`.

https://github.com/keaven/gsDesign/blob/6b9153c93b49334f84eac45945e6572c3097ad7a/DESCRIPTION#L19

<details>
<summary>Example code combining a data frame with additional vectors
</summary>

```R
R.version.string
## [1] "R version 3.5.0 (2018-04-23)"

df1 <- data.frame(col1 = letters[1:3], col2 = 1:3, col3 = c(1.1, 1.2, 1.3))
vec1 <- letters[4:6]
vec2 <- 4:6
cbind(df1, vec1, vec2)
##   col1 col2 col3 vec1 vec2
## 1    a    1  1.1    d    4
## 2    b    2  1.2    e    5
## 3    c    3  1.3    f    6
data.frame(df1, vec1, vec2)
##   col1 col2 col3 vec1 vec2
## 1    a    1  1.1    d    4
## 2    b    2  1.2    e    5
## 3    c    3  1.3    f    6
data.frame(cbind(df1, vec1, vec2))
##   col1 col2 col3 vec1 vec2
## 1    a    1  1.1    d    4
## 2    b    2  1.2    e    5
## 3    c    3  1.3    f    6
str(cbind(df1, vec1, vec2))
## 'data.frame':   3 obs. of  5 variables:
##  $ col1: Factor w/ 3 levels "a","b","c": 1 2 3
##  $ col2: int  1 2 3
##  $ col3: num  1.1 1.2 1.3
##  $ vec1: Factor w/ 3 levels "d","e","f": 1 2 3
##  $ vec2: int  4 5 6
str(data.frame(df1, vec1, vec2))
## 'data.frame':   3 obs. of  5 variables:
##  $ col1: Factor w/ 3 levels "a","b","c": 1 2 3
##  $ col2: int  1 2 3
##  $ col3: num  1.1 1.2 1.3
##  $ vec1: Factor w/ 3 levels "d","e","f": 1 2 3
##  $ vec2: int  4 5 6
str(data.frame(cbind(df1, vec1, vec2)))
## 'data.frame':   3 obs. of  5 variables:
##  $ col1: Factor w/ 3 levels "a","b","c": 1 2 3
##  $ col2: int  1 2 3
##  $ col3: num  1.1 1.2 1.3
##  $ vec1: Factor w/ 3 levels "d","e","f": 1 2 3
##  $ vec2: int  4 5 6
```

</details>

Additionally, I did some spot checks with `browser()` to convince myself the results were unchanged:

https://github.com/keaven/gsDesign/blob/6b9153c93b49334f84eac45945e6572c3097ad7a/R/gsMethods.R#L623
https://github.com/keaven/gsDesign/blob/6b9153c93b49334f84eac45945e6572c3097ad7a/R/gsMethods.R#L656
https://github.com/keaven/gsDesign/blob/6b9153c93b49334f84eac45945e6572c3097ad7a/R/gsSurv.R#L1386

Lastly, I checked [_Advanced R_](http://adv-r.had.co.nz/Data-structures.html#data-frames), and it explicitly advises against the pattern `data.frame(cbind())`:

> It's a common mistake to try and create a data frame by `cbind()`ing vectors together. This doesn't work because `cbind()` will create a matrix unless one of the arguments is already a data frame. Instead use `data.frame()` directly:
>
> The conversion rules for `cbind()` are complicated and best avoided by ensuring all inputs are of the same type.