### PR TITLE
Update news for gsDesign 3.6.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.6.5
+Version: 3.6.6
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# gsDesign 3.6.6 (February, 2025)
+
+## New features
+
+- `gsBoundSummary()` gains a new argument `alpha` to assemble a summary
+  table with multiple efficacy boundaries (@keaven, #183).
+
+## Testing
+
+- Add essential unit tests for `gsSurvCalendar()` (@keaven, #178).
+- Refactor graphical tests with `vdiffr::expect_doppelganger()` (@nanxstats, #176)
+- Use `CODECOV_TOKEN` to fix code coverage uploads (@jdblischak, #179).
+
+## Documentation
+
+- Add more details to the parameter `r` for controlling numerical
+  integration grid points (@nanxstats, #181).
+
 # gsDesign 3.6.5 (November, 2024)
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gsDesign 3.6.6 (February, 2025)
+# gsDesign 3.6.6 (February 2025)
 
 ## New features
 
@@ -8,7 +8,7 @@
 ## Testing
 
 - Add essential unit tests for `gsSurvCalendar()` (@keaven, #178).
-- Refactor graphical tests with `vdiffr::expect_doppelganger()` (@nanxstats, #176)
+- Refactor graphical tests with `vdiffr::expect_doppelganger()` (@nanxstats, #176).
 - Use `CODECOV_TOKEN` to fix code coverage uploads (@jdblischak, #179).
 
 ## Documentation
@@ -16,7 +16,7 @@
 - Add more details to the parameter `r` for controlling numerical
   integration grid points (@nanxstats, #181).
 
-# gsDesign 3.6.5 (November, 2024)
+# gsDesign 3.6.5 (November 2024)
 
 ## Improvements
 
@@ -37,7 +37,7 @@
 - Add the `cph` role to the `Authors@R` field following best practices
   (@nanxstats, #166).
 
-# gsDesign 3.6.4 (July, 2024)
+# gsDesign 3.6.4 (July 2024)
 
 ## Improvements
 
@@ -60,7 +60,7 @@ We have made the spending function summary output more readable and informative.
 - Standardized vignette titles and headings by using h2 as the base level
   and adopting sentence case throughout (@nanxstats, #158).
 
-# gsDesign 3.6.3 (July, 2024)
+# gsDesign 3.6.3 (July 2024)
 
 ## New features
 
@@ -80,7 +80,7 @@ We have made the spending function summary output more readable and informative.
 - Added independent testing for `gsSurvCalendar()` (@myeongjong, #144).
 - Expanded test coverage for `gsBinomialExact()` (@menglu2, #143).
 
-# gsDesign 3.6.2 (April, 2024)
+# gsDesign 3.6.2 (April 2024)
 
 ## Documentation
 
@@ -96,7 +96,7 @@ We have made the spending function summary output more readable and informative.
 - Move independently programmed functions for validation as
   standard test helper files (#130).
 
-# gsDesign 3.6.1 (February, 2024)
+# gsDesign 3.6.1 (February 2024)
 
 ## New features
 
@@ -126,7 +126,7 @@ We have made the spending function summary output more readable and informative.
 - Fix equation syntax in plotting function documentation to render
   math symbols properly (@keaven, #118).
 
-# gsDesign 3.6.0 (November, 2023)
+# gsDesign 3.6.0 (November 2023)
 
 ## Breaking changes
 
@@ -153,7 +153,7 @@ We have made the spending function summary output more readable and informative.
 - Update the vaccine efficacy, Poisson mixture model, and toInteger vignettes (#105).
 - Standardize and improve roxygen2 documentation (#104).
 
-# gsDesign 3.5.0 (July, 2023)
+# gsDesign 3.5.0 (July 2023)
 
 - `sfPower()` now allows a wider parameter range (0, 15].
 - `toInteger()` function added to convert `gsDesign` or `gsSurv` classes
@@ -171,14 +171,14 @@ We have made the spending function summary output more readable and informative.
   now directly pointing to the gsDesign technical manual bookdown project.
 - Introduced a new hex sticker logo.
 
-# gsDesign 3.4.0 (October, 2022)
+# gsDesign 3.4.0 (October 2022)
 
 - Removed restriction on `gsCP()` interim test statistic zi (#63).
 - Removed gMCP dependency. Updated vignettes and linked to vignettes in gMCPLite (#69).
 - Added deprecation warning to `hGraph()` and suggested using `gMCPLite::hGraph()` instead (#70).
 - Moved ggplot2 from `Depends` to `Imports` (#56).
 
-# gsDesign 3.3.0 (May, 2022)
+# gsDesign 3.3.0 (May 2022)
 
 - Addition of vignettes
   - Demonstrate cure model and calendar-based analysis timing for time-to-event endpoint design
@@ -187,7 +187,7 @@ We have made the spending function summary output more readable and informative.
 - Fixed error in sfStep
 - Updates to reduce R CMD check and other minor issues
 
-# gsDesign 3.2.2 (January, 2022)
+# gsDesign 3.2.2 (January 2022)
 
 - Use `inherits()` instead of `is()` to determine if an object is an instance of a class, when appropriate
 - Correctly close graphics device in unit tests to avoid plot output file not found issues
@@ -195,20 +195,20 @@ We have made the spending function summary output more readable and informative.
 - Minor fix to nBinomial() when odds-ratio scale specified to resolve user issue
 - Minor changes to vignettes
 
-# gsDesign 3.2.1 (July, 2021)
+# gsDesign 3.2.1 (July 2021)
 
 - Changed gt package usage in a vignette due to deprecated gt function
 - Replied to minor comments from CRAN reviewer (no functionality impact)
 - Minor update to DESCRIPTION citing Jennison and Turnbull reference
 
-# gsDesign 3.2.0 (January, 2021)
+# gsDesign 3.2.0 (January 2021)
 
 - Substantially updated unit testing to increase code coverage above 80%
 - Updated error checking messages to print function where check fails
 - Removed dependencies on plyr packages
 - Updated github actions
 
-# gsDesign 3.1.1 (May, 2020)
+# gsDesign 3.1.1 (May 2020)
 
 - Vignettes updated
 - Added `hGraph()` to support ggplot2 versions of multiplicity graphs
@@ -218,7 +218,7 @@ We have made the spending function summary output more readable and informative.
 - Updated continuous integration
 - Updated license
 
-# gsDesign 3.1.0 (April, 2019)
+# gsDesign 3.1.0 (April 2019)
 
 - Addition of pkgdown web site
 - Updated unit testing to from RUnit to testthat
@@ -228,13 +228,13 @@ We have made the spending function summary output more readable and informative.
 - Added `sequentialPValue` function
 - Backwards compatible addition of spending time capabilities to `gsDesign` and `gsSurv`
 
-# gsDesign 3.0-5 (January, 2018)
+# gsDesign 3.0-5 (January 2018)
 
 - Registered C routines
 - Fixed "gsbound"
 - Replaced "array" by "rep" calls to avoid `R CMD check` warnings
 
-# gsDesign 3.0-4 (September, 2017)
+# gsDesign 3.0-4 (September 2017)
 
 - First Github-based release
 - Cleaned up documentation for `nBinomial1Sample()`
@@ -245,19 +245,19 @@ We have made the spending function summary output more readable and informative.
 
 - Introduced spending time as a separate concept from information time to enable concepts such as calendar-based spending functions. The only user function changed is the `gsDesign()` function and the change is the addition of the parameters `usTime` and `lsTime`; default behavior is backwards compatible.
 
-# gsDesign 3.0-2 (February, 2016)
+# gsDesign 3.0-2 (February 2016)
 
 - Simplified conditional power section of gsDesignManual.pdf in doc directory
 - Corrected basic calculation in `gsCP()`
 - Eliminated deprecated ggplot2 function `opts()`
 
-# gsDesign 3.0-1 (January, 2016)
+# gsDesign 3.0-1 (January 2016)
 
 - More changes to comply with R standards (in NAMESPACE - `importFrom` statements - and DESCRIPTION - adding plyr to imports) ensuring appropriate references.
 - Deleted link in documentation that no longer exists (gsBinomialExact.Rd).
 - Last planned RForge-based release; moving to Github.
 
-# gsDesign 3.0-0 (December, 2015)
+# gsDesign 3.0-0 (December 2015)
 
 - Updated xtable extension to meet R standards for extensions.
 - Fixed `xtable.gsSurv` and `print.gsSurv` to work with 1-sided designs
@@ -270,7 +270,7 @@ We have made the spending function summary output more readable and informative.
 
 - Minor edit to package description to comply with R standards
 
-# gsDesign 2.9-3 (November, 2014)
+# gsDesign 2.9-3 (November 2014)
 
 - Added `sfTrimmed` as likely preferred spending function approach to skipping early or all interim efficacy analyses; this also can adjust bound when final analysis is performed with less than maximum planned information. Updated `help(sfTrimmed)` to demonstrate these capabilities.
 - Added `sfGapped`, which is primarily intended to eliminate futility analyses later in a study; see `help(sfGapped)` for an example


### PR DESCRIPTION
This PR bumps the version number to 3.6.6 and updates the changelog.