### PR TITLE
Set `fig.ext` in vignettes so SVG images can render in pkgdown

### DIFF
--- a/man/ssrCP.Rd
+++ b/man/ssrCP.Rd
@@ -301,9 +301,9 @@ xxFisher <- ssrCP(
 )
 # combine data frames from these designs
 y <- rbind(
-  data.frame(cbind(xx$dat, Test = "Normal combination")),
-  data.frame(cbind(xxZ$dat, Test = "Sufficient statistic")),
-  data.frame(cbind(xxFisher$dat, Test = "Fisher combination"))
+  data.frame(xx$dat, Test = "Normal combination"),
+  data.frame(xxZ$dat, Test = "Sufficient statistic"),
+  data.frame(xxFisher$dat, Test = "Fisher combination")
 )
 # plot stage 2 statistic required for positive combination test
 ggplot2::ggplot(data = y, ggplot2::aes(x = z1, y = z2, col = Test)) + 
@@ -321,8 +321,8 @@ xxtheta1 <- ssrCP(
 )
 # combine data frames for the 2 designs
 y <- rbind(
-  data.frame(cbind(xx$dat, "CP effect size" = "Obs. at IA")),
-  data.frame(cbind(xxtheta1$dat, "CP effect size" = "Alt. hypothesis"))
+  data.frame(xx$dat, "CP effect size" = "Obs. at IA"),
+  data.frame(xxtheta1$dat, "CP effect size" = "Alt. hypothesis")
 )
 # plot stage 2 sample size by design
 ggplot2::ggplot(data = y, ggplot2::aes(x = z1, y = n2, col = CP.effect.size)) + 
@@ -332,8 +332,8 @@ y1 <- Power.ssrCP(x = xx)
 y2 <- Power.ssrCP(x = xxtheta1)
 # combine data frames for the 2 designs
 y3 <- rbind(
-  data.frame(cbind(y1, "CP effect size" = "Obs. at IA")),
-  data.frame(cbind(y2, "CP effect size" = "Alt. hypothesis"))
+  data.frame(y1, "CP effect size" = "Obs. at IA"),
+  data.frame(y2, "CP effect size" = "Alt. hypothesis")
 )
 # plot expected sample size by design and effect size
 ggplot2::ggplot(data = y3, ggplot2::aes(x = delta, y = en, col = CP.effect.size)) + 

--- a/vignettes/ConditionalErrorSpending.Rmd
+++ b/vignettes/ConditionalErrorSpending.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7,
   fig.asp = 1,
   fig.align = "center",

--- a/vignettes/ConditionalPowerPlot.Rmd
+++ b/vignettes/ConditionalPowerPlot.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/GentleIntroductionToGSD.Rmd
+++ b/vignettes/GentleIntroductionToGSD.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = FALSE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/PoissonMixtureModel.Rmd
+++ b/vignettes/PoissonMixtureModel.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/SpendingFunctionOverview.Rmd
+++ b/vignettes/SpendingFunctionOverview.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.align = "center",
   out.width = "80%"

--- a/vignettes/SurvivalOverview.Rmd
+++ b/vignettes/SurvivalOverview.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/VaccineEfficacy.Rmd
+++ b/vignettes/VaccineEfficacy.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = FALSE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/binomialSPRTExample.Rmd
+++ b/vignettes/binomialSPRTExample.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/gsDesignPackageOverview.Rmd
+++ b/vignettes/gsDesignPackageOverview.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/gsSurvBasicExamples.Rmd
+++ b/vignettes/gsSurvBasicExamples.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",

--- a/vignettes/nNormal.Rmd
+++ b/vignettes/nNormal.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   dev = "svg",
+  fig.ext = "svg",
   fig.width = 7.2916667,
   fig.asp = 0.618,
   fig.align = "center",


### PR DESCRIPTION
Fixes #191 

As a follow-up to #188, this PR sets the knitr chunk option `fig.ext = "svg"` in vignettes. As a workaround, this allows the SVG images to load properly when being rendered in the pkgdown website.