### PR TITLE
Add Merck ROR ID to package metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Author: Keaven Anderson [aut, cre], Merck & Co., Inc., Rahway, NJ, USA and its a
 Maintainer: Keaven Anderson <keaven_anderson@merck.com>
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),
-    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph",
+           comment = c(ROR = "02891sr49"))
     )
 Description: Derives group sequential clinical trial designs and describes
     their properties. Particular focus on time-to-event, binary, and

--- a/man/gsDesign-package.Rd
+++ b/man/gsDesign-package.Rd
@@ -23,7 +23,7 @@ Useful links:
 
 Other contributors:
 \itemize{
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
 }
 
 }


### PR DESCRIPTION
CRAN and {pkgdown} [2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now support linking to an organization's ROR ID: https://ror.org/02891sr49

cc: @nanxstats
xref: https://github.com/Merck/simtrial/pull/326, https://github.com/Merck/gsDesign2/pull/544