### PR TITLE
Revert manifest file changes from #198

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,3 @@ TODO
 docs/
 vignettes/*.html
 vignettes/*.R
-# Build artifacts
-*.tar.gz
-*.Rcheck/
-.Rcheck/
-src/symbols.rds
-# Temporary directories
-tryANewOne/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,6 @@
 Package: gsDesign
 Version: 3.6.7
 Title: Group Sequential Design
-Author: Keaven Anderson [aut, cre], Merck & Co., Inc., Rahway, NJ, USA and its affiliates [cph]
-Maintainer: Keaven Anderson <keaven_anderson@merck.com>
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),
     person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph",


### PR DESCRIPTION
This PR reverts the random changes made to manifest files (`DESCRIPTION`, `.gitignore`) in #198 as the changes are unnecessary.