### PR TITLE
Update news for gsDesign 3.6.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.6.8
+Version: 3.6.9
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,17 @@
 
 ## Documentation
 
-- New vignette `vignette("binomialTwoSample")` provides a practical guide for
-  binomial two-arm trial design and analysis (@keaven, #202). It covers
-  superiority, non-inferiority, and super-superiority designs with both
-  asymptotic and simulation methods. Also includes examples for power,
-  sample size, and confidence interval calculations.
+- Added new vignette `vignette("binomialTwoSample")` for binomial two-arm
+  trial design and analysis (@keaven, #202). Covers superiority,
+  non-inferiority, and super-superiority designs using risk-difference methods.
+  Includes sample size calculations, power analysis, and protocol wording with
+  both asymptotic approximations and simulation approaches.
 
 ## New features
 
-- New exported function `binomialPowerTable()` generates power tables across
-  ranges of control rates and treatment effects. Supports both analytical
-  calculations and fast simulation for exact results.
+- New function `binomialPowerTable()` generates power tables across control
+  rates and treatment effects. Supports both analytical calculations and
+  fast simulation for exact results.
 
 # gsDesign 3.6.8 (May 2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# gsDesign 3.6.9 (June 2025)
+
+## Documentation
+
+- New vignette `vignette("binomialTwoSample")` provides a practical guide for
+  binomial two-arm trial design and analysis (@keaven, #202). It covers
+  superiority, non-inferiority, and super-superiority designs with both
+  asymptotic and simulation methods. Also includes examples for power,
+  sample size, and confidence interval calculations.
+
+## New features
+
+- New exported function `binomialPowerTable()` generates power tables across
+  ranges of control rates and treatment effects. Supports both analytical
+  calculations and fast simulation for exact results.
+
 # gsDesign 3.6.8 (May 2025)
 
 ## Bug fixes


### PR DESCRIPTION
This PR bumps the version number to 3.6.9 and updates the changelog.