### PR TITLE
Reduce visual regression test output verbosity

### DIFF
--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -893,7 +893,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
                            col = .data$Bound,
                            lty = .data$Analysis)
                          ) + 
-      ggplot2::geom_line(size = lwd) + 
+      ggplot2::geom_line(lwd = lwd) + 
       ggplot2::ylab(ylab) +
       ggplot2::guides(color = ggplot2::guide_legend(title = "Probability")) + 
       ggplot2::xlab(xlab) +

--- a/tests/testthat/test-independent-test-plot.gsDesign.R
+++ b/tests/testthat/test-independent-test-plot.gsDesign.R
@@ -3,7 +3,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 1 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 1 base TRUE",
-    plot.gsDesign(x, plottype = 1, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 1, base = TRUE))
   )
 })
 
@@ -12,7 +12,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 1 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 1 base FALSE",
-    plot.gsDesign(x, plottype = 1, base = FALSE)
+    capture.output(plot.gsDesign(x, plottype = 1, base = FALSE))
   )
 })
 
@@ -21,7 +21,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype = power and 
 
   vdiffr::expect_doppelganger(
     "plottype power base FALSE",
-    plot.gsDesign(x, plottype = "power", base = FALSE)
+    capture.output(plot.gsDesign(x, plottype = "power", base = FALSE))
   )
 })
 
@@ -30,7 +30,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 2 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 2 base TRUE",
-    plot.gsDesign(x, plottype = 2, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 2, base = TRUE))
   )
 })
 
@@ -39,7 +39,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 3 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 3 base TRUE",
-    plot.gsDesign(x, plottype = 3, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 3, base = TRUE))
   )
 })
 
@@ -48,7 +48,7 @@ test_that("plot.gsDesign: graphs are correctly rendered for plottype 4 and base 
 
   vdiffr::expect_doppelganger(
     "plottype 4 base FALSE",
-    plot.gsDesign(x, plottype = 4, base = FALSE)
+    capture.output(plot.gsDesign(x, plottype = 4, base = FALSE))
   )
 })
 
@@ -57,7 +57,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 4 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 4 base TRUE",
-    plot.gsDesign(x, plottype = 4, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 4, base = TRUE))
   )
 })
 
@@ -66,7 +66,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 5 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 5 base TRUE",
-    plot.gsDesign(x, plottype = 5, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 5, base = TRUE))
   )
 })
 
@@ -75,7 +75,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 6 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 6 base FALSE",
-    plot.gsDesign(x, plottype = 6, base = FALSE)
+    capture.output(plot.gsDesign(x, plottype = 6, base = FALSE))
   )
 })
 
@@ -84,7 +84,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 6 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 6 base TRUE",
-    plot.gsDesign(x, plottype = 6, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 6, base = TRUE))
   )
 })
 
@@ -93,7 +93,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 7 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 7 base TRUE",
-    plot.gsDesign(x, plottype = 7, base = TRUE)
+    capture.output(plot.gsDesign(x, plottype = 7, base = TRUE))
   )
 })
 
@@ -106,7 +106,7 @@ test_that("plot.gsDesign: plots are correctly rendered for gsSurv objects and ba
 
   vdiffr::expect_doppelganger(
     "gsSurv base TRUE",
-    plot.gsDesign(z, plottype = 2, base = TRUE)
+    capture.output(plot.gsDesign(z, plottype = 2, base = TRUE))
   )
 })
 
@@ -119,7 +119,7 @@ test_that("plot.gsDesign: plots are correctly rendered for gSurv objects and bas
 
   vdiffr::expect_doppelganger(
     "gsSurv base FALSE",
-    plot.gsDesign(z, plottype = 2, base = FALSE)
+    capture.output(plot.gsDesign(z, plottype = 2, base = FALSE))
   )
 })
 
@@ -128,6 +128,6 @@ test_that("plot.gsDesign: plots are correctly rendered for test.type 1 and plott
 
   vdiffr::expect_doppelganger(
     "test type 1 plottype 2",
-    plot.gsDesign(y, plottype = 2, base = TRUE)
+    capture.output(plot.gsDesign(y, plottype = 2, base = TRUE))
   )
 })

--- a/tests/testthat/test-independent-test-plot.gsDesign.R
+++ b/tests/testthat/test-independent-test-plot.gsDesign.R
@@ -12,7 +12,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 1 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 1 base FALSE",
-    capture.output(plot.gsDesign(x, plottype = 1, base = FALSE))
+    plot.gsDesign(x, plottype = 1, base = FALSE)
   )
 })
 
@@ -21,7 +21,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype = power and 
 
   vdiffr::expect_doppelganger(
     "plottype power base FALSE",
-    capture.output(plot.gsDesign(x, plottype = "power", base = FALSE))
+    plot.gsDesign(x, plottype = "power", base = FALSE)
   )
 })
 
@@ -48,7 +48,7 @@ test_that("plot.gsDesign: graphs are correctly rendered for plottype 4 and base 
 
   vdiffr::expect_doppelganger(
     "plottype 4 base FALSE",
-    capture.output(plot.gsDesign(x, plottype = 4, base = FALSE))
+    plot.gsDesign(x, plottype = 4, base = FALSE)
   )
 })
 
@@ -75,7 +75,7 @@ test_that("plot.gsDesign: plots are correctly rendered for plottype 6 and base s
 
   vdiffr::expect_doppelganger(
     "plottype 6 base FALSE",
-    capture.output(plot.gsDesign(x, plottype = 6, base = FALSE))
+    plot.gsDesign(x, plottype = 6, base = FALSE)
   )
 })
 
@@ -119,7 +119,7 @@ test_that("plot.gsDesign: plots are correctly rendered for gSurv objects and bas
 
   vdiffr::expect_doppelganger(
     "gsSurv base FALSE",
-    capture.output(plot.gsDesign(z, plottype = 2, base = FALSE))
+    plot.gsDesign(z, plottype = 2, base = FALSE)
   )
 })
 

--- a/tests/testthat/test-independent-test-plot.gsProbability.R
+++ b/tests/testthat/test-independent-test-plot.gsProbability.R
@@ -4,62 +4,62 @@ y <- gsProbability(k = 5, theta = seq(0, .5, .025), x$n.I, x$lower$bound, x$uppe
 test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and base set to TRUE", {
   vdiffr::expect_doppelganger(
     "plottype 1 base TRUE",
-    plot.gsProbability(y, plottype = 1, base = TRUE)
+    capture.output(plot.gsProbability(y, plottype = 1, base = TRUE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 1 base FALSE",
-    plot.gsProbability(y, plottype = 1, base = FALSE)
+    capture.output(plot.gsProbability(y, plottype = 1, base = FALSE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype power and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype power base FALSE",
-    plot.gsProbability(y, plottype = "power", base = FALSE)
+    capture.output(plot.gsProbability(y, plottype = "power", base = FALSE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 2 and base set to TRUE", {
   vdiffr::expect_doppelganger(
     "plottype 2 base TRUE",
-    plot.gsProbability(y, plottype = 2, base = TRUE)
+    capture.output(plot.gsProbability(y, plottype = 2, base = TRUE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 4 base FALSE",
-    plot.gsProbability(y, plottype = 4, base = FALSE)
+    capture.output(plot.gsProbability(y, plottype = 4, base = FALSE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and base set to TRUE", {
   vdiffr::expect_doppelganger(
     "plottype 4 base TRUE",
-    plot.gsProbability(x, plottype = 4, base = TRUE)
+    capture.output(plot.gsProbability(x, plottype = 4, base = TRUE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 6 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 6 base FALSE",
-    plot.gsProbability(y, plottype = 6, base = FALSE)
+    capture.output(plot.gsProbability(y, plottype = 6, base = FALSE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 6 and base set to TRUE", {
   vdiffr::expect_doppelganger(
     "plottype 6 base TRUE",
-    plot.gsProbability(y, plottype = 6, base = TRUE)
+    capture.output(plot.gsProbability(y, plottype = 6, base = TRUE))
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype 7 and base set to TRUE", {
   vdiffr::expect_doppelganger(
     "plottype 7 base TRUE",
-    plot.gsProbability(y, plottype = 7, base = TRUE)
+    capture.output(plot.gsProbability(y, plottype = 7, base = TRUE))
   )
 })

--- a/tests/testthat/test-independent-test-plot.gsProbability.R
+++ b/tests/testthat/test-independent-test-plot.gsProbability.R
@@ -11,14 +11,14 @@ test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and b
 test_that("plot.gsProbability: plots are correctly rendered for plottype 1 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 1 base FALSE",
-    capture.output(plot.gsProbability(y, plottype = 1, base = FALSE))
+    plot.gsProbability(y, plottype = 1, base = FALSE)
   )
 })
 
 test_that("plot.gsProbability: plots are correctly rendered for plottype power and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype power base FALSE",
-    capture.output(plot.gsProbability(y, plottype = "power", base = FALSE))
+    plot.gsProbability(y, plottype = "power", base = FALSE)
   )
 })
 
@@ -32,7 +32,7 @@ test_that("plot.gsProbability: plots are correctly rendered for plottype 2 and b
 test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 4 base FALSE",
-    capture.output(plot.gsProbability(y, plottype = 4, base = FALSE))
+    plot.gsProbability(y, plottype = 4, base = FALSE)
   )
 })
 
@@ -46,7 +46,7 @@ test_that("plot.gsProbability: plots are correctly rendered for plottype 4 and b
 test_that("plot.gsProbability: plots are correctly rendered for plottype 6 and base set to FALSE", {
   vdiffr::expect_doppelganger(
     "plottype 6 base FALSE",
-    capture.output(plot.gsProbability(y, plottype = 6, base = FALSE))
+    plot.gsProbability(y, plottype = 6, base = FALSE)
   )
 })
 


### PR DESCRIPTION
It looks like vdiffr will force a `print()` action on the plotting expression. As a side effect, this will print out all the objects used in `plot.gsDesign()` and `plot.gsProbability()` visual regression tests for **base graphics**, which makes the log way too verbose. In comparison, the ggplot2 plotting expressions are ok (objects are not printed out).

This PR wraps `capture.output()` around the base graphics plotting expressions to avoid the verbosity.

Interestingly, we can't wrap `capture.output()` on ggplot2 expressions because that will change the theme to a minimal one and thus change the SVG snapshot.

Also fixes a test warning on using `linewidth` instead of `size` for `geom_line()` calls in ggplot2 > 3.4.0.