### PR TITLE
Link `vignette("nNormal")` on `help(nNormal)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Suggests:
     vdiffr
 VignetteBuilder:
     knitr
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/nNormal.R
+++ b/R/nNormal.R
@@ -73,7 +73,9 @@
 #' # non-inferiority assuming a better effect than null
 #' nNormal(delta1 = .5, delta0 = -.1, sd = 1.2)
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
-#' @seealso \code{vignette("gsDesignPackageOverview")}
+#' @seealso See \code{vignette("nNormal")} for the full story, including the
+#' derivation of the sample size formula, power checks via simulation,
+#' and a group sequential design example.
 #' @references 
 #' Jennison C and Turnbull BW (2000), \emph{Group Sequential
 #' Methods with Applications to Clinical Trials}. Boca Raton: Chapman and Hall.

--- a/man/gsDesign-package.Rd
+++ b/man/gsDesign-package.Rd
@@ -23,7 +23,7 @@ Useful links:
 
 Other contributors:
 \itemize{
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (\href{https://ror.org/02891sr49}{ROR}) [copyright holder]
 }
 
 }

--- a/man/nNormal.Rd
+++ b/man/nNormal.Rd
@@ -109,7 +109,9 @@ Snedecor GW and Cochran WG (1989), Statistical Methods. 8th ed. Ames, IA:
 Iowa State University Press.
 }
 \seealso{
-\code{vignette("gsDesignPackageOverview")}
+See \code{vignette("nNormal")} for the full story, including the
+derivation of the sample size formula, power checks via simulation,
+and a group sequential design example.
 }
 \author{
 Keaven Anderson \email{keaven_anderson@merck.com}


### PR DESCRIPTION
Closes #219 

This PR updates the `@seealso` section on the function reference page of `nNormal()` to point the user to the nNormal vignette which has a nice and full explanation of how it works.