### PR TITLE
Update `as_gt()` snapshot for gt 1.1.0

### DIFF
--- a/tests/testthat/_snaps/independent-test-as_gt.md
+++ b/tests/testthat/_snaps/independent-test-as_gt.md
@@ -2,10 +2,10 @@
 
     \begin{table}[t]
     \caption*{
-    {\large Operating Characteristics for the Truncated SPRT Design} \\ 
-    {\small Assumes trial evaluated sequentially after each response}
+    {\fontsize{20}{25}\selectfont  Operating Characteristics for the Truncated SPRT Design\fontsize{12}{15}\selectfont } \\ 
+    {\fontsize{14}{17}\selectfont  Assumes trial evaluated sequentially after each response\fontsize{12}{15}\selectfont }
     } 
-    \fontsize{12.0pt}{14.4pt}\selectfont
+    \fontsize{12.0pt}{14.0pt}\selectfont
     \begin{tabular*}{\linewidth}{@{\extracolsep{\fill}}rrrr}
     \toprule
      & \multicolumn{2}{c}{Probability of crossing} &  \\ 


### PR DESCRIPTION
This PR updates the snapshot output for `as_gt()` tests so the all CI/CD workflows can pass.

This is due to upstream font size changes in LaTeX outputs of gt 1.1.0: https://github.com/rstudio/gt/pull/1995