### PR TITLE
Add manual workflow_dispatch trigger to `R CMD check` workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 


### PR DESCRIPTION
This makes it easier to test a feature branch on a fork prior to submitting a Pull Request.

The other two pipelines already have the `workflow_dispatch` trigger:

https://github.com/keaven/gsDesign/blob/a60c30bf6be3553719128198d7cb9f3403993c09/.github/workflows/pkgdown.yaml#L9
https://github.com/keaven/gsDesign/blob/a60c30bf6be3553719128198d7cb9f3403993c09/.github/workflows/test-coverage.yaml#L6