### PR TITLE
feat: Allow calendar time display in gsBoundSummary for non-gsSurv objects

### DIFF
--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -425,7 +425,14 @@ gsBoundSummary0 <- function(
   if (!("gsSurv" %in% class(x))) {
     if (x$n.fix > 1) N <- ceiling(x$n.I) else N <- round(x$n.I, 2)
     if (Nname == "Information") N <- round(x$n.I, 2)
-    nstat <- 2
+    # Check if calendar time T is provided (for non-gsSurv objects like gsNB)
+    if (!is.null(x$T)) {
+      nstat <- 3
+      Time <- round(x$T, tdigits)
+      statframe[statframe$Value == statframe$Value[3], ]$Analysis <- paste(timename, ": ", as.character(Time), sep = "")
+    } else {
+      nstat <- 2
+    }
   } else {
     nstat <- 4
     statframe[statframe$Value == statframe$Value[3], ]$Analysis <- paste("Events:", ceiling(x$n.I))


### PR DESCRIPTION
Summary

This PR modifies gsBoundSummary0 to check for the presence of x$T rather than only checking if the object is of class gsSurv. This allows other gsDesign-derived classes (like gsNB from the gsDesignNB package) to display calendar time in the bound summary table.

Changes

Added check for !is.null(x$T) in non-gsSurv branch
When T is present, nstat is set to 3 (Z, N, Time) instead of 2 (Z, N)
Calendar time is displayed using the timename parameter
Backward Compatibility

This is a backward-compatible change:

Existing gsSurv objects continue to work as before (with nstat=4 showing Events and Time)
Existing gsDesign objects without T continue to work with nstat=2
Motivation

The gsDesignNB package creates gsNB objects that extend gsDesign and include analysis times (stored in T). With this change, gsBoundSummary() can display the calendar time for these objects without needing to inherit from gsSurv.

Testing

R CMD check passes with no errors or warnings
Click "Create pull request" to submit it for review