### PR TITLE
Restrict `gsBoundSummary()` calendar time to `gsNB` objects

### DIFF
--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -426,7 +426,7 @@ gsBoundSummary0 <- function(
     if (x$n.fix > 1) N <- ceiling(x$n.I) else N <- round(x$n.I, 2)
     if (Nname == "Information") N <- round(x$n.I, 2)
     # Check if calendar time T is provided (for non-gsSurv objects like gsNB)
-    if (!is.null(x$T)) {
+    if (inherits(x, "gsNB") && !is.null(x$T)) {
       nstat <- 3
       Time <- round(x$T, tdigits)
       statframe[statframe$Value == statframe$Value[3], ]$Analysis <- paste(timename, ": ", as.character(Time), sep = "")


### PR DESCRIPTION
Fixes #230

This is a follow up to #229 

This PR improves non-gsSurv calendar-time handling in `gsBoundSummary()` to use a more specific condition `inherits(x, "gsNB") && !is.null(x$T)` to avoid false positives from other gsDesign objects that may carry `T`. This keeps the existing gsSurv behavior intact while enabling calendar time display for **gsNB designs** that **supply analysis times**.

If we add other design types in the future, the logic can be extended as needed.