### PR TITLE
Update gt snapshots due to gt 1.3.0 changes

### DIFF
--- a/tests/testthat/_snaps/independent-test-as_gt.md
+++ b/tests/testthat/_snaps/independent-test-as_gt.md
@@ -8,7 +8,7 @@
     \fontsize{12.0pt}{14.0pt}\selectfont
     \begin{tabular*}{\linewidth}{@{\extracolsep{\fill}}rrrr}
     \toprule
-     & \multicolumn{2}{c}{Probability of crossing} &  \\ 
+     & \multicolumn{2}{c}{{Probability of crossing}} &  \\ 
     \cmidrule(lr){2-3}
     Underlying<br>AE rate & low rate & high rate & Average<br>sample size \\ 
     \midrule\addlinespace[2.5pt]


### PR DESCRIPTION
This PR reruns the tests and updates the gt snapshots so the tests can pass.

This is because gt 1.3.0 (released 2026-01-22) includes LaTeX output changes that makes the output bitwise different.