### PR TITLE
C: centralize `sqrt(2 * pi)` constant and remove normal density magic numbers

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -1,4 +1,0 @@
-#include "gsDesign.h"
-
-/* sqrt(2 * pi), used to scale the standard normal density. */
-const double gs_sqrt_2pi = 2.506628274631;

--- a/src/constants.c
+++ b/src/constants.c
@@ -1,0 +1,4 @@
+#include "gsDesign.h"
+
+/* sqrt(2 * pi), used to scale the standard normal density. */
+const double gs_sqrt_2pi = 2.506628274631;

--- a/src/gsDesign.h
+++ b/src/gsDesign.h
@@ -1,3 +1,9 @@
+#ifndef GSDESIGN_H
+#define GSDESIGN_H
+
+/* sqrt(2 * pi): shared scale factor for the standard normal density. */
+extern const double gs_sqrt_2pi;
+
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
              double *probhi, double *xtol, int *xr, int *retval, int *printerr);
 void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
@@ -8,3 +14,5 @@ void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
                double *a, double *b, double *xz, int *zlen, int *xr);
 void stdnorpts(int *r, double *bounds, double *z, double *w);
+
+#endif

--- a/src/gsDesign.h
+++ b/src/gsDesign.h
@@ -1,8 +1,8 @@
 #ifndef GSDESIGN_H
 #define GSDESIGN_H
 
-/* sqrt(2 * pi): shared scale factor for the standard normal density. */
-extern const double gs_sqrt_2pi;
+/* 1 / sqrt(2 * pi): shared scale factor for standard normal density. */
+static const double gs_inv_sqrt_2pi = 0.3989422804014327;
 
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
              double *probhi, double *xtol, int *xr, int *retval, int *printerr);

--- a/src/gsbound.c
+++ b/src/gsbound.c
@@ -42,7 +42,7 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
   double adelta, bdelta, tol;
   /* note: should allocate zwk & wwk dynamically...*/
   double zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000], hwk2[1000],
-      *z1, *z2, *w1, *w2, *h, *h2, *tem, rt2pi;
+      *z1, *z2, *w1, *w2, *h, *h2, *tem;
   void h1(double, int, double *, double, double *, double *);
   void hupdate(double, double *, int, double, double *, double *, int, double,
                double *, double *);
@@ -50,7 +50,6 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
   r = xr[0];
   nanal = xnanal[0];
   tol = xtol[0];
-  rt2pi = 2.506628274631;
   /* compute bounds at 1st interim analysis using inverse normal */
   if (nanal < 1 || r < 1 || r > MAXR) {
     retval[0] = 1;
@@ -111,8 +110,8 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
         xhi = (z1[ii] * rtIkm1 - btem * rtIk) / rtdeltak;
         plo += h[ii] * pnorm(xlo, 0., 1., 0, 0);
         phi += h[ii] * pnorm(xhi, 0., 1., 1, 0);
-        dplo += h[ii] * exp(-xlo * xlo / 2) / rt2pi * rtIk / rtdeltak;
-        dphi -= h[ii] * exp(-xhi * xhi / 2) / rt2pi * rtIk / rtdeltak;
+        dplo += h[ii] * exp(-xlo * xlo / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
+        dphi -= h[ii] * exp(-xhi * xhi / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
       }
       /* use 1st order Taylor's series to update boundaries */
       /* maximum allowed change is 1 */

--- a/src/gsbound.c
+++ b/src/gsbound.c
@@ -110,8 +110,8 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
         xhi = (z1[ii] * rtIkm1 - btem * rtIk) / rtdeltak;
         plo += h[ii] * pnorm(xlo, 0., 1., 0, 0);
         phi += h[ii] * pnorm(xhi, 0., 1., 1, 0);
-        dplo += h[ii] * exp(-xlo * xlo / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
-        dphi -= h[ii] * exp(-xhi * xhi / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
+        dplo += h[ii] * exp(-xlo * xlo / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
+        dphi -= h[ii] * exp(-xhi * xhi / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
       }
       /* use 1st order Taylor's series to update boundaries */
       /* maximum allowed change is 1 */

--- a/src/gsbound1.c
+++ b/src/gsbound1.c
@@ -112,7 +112,7 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
         xlo = (z1[ii] * rtIkm1 - a[i] * rtIk + theta * (I[i] - I[i - 1])) /
               rtdeltak;
         plo += pnorm(xlo, 0., 1., 0, 0) * h[ii];
-        dphi -= h[ii] * exp(-xhi * xhi / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
+        dphi -= h[ii] * exp(-xhi * xhi / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
         if (DEBUG)
           Rprintf("m1=%d ii=%d xhi=%lf phi=%lf xlo=%lf plo=%lf dphi=%lf\n", m1,
                   ii, xhi, phi, xlo, plo, dphi);

--- a/src/gsbound1.c
+++ b/src/gsbound1.c
@@ -112,7 +112,7 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
         xlo = (z1[ii] * rtIkm1 - a[i] * rtIk + theta * (I[i] - I[i - 1])) /
               rtdeltak;
         plo += pnorm(xlo, 0., 1., 0, 0) * h[ii];
-        dphi -= h[ii] * exp(-xhi * xhi / 2) / 2.506628275 * rtIk / rtdeltak;
+        dphi -= h[ii] * exp(-xhi * xhi / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
         if (DEBUG)
           Rprintf("m1=%d ii=%d xhi=%lf phi=%lf xlo=%lf plo=%lf dphi=%lf\n", m1,
                   ii, xhi, phi, xlo, plo, dphi);

--- a/src/gsdensity.c
+++ b/src/gsdensity.c
@@ -51,7 +51,7 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
       mu = sqrt(I[0]) * xtheta[k];
       for (i = 0; i < nz; i++) {
         z = xz[i] - mu;
-        den[j++] = exp(-z * z / 2) / 2.506628275;
+        den[j++] = exp(-z * z / 2) / gs_sqrt_2pi;
       }
     }
     return;

--- a/src/gsdensity.c
+++ b/src/gsdensity.c
@@ -51,7 +51,7 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
       mu = sqrt(I[0]) * xtheta[k];
       for (i = 0; i < nz; i++) {
         z = xz[i] - mu;
-        den[j++] = exp(-z * z / 2) / gs_sqrt_2pi;
+        den[j++] = exp(-z * z / 2) * gs_inv_sqrt_2pi;
       }
     }
     return;

--- a/src/h1.c
+++ b/src/h1.c
@@ -1,3 +1,4 @@
+#include "gsDesign.h"
 #include <math.h>
 #include <stdio.h>
 
@@ -22,6 +23,6 @@ void h1(double theta, int m, double *wgt, double I, double *z, double *h) {
   mu = theta * sqrt(I);
   for (i = 0; i <= m; i++) {
     x = z[i] - mu;
-    h[i] = wgt[i] * exp(-x * x / 2) / 2.506628275;
+    h[i] = wgt[i] * exp(-x * x / 2) / gs_sqrt_2pi;
   }
 }

--- a/src/h1.c
+++ b/src/h1.c
@@ -23,6 +23,6 @@ void h1(double theta, int m, double *wgt, double I, double *z, double *h) {
   mu = theta * sqrt(I);
   for (i = 0; i <= m; i++) {
     x = z[i] - mu;
-    h[i] = wgt[i] * exp(-x * x / 2) / gs_sqrt_2pi;
+    h[i] = wgt[i] * exp(-x * x / 2) * gs_inv_sqrt_2pi;
   }
 }

--- a/src/hupdate.c
+++ b/src/hupdate.c
@@ -36,7 +36,7 @@ void hupdate(double theta, double *wgt, int m1, double Ikm1, double *zkm1,
     hk[i] = 0.;
     for (ii = 0; ii <= m1; ii++) {
       x = (zk[i] * rtIk - zkm1[ii] * rtIkm1 - theta * deltak) / rtdeltak;
-      hk[i] += hkm1[ii] * exp(-x * x / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
+      hk[i] += hkm1[ii] * exp(-x * x / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
     }
     hk[i] *= wgt[i];
   }

--- a/src/hupdate.c
+++ b/src/hupdate.c
@@ -1,3 +1,4 @@
+#include "gsDesign.h"
 #include <math.h>
 #include <stdio.h>
 
@@ -35,7 +36,7 @@ void hupdate(double theta, double *wgt, int m1, double Ikm1, double *zkm1,
     hk[i] = 0.;
     for (ii = 0; ii <= m1; ii++) {
       x = (zk[i] * rtIk - zkm1[ii] * rtIkm1 - theta * deltak) / rtdeltak;
-      hk[i] += hkm1[ii] * exp(-x * x / 2) / 2.506628275 * rtIk / rtdeltak;
+      hk[i] += hkm1[ii] * exp(-x * x / 2) / gs_sqrt_2pi * rtIk / rtdeltak;
     }
     hk[i] *= wgt[i];
   }

--- a/tests/testthat/test-normal-density-constant-regression.R
+++ b/tests/testthat/test-normal-density-constant-regression.R
@@ -1,0 +1,133 @@
+testthat::test_that("gsBound is stable for representative inputs", {
+  x <- gsDesign::gsBound(
+    I = c(0.25, 0.5, 0.75, 1),
+    trueneg = c(0.01, 0.02, 0.03, 0.04),
+    falsepos = c(0.005, 0.01, 0.015, 0.02),
+    tol = 1e-8,
+    r = 18
+  )
+
+  testthat::expect_equal(x$error, 0L)
+  testthat::expect_equal(
+    x$a,
+    c(-2.32634787404084, -1.96818185313167, -1.67671154533665, -1.41871200118752),
+    tolerance = 1e-8
+  )
+  testthat::expect_equal(
+    x$b,
+    c(2.5758293035489, 2.25986082564025, 2.00956238688048, 1.79397591800809),
+    tolerance = 1e-8
+  )
+})
+
+testthat::test_that("gsBound1 is stable for representative inputs", {
+  x <- gsDesign::gsBound1(
+    theta = 0.35,
+    I = c(0.25, 0.5, 0.75, 1),
+    a = c(-2.8, -2.4, -2.1, -1.96),
+    probhi = c(0.002, 0.006, 0.012, 0.02),
+    tol = 1e-8,
+    r = 18
+  )
+
+  testthat::expect_equal(x$error, 0L)
+  testthat::expect_equal(
+    x$b,
+    c(3.05316173909548, 2.71771590385463, 2.4436403142931, 2.19873543003778),
+    tolerance = 1e-8
+  )
+  testthat::expect_equal(
+    x$problo,
+    c(0.00146494273922955, 0.00358821454505199, 0.00597577248693223, 0.00579998523854975),
+    tolerance = 1e-8
+  )
+})
+
+testthat::test_that("gsDensity is stable at first and later analyses", {
+  d <- gsDesign::gsDesign(k = 4, test.type = 2, sfu = "OF", alpha = 0.025, beta = 0.2)
+
+  den1 <- gsDesign::gsDensity(
+    x = d,
+    theta = c(-0.2, 0, 0.3),
+    i = 1,
+    zi = c(-1.5, -0.25, 0, 1.25)
+  )$density
+  den3 <- gsDesign::gsDensity(
+    x = d,
+    theta = c(-0.2, 0, 0.3),
+    i = 3,
+    zi = c(-2.5, -1, 0, 1, 2.5)
+  )$density
+
+  testthat::expect_equal(
+    den1,
+    structure(
+      c(
+        0.149976025630557, 0.394549195919026, 0.396905220923099,
+        0.160126783568876, 0.129517595646825, 0.386668116745928,
+        0.398942280342705, 0.182649085362134, 0.101965198817964,
+        0.368007747082996, 0.394373517573607, 0.218278309393156
+      ),
+      dim = c(4L, 3L)
+    ),
+    tolerance = 1e-9
+  )
+  testthat::expect_equal(
+    den3,
+    structure(
+      c(
+        0.0246750805539103, 0.283868325719495, 0.392861731743116,
+        0.199935428769518, 0.0102728391182201, 0.0161675545893474,
+        0.241920745139233, 0.398941749191519, 0.241920745139233,
+        0.0161675545893474, 0.00809489540955571, 0.179678354438577,
+        0.385391850092692, 0.303974064378235, 0.0301344580501573
+      ),
+      dim = c(5L, 3L)
+    ),
+    tolerance = 1e-9
+  )
+})
+
+testthat::test_that("gsProbability remains stable for representative bounds", {
+  d <- gsDesign::gsDesign(k = 4, test.type = 2, sfu = "OF", alpha = 0.025, beta = 0.2)
+  p <- gsDesign::gsProbability(
+    k = d$k,
+    theta = c(-0.2, 0, 0.3),
+    n.I = d$n.I,
+    a = d$lower$bound,
+    b = d$upper$bound,
+    r = 18
+  )
+
+  testthat::expect_equal(
+    p$upper$prob,
+    structure(
+      c(
+        1.66400022856292e-05, 0.00131497939619109, 0.00518530133766029,
+        0.00895618146440017, 2.57634255827315e-05, 0.00208457724169985,
+        0.00834554793644277, 0.0145441105183363, 4.87333522297357e-05,
+        0.0040153716903915, 0.0161524792689938, 0.0279995912619114
+      ),
+      dim = c(4L, 3L)
+    ),
+    tolerance = 1e-9
+  )
+  testthat::expect_equal(
+    p$lower$prob,
+    structure(
+      c(
+        3.95012721949405e-05, 0.00324246173719493, 0.0130536432925157,
+        0.0227249203543359, 2.57634255827315e-05, 0.00208457724169985,
+        0.00834554793644276, 0.0145441105183363, 1.33240065689145e-05,
+        0.00103696987534739, 0.00404355061406175, 0.0069268941635626
+      ),
+      dim = c(4L, 3L)
+    ),
+    tolerance = 1e-9
+  )
+  testthat::expect_equal(
+    p$en,
+    c(1.01680169602634, 1.01740020212267, 1.01604286351769),
+    tolerance = 1e-9
+  )
+})


### PR DESCRIPTION
This PR centralizes the constant `sqrt(2 * pi)` used in normal density calculations.

## What changed

Added a centralized constant:

- `static const double gs_inv_sqrt_2pi = 0.3989422804014327` in `src/gsDesign.h`.
- Replaced all occurrences of `2.506628274631` / `2.506628275` in C code with `gs_inv_sqrt_2pi`.
- Switched from division to multiplication (`* gs_inv_sqrt_2pi`) in density calculations.
- Added include guards to `src/gsDesign.h`.

## Why

- Eliminates duplicated magic numbers and inconsistent precision.
- Improves maintainability with a single source of truth.
- Enables better compiler constant folding across translation units and avoids repeated division in tight loops.

## Validation

Added regression tests to capture pre-refactor behavior in `tests/testthat/test-normal-density-constant-regression.R`, which covers `gsBound()`, `gsBound1()`, `gsDensity()`, and `gsProbability()`.

## Impact

- No intended functional change.
- Numerical behavior remains stable within test tolerances.

## Prompts

This prompt was ran on gpt-5.3-codex xhigh in Codex CLI:

> Act as a senior principal software engineer working at Google who is an expert in C and R. I'm improve the C code of my R package gsDesign (for group sequential design). This is not only a test of your expertise but also of you taste. Make sure to follow C and R community best practices, including idiomatic naming conventions, error handling, and documentation.
>
> In the C code under @src/ , we currently use two magic numbers `2.506628274631` and `2.506628275` to compute the normal density function as a substitute for `sqrt(2 * pi)`. However, the number was defined ad hoc in multiple places with different values, which can lead to confusion and maintenance issues. Replace these magic numbers with a single constant that is defined in a central location following C best practices, and use it uniformly across the codebase.
>
> Notes:
>
> - To make sure your changes don't change the existing behavior of these functions (minor numerical differences are acceptable), first create testthat unit tests under @tests/testthat/ (snapshot tests if appropriate) that capture the current output/behavior of the affected functions. Then, implement the changes and run the tests to ensure correctness.
> - All the R package dependencies and C toolchain have been installed so no need to install anything. You can run `devtools::test()` or `testthat::test_file()` to run the tests. Use `devtools::load_all(recompile = TRUE)` in `Rscript` calls to recompile and load the package after making changes to the C code before running the tests.
> - R's C API reference is in @R-exts.texi . There is a section about mathematical constants and other things but not sure if it's useful.
> - This number of precision 256 bits (but you don't need to use all of it, perhaps `2.506628274631` makes sense) is: 2.506628274631000502415765284811045253006986740609938316629923576342293654607848