### PR TITLE
Warn when hr0 missing in gsBoundSummary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.9.0.9008
+Version: 3.9.0.9009
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,8 @@
 
 ## Bug fixes
 
+- `gsBoundSummary()` now warns before defaulting missing `hr0` to 1 for
+  hazard-ratio boundary summaries (#42).
 - `nSurv()` and `gsSurv()` now validate fixed survival timing inputs before
   enrollment periods are adjusted, giving a clear error when `R`/`gamma`
   imply accrual beyond `T - minfup` instead of failing later while assigning

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -389,6 +389,14 @@ print.nSurvival <- function(x, ...) {
 
 # Old version of gsBoundSummary is now gsBoundSummary0()
 # This is not exported, but is called by the new version of gsBoundSummary() below
+gsBoundSummaryUsesHR <- function(x, deltaname) {
+  if (is.null(deltaname)) {
+    deltaname <- if ("gsSurv" %in% class(x) || isTRUE(x$nFixSurv > 0)) "HR" else "delta"
+  }
+
+  isTRUE(x$nFixSurv > 0) || "gsSurv" %in% class(x) || isTRUE(toupper(deltaname) == "HR")
+}
+
 gsBoundSummary0 <- function(
     x, deltaname = NULL, logdelta = FALSE, Nname = NULL, digits = 4, ddigits = 2, tdigits = 0, timename = "Month",
     prior = normalGrid(mu = x$delta / 2, sigma = 10 / sqrt(x$n.fix)),
@@ -408,6 +416,7 @@ gsBoundSummary0 <- function(
       deltaname <- "delta"
     }
   }
+  hr_summary <- gsBoundSummaryUsesHR(x, deltaname)
   # delta values corresponding to x$theta
   delta <- x$delta0 + (x$delta1 - x$delta0) * x$theta / x$delta
   if (logdelta || "gsSurv" %in% class(x)) delta <- exp(delta)
@@ -418,7 +427,7 @@ gsBoundSummary0 <- function(
   # delta values at bounds
   # note that RR and HR are treated specially
   if (x$test.type > 1) {
-    if (x$nFixSurv > 0 || "gsSurv" %in% class(x) || toupper(deltaname) == "HR") {
+    if (hr_summary) {
       deltafutility <- gsHR(x = x, i = 1:x$k, z = x$lower$bound[1:x$k], ratio = ratio)
     } else if (tolower(deltaname) == "rr") {
       deltafutility <- gsRR(x = x, i = 1:x$k, z = x$lower$bound[1:x$k], ratio = ratio)
@@ -429,7 +438,7 @@ gsBoundSummary0 <- function(
   }
   # delta values at harm bounds for test.type 7/8
   if (x$test.type %in% c(7, 8)) {
-    if (x$nFixSurv > 0 || "gsSurv" %in% class(x) || toupper(deltaname) == "HR") {
+    if (hr_summary) {
       deltaharm <- gsHR(x = x, i = 1:x$k, z = x$harm$bound[1:x$k], ratio = ratio)
     } else if (tolower(deltaname) == "rr") {
       deltaharm <- gsRR(x = x, i = 1:x$k, z = x$harm$bound[1:x$k], ratio = ratio)
@@ -438,7 +447,7 @@ gsBoundSummary0 <- function(
       if (logdelta == TRUE) deltaharm <- exp(deltaharm)
     }
   }
-  if (x$nFixSurv > 0 || "gsSurv" %in% class(x) || toupper(deltaname) == "HR") {
+  if (hr_summary) {
     deltaefficacy <- gsHR(x = x, i = 1:x$k, z = x$upper$bound[1:x$k], ratio = ratio)
   } else if (tolower(deltaname) == "rr") {
     deltaefficacy <- gsRR(x = x, i = 1:x$k, z = x$upper$bound[1:x$k], ratio = ratio)
@@ -887,6 +896,10 @@ gsBoundSummary <- function(
     r = 18,
     alpha = NULL,
     ...) {
+  if (gsBoundSummaryUsesHR(x, deltaname) && is.null(x$hr0)) {
+    warning("gsBoundSummary: hr0 is not present; using hr0 = 1 for HR at bound calculations.", call. = FALSE)
+  }
+
   # Get initial table
   out <- gsBoundSummary0(
     x, deltaname, logdelta, Nname, digits, ddigits, tdigits, timename,

--- a/tests/testthat/test-independent-test-as_rtf.R
+++ b/tests/testthat/test-independent-test-as_rtf.R
@@ -17,7 +17,11 @@ test_that("Snapshot test for gsDesign gsBoundSummary as_rtf", {
 
   ss <- nSurvival(lambda1 = 0.2, lambda2 = 0.1, eta = 0.1, Ts = 2, Tr = 0.5, sided = 1, alpha = 0.025, ratio = 2)
   xs <- gsDesign(nFixSurv = ss$n, n.fix = ss$nEvents, delta1 = log(ss$lambda2 / ss$lambda1))
-  tbl <- gsBoundSummary(xs, logdelta = TRUE, ratio = ss$ratio)
+  expect_warning(
+    tbl <- gsBoundSummary(xs, logdelta = TRUE, ratio = ss$ratio),
+    "hr0 is not present",
+    fixed = TRUE
+  )
   as_rtf(tbl, file = path)
 
   local_edition(3)
@@ -30,7 +34,11 @@ test_that("Snapshot test for gsDesign gsBoundSummary as_rtf with custom footnote
   path <- tempfile(fileext = ".rtf")
   ss <- nSurvival(lambda1 = 0.2, lambda2 = 0.1, eta = 0.1, Ts = 2, Tr = 0.5, sided = 1, alpha = 0.025, ratio = 2)
   xs <- gsDesign(nFixSurv = ss$n, n.fix = ss$nEvents, delta1 = log(ss$lambda2 / ss$lambda1))
-  tbl <- gsBoundSummary(xs, logdelta = TRUE, ratio = ss$ratio)
+  expect_warning(
+    tbl <- gsBoundSummary(xs, logdelta = TRUE, ratio = ss$ratio),
+    "hr0 is not present",
+    fixed = TRUE
+  )
   as_rtf(tbl, file = path, footnote_specify = "Z", footnote_text = "Z-Score")
 
   local_edition(3)

--- a/tests/testthat/test-independent-test-gsBoundSummary.R
+++ b/tests/testthat/test-independent-test-gsBoundSummary.R
@@ -23,12 +23,63 @@ testthat::test_that(desc = "Test gsBoundSummary for gsSurv Object", code = {
   expect_snapshot_output(x = gsBoundSummary(xgs))
 })
 
+testthat::test_that(desc = "Test gsBoundSummary warns when hr0 is missing for HR summary", code = {
+  x <- gsSurv(
+    k = 2,
+    test.type = 4,
+    hr = 0.8,
+    hr0 = 1.2,
+    lambdaC = log(2) / 12,
+    gamma = 1,
+    R = 12,
+    T = 36,
+    minfup = 12
+  )
+
+  xu <- gsDesign(
+    k = x$k,
+    test.type = x$test.type,
+    alpha = x$alpha,
+    beta = x$beta,
+    astar = x$astar,
+    sfu = x$upper$sf,
+    sfupar = x$upper$param,
+    sfl = x$lower$sf,
+    sflpar = x$lower$param,
+    n.I = x$n.I,
+    delta = x$delta,
+    delta1 = x$delta1,
+    delta0 = x$delta0
+  )
+
+  expect_null(xu$hr0)
+  missing_hr0 <- expect_warning(
+    gsBoundSummary(xu, deltaname = "HR", logdelta = TRUE, Nname = "Events"),
+    "hr0 is not present",
+    fixed = TRUE
+  )
+
+  xu$hr0 <- x$hr0
+  with_hr0 <- expect_no_warning(
+    gsBoundSummary(xu, deltaname = "HR", logdelta = TRUE, Nname = "Events")
+  )
+
+  missing_bound <- missing_hr0[missing_hr0$Value == "~HR at bound", "Efficacy"]
+  supplied_bound <- with_hr0[with_hr0$Value == "~HR at bound", "Efficacy"]
+  expect_false(isTRUE(all.equal(missing_bound, supplied_bound)))
+})
+
 testthat::test_that(desc = "Test gsBoundSummary for gsDesign Object, test.type > 1", 
                     code = {
   x <- gsDesign(nFixSurv = 3, k = 5, test.type = 4, n.fix = 1)
 
   local_edition(3) # use 3rd edition of testthat for this testcase
-  expect_snapshot_output(x = gsBoundSummary(x, Nname = NULL))
+  out <- expect_warning(
+    gsBoundSummary(x, Nname = NULL),
+    "hr0 is not present",
+    fixed = TRUE
+  )
+  expect_snapshot_output(x = out)
 })
 
 testthat::test_that(desc = "Test gsBoundSummary for gsDesign Object, when nFixSurv is set", 
@@ -36,7 +87,12 @@ testthat::test_that(desc = "Test gsBoundSummary for gsDesign Object, when nFixSu
   x <- gsDesign(nFixSurv = 0.8, k = 5, test.type = 4, n.fix = 1)
 
   local_edition(3) # use 3rd edition of testthat for this testcase
-  expect_snapshot_output(x = gsBoundSummary(x, deltaname = "RR", ratio = .3))
+  out <- expect_warning(
+    gsBoundSummary(x, deltaname = "RR", ratio = .3),
+    "hr0 is not present",
+    fixed = TRUE
+  )
+  expect_snapshot_output(x = out)
 })
 
 testthat::test_that(desc = "Test with Probability Of Success(POS) set to TRUE", 
@@ -232,19 +288,23 @@ testthat::test_that(desc = "Test gsBoundSummary for correct use of spending time
     lsTime = lsTime
   )
 
-  xu2 <- gsBoundSummary(
-    xu,
-    deltaname = "HR",
-    logdelta = TRUE,
-    Nname = "Events",
-    digits = 4,
-    ddigits = 2,
-    tdigits = 1,
-    exclude = c(
-      "B-value", "CP", "CP H1", "PP",
-      paste0("P(Cross) if HR=", round(c(x$hr0, x$hr), digits = 2))
+  xu2 <- expect_warning(
+    gsBoundSummary(
+      xu,
+      deltaname = "HR",
+      logdelta = TRUE,
+      Nname = "Events",
+      digits = 4,
+      ddigits = 2,
+      tdigits = 1,
+      exclude = c(
+        "B-value", "CP", "CP H1", "PP",
+        paste0("P(Cross) if HR=", round(c(x$hr0, x$hr), digits = 2))
+      ),
+      alpha = c(0.02, 0.025)
     ),
-    alpha = c(0.02, 0.025)
+    "hr0 is not present",
+    fixed = TRUE
   )
 
   alpha_vec <- c(0.01, 0.02, 0.025)

--- a/tests/testthat/test-independent-test-gsBoundSummary.R
+++ b/tests/testthat/test-independent-test-gsBoundSummary.R
@@ -53,8 +53,8 @@ testthat::test_that(desc = "Test gsBoundSummary warns when hr0 is missing for HR
   )
 
   expect_null(xu$hr0)
-  missing_hr0 <- expect_warning(
-    gsBoundSummary(xu, deltaname = "HR", logdelta = TRUE, Nname = "Events"),
+  expect_warning(
+    missing_hr0 <- gsBoundSummary(xu, deltaname = "HR", logdelta = TRUE, Nname = "Events"),
     "hr0 is not present",
     fixed = TRUE
   )
@@ -74,8 +74,8 @@ testthat::test_that(desc = "Test gsBoundSummary for gsDesign Object, test.type >
   x <- gsDesign(nFixSurv = 3, k = 5, test.type = 4, n.fix = 1)
 
   local_edition(3) # use 3rd edition of testthat for this testcase
-  out <- expect_warning(
-    gsBoundSummary(x, Nname = NULL),
+  expect_warning(
+    out <- gsBoundSummary(x, Nname = NULL),
     "hr0 is not present",
     fixed = TRUE
   )
@@ -87,8 +87,8 @@ testthat::test_that(desc = "Test gsBoundSummary for gsDesign Object, when nFixSu
   x <- gsDesign(nFixSurv = 0.8, k = 5, test.type = 4, n.fix = 1)
 
   local_edition(3) # use 3rd edition of testthat for this testcase
-  out <- expect_warning(
-    gsBoundSummary(x, deltaname = "RR", ratio = .3),
+  expect_warning(
+    out <- gsBoundSummary(x, deltaname = "RR", ratio = .3),
     "hr0 is not present",
     fixed = TRUE
   )


### PR DESCRIPTION
Fixes #42. Summary: adds a gsBoundSummary() warning when HR boundary summaries default missing hr0 to 1; adds regression coverage for the design-update pathway; bumps the development version and NEWS. Tests: devtools::document(); testthat::test_file('tests/testthat/test-independent-test-gsBoundSummary.R'); testthat::test_dir('tests/testthat'); git diff --check.