### PR TITLE
Complete roxygen2 8 migration and fix long-running examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.10.0
+Version: 3.10.0.9000
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),
@@ -47,4 +47,3 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3

--- a/R/binomialExactPValues.R
+++ b/R/binomialExactPValues.R
@@ -40,7 +40,9 @@
 #'   gamma = 10, R = 16, T = 24, minfup = 8, ratio = 3
 #' )
 #' counts <- toBinomialExact(x)$n.I
+#' \donttest{
 #' repeatedPValueBinomialExact(gsD = x, n.I = counts, x = c(12, 23, 38))
+#' }
 #' @export
 repeatedPValueBinomialExact <- function(
     gsD,
@@ -312,7 +314,9 @@ binomialExactLowerBound <- function(
 #'   gamma = 10, R = 16, T = 24, minfup = 8, ratio = 3
 #' )
 #' counts <- toBinomialExact(x)$n.I
+#' \donttest{
 #' sequentialPValueBinomialExact(gsD = x, n.I = counts, x = c(12, 23, 38))
+#' }
 #' @export
 sequentialPValueBinomialExact <- function(
     gsD,

--- a/man/gsDesign-package.Rd
+++ b/man/gsDesign-package.Rd
@@ -21,6 +21,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Keaven Anderson \email{keaven_anderson@merck.com}
 
+Authors:
+\itemize{
+  \item Keaven Anderson \email{keaven_anderson@merck.com}
+}
+
 Other contributors:
 \itemize{
   \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (\href{https://ror.org/02891sr49}{ROR}) [copyright holder]

--- a/man/repeatedPValueBinomialExact.Rd
+++ b/man/repeatedPValueBinomialExact.Rd
@@ -60,7 +60,9 @@ x <- gsSurv(
   gamma = 10, R = 16, T = 24, minfup = 8, ratio = 3
 )
 counts <- toBinomialExact(x)$n.I
+\donttest{
 repeatedPValueBinomialExact(gsD = x, n.I = counts, x = c(12, 23, 38))
+}
 }
 \seealso{
 [sequentialPValueBinomialExact()], [sequentialPValue()],

--- a/man/sequentialPValueBinomialExact.Rd
+++ b/man/sequentialPValueBinomialExact.Rd
@@ -50,7 +50,9 @@ x <- gsSurv(
   gamma = 10, R = 16, T = 24, minfup = 8, ratio = 3
 )
 counts <- toBinomialExact(x)$n.I
+\donttest{
 sequentialPValueBinomialExact(gsD = x, n.I = counts, x = c(12, 23, 38))
+}
 }
 \seealso{
 [repeatedPValueBinomialExact()], [sequentialPValue()]


### PR DESCRIPTION
Two minor updates prior to CRAN submission:

* Complete migration to [roxygen2 8](https://opensource.posit.co/blog/2026-05-01_roxygen2-8-0-0/): Removed `RoxygenNote` and rebuilt docs
* Avoided `NOTE` from `R CMD check` about long-running examples by wrapping them in `\donttest{}`