### PR TITLE
Fix independent harm and futility bounds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.10.0.9000
+Version: 3.10.0.9001
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # gsDesign (development version)
 
+## Bug fixes
+
+- Futility and harm bounds can now be skipped independently at an analysis;
+  skipping futility no longer also removes an active harm bound (#284).
+
 # gsDesign 3.10.0
 
 ## New features

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -1437,8 +1437,11 @@ gsDType7 <- function(x) {
   xx <- gsBound1(theta = 0, I = x$n.I, a = -x$upper$bound, probhi = harm_spend, tol = x$tol, r = x$r)
   x$harm$bound <- -xx$b
 
-  # Cap harm bound: if harm > futility, set to futility
+  # Cap harm bound only where both lower bounds are active
   cap_idx <- x$harm$bound > x$lower$bound
+  if (!is.null(x$testLower) && !is.null(x$testHarm)) {
+    cap_idx <- cap_idx & x$testLower & x$testHarm
+  }
   if (any(cap_idx)) {
     x$harm$bound[cap_idx] <- x$lower$bound[cap_idx]
   }
@@ -1470,8 +1473,11 @@ gsDType8 <- function(x) {
   xx <- gsBound1(theta = 0, I = x$n.I, a = -x$upper$bound, probhi = harm_spend, tol = x$tol, r = x$r)
   x$harm$bound <- -xx$b
 
-  # Cap harm bound: if harm > futility, set to futility
+  # Cap harm bound only where both lower bounds are active
   cap_idx <- x$harm$bound > x$lower$bound
+  if (!is.null(x$testLower) && !is.null(x$testHarm)) {
+    cap_idx <- cap_idx & x$testLower & x$testHarm
+  }
   if (any(cap_idx)) {
     x$harm$bound[cap_idx] <- x$lower$bound[cap_idx]
   }

--- a/tests/testthat/test-selective-bounds.R
+++ b/tests/testthat/test-selective-bounds.R
@@ -183,6 +183,21 @@ testthat::test_that("testHarm = c(TRUE, FALSE, FALSE) with test.type 7", {
   testthat::expect_equal(x$harm$bound[3], -EXTREMEZ)
 })
 
+testthat::test_that("futility and harm bounds can be skipped independently", {
+  for (test_type in 7:8) {
+    x <- gsDesign(
+      k = 3, test.type = test_type, alpha = 0.025, beta = 0.1, astar = 0.05,
+      testLower = c(TRUE, FALSE, TRUE),
+      testHarm = c(TRUE, TRUE, FALSE)
+    )
+
+    testthat::expect_equal(x$lower$bound[2], -EXTREMEZ)
+    testthat::expect_gt(x$harm$bound[2], -EXTREMEZ)
+    testthat::expect_gt(x$lower$bound[3], -EXTREMEZ)
+    testthat::expect_equal(x$harm$bound[3], -EXTREMEZ)
+  }
+})
+
 # ---- Combining testUpper and testLower ----
 
 testthat::test_that("Combined: futility only at IA1, efficacy only at IA2 and final", {


### PR DESCRIPTION
Keeps harm monitoring active when futility is skipped, preserves independent selective-bound behavior for test types 7 and 8, and adds regression coverage. Complete testthat suite: 2,905 passed, 0 failed, 0 warnings. Fixes #284.