### PR TITLE
Release gsDesign 3.10.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.10.0.9001
+Version: 3.10.1
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gsDesign (development version)
+# gsDesign 3.10.1
 
 ## Bug fixes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,7 @@
-# Version 3.10.0 July, 2026
+# Version 3.10.1 July, 2026
 
-This is a feature and maintenance release.
+This is a patch release fixing independent selection of futility and harm
+bounds at group sequential analyses.
 
 # Test environments
 
@@ -12,20 +13,19 @@ GitHub Actions at github.com/keaven/gsDesign (all pass):
 - Ubuntu (latest), R release
 - Ubuntu (latest), R oldrel-1
 
-Local `R CMD check --as-cran` on macOS Tahoe 26.5.2 with R 4.5.0:
+Local `R CMD check --as-cran` on macOS Tahoe 26.5.2 with R 4.6.1:
 
-0 errors | 0 warnings | 0 notes
+0 errors | 0 warnings | 1 note
 
-(One local-only WARNING from R's own `R_ext/Boolean.h` header with
-Apple clang 21: `unknown warning group '-Wfixed-enum-extension'`.
-Two local-only NOTEs: "unable to verify current time" and HTML Tidy
-version too old. None of these appear on CRAN infrastructure.)
+The local-only NOTE reports that HTML validation was skipped because the
+installed HTML Tidy is not recent enough. This is an environment/tooling note,
+not a package-content issue.
 
 # Reverse dependencies
 
-There are 8 reverse dependencies on CRAN:
+There are 8 reverse dependencies in Depends, Imports, or LinkingTo on CRAN:
 gsbDesign, gsDesign2, gsDesignNB, gsDesignTune, gsearly, gsMeanFreq,
 randomizeR, ssutil.
 
-No breaking API changes were made in this release. All existing
-exported functions retain their prior interfaces.
+No breaking API changes were made in this release. All existing exported
+functions retain their prior interfaces.


### PR DESCRIPTION
Finalizes version 3.10.1, promotes the NEWS development section, and updates CRAN submission comments. Validation: full testthat suite 2,905 passed with 0 failures and 0 warnings; R CMD check --as-cran on gsDesign_3.10.1.tar.gz completed with 0 errors, 0 warnings, and 1 local HTML Tidy tooling NOTE.