### PR TITLE
Fix skipped futility sizing

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,19 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: "Deployment target"
+        required: true
+        default: devel
+        type: choice
+        options:
+          - devel
+          - stable
+      source_branch:
+        description: "Branch to build for manual deployment; leave blank to use the selected workflow branch"
+        required: false
+        type: string
 
 name: pkgdown.yaml
 
@@ -23,7 +36,38 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Set deployment parameters
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            deploy_target="${{ github.event.inputs.deploy_target }}"
+            source_branch="${{ github.event.inputs.source_branch }}"
+            if [[ -z "$source_branch" ]]; then
+              source_branch="${{ github.ref_name }}"
+            fi
+          else
+            deploy_target="stable"
+            source_branch="${{ github.ref_name }}"
+          fi
+
+          if [[ "$deploy_target" == "devel" ]]; then
+            site_url="https://keaven.github.io/gsDesign/devel/"
+            target_folder="devel"
+            deploy_message="Deploy development pkgdown for ${source_branch}"
+          else
+            site_url="https://keaven.github.io/gsDesign/"
+            target_folder=""
+            deploy_message="Deploy stable pkgdown for ${source_branch}"
+          fi
+
+          echo "SOURCE_BRANCH=$source_branch" >> "$GITHUB_ENV"
+          echo "SITE_URL=$site_url" >> "$GITHUB_ENV"
+          echo "TARGET_FOLDER=$target_folder" >> "$GITHUB_ENV"
+          echo "DEPLOY_MESSAGE=$deploy_message" >> "$GITHUB_ENV"
+        shell: bash
+
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_BRANCH }}
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -35,7 +79,7 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override = list(url = Sys.getenv("SITE_URL")))
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
@@ -44,4 +88,6 @@ jobs:
         with:
           clean: false
           branch: gh-pages
+          target-folder: ${{ env.TARGET_FOLDER }}
+          commit-message: ${{ env.DEPLOY_MESSAGE }}
           folder: docs

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -46,7 +46,7 @@ jobs:
             fi
           else
             deploy_target="stable"
-            source_branch="${{ github.ref_name }}"
+            source_branch="${{ github.ref }}"
           fi
 
           if [[ "$deploy_target" == "devel" ]]; then

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.10.1.9000
+Version: 3.10.1.9001
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.10.1
+Version: 3.10.1.9000
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,12 @@
 
 - Sequential p-values, including exact-binomial repeated and sequential
   efficacy p-values, now support `test.type = 8` by ignoring its non-binding
-  futility and harm bounds. Exact-binomial efficacy p-values also support
-  non-binding `test.type = 6`. `toBinomialExact()` now provides full two-bound
-  conversion for test types 1, 4, and 6; for type 6, the upper event-count
-  boundary targets lower-bound spending under the null hypothesis. It also
-  explains why the remaining test types are not supported (#287).
+  futility and harm bounds. `toBinomialExact()` now provides full exact
+  conversion for non-binding test types 1, 4, 6, and 8. For type 6, the upper
+  event-count boundary targets lower-bound spending under the null hypothesis.
+  For type 8, exact upper event-count stops are partitioned into mutually
+  exclusive futility and harm regions, targeting beta spending under the
+  alternative and harm spending under the null, respectively (#287).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# gsDesign (development version)
+
+## Bug fixes
+
+- Sample-size derivation now accounts for analyses where futility testing is
+  skipped, avoiding power above the requested target (#287).
+
 # gsDesign 3.10.1
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 
 ## Bug fixes
 
+- Power plots for test types 7 and 8 now treat crossing the futility threshold
+  as the union of futility-only and harm stops. The separate harm curve remains
+  harm-only, and the mutually exclusive probabilities stored on the design are
+  unchanged (#287).
 - Sample-size derivation now accounts for analyses where efficacy, futility,
   or harm testing is skipped, avoiding power above the requested target. Harm,
   futility, and efficacy crossing probabilities are reported as mutually

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,29 @@
 # gsDesign (development version)
 
+## New features
+
+- Sequential p-values, including exact-binomial repeated and sequential
+  efficacy p-values, now support `test.type = 8` by ignoring its non-binding
+  futility and harm bounds. Exact-binomial efficacy p-values also support
+  non-binding `test.type = 6`. `toBinomialExact()` now provides full two-bound
+  conversion for test types 1, 4, and 6; for type 6, the upper event-count
+  boundary targets lower-bound spending under the null hypothesis. It also
+  explains why the remaining test types are not supported (#287).
+
 ## Bug fixes
 
-- Sample-size derivation now accounts for analyses where futility or harm
-  testing is skipped, avoiding power above the requested target. Harm,
+- Sample-size derivation now accounts for analyses where efficacy, futility,
+  or harm testing is skipped, avoiding power above the requested target. Harm,
   futility, and efficacy crossing probabilities are reported as mutually
-  exclusive outcomes (#287).
+  exclusive outcomes. Alternate-alpha summaries and power calculations retain
+  the planned efficacy testing schedule, and survival-design inputs retain the
+  applicable testing flags. `gsBoundSummary()` reports every characteristic,
+  including cumulative crossing probability, as `NA` when its bound is not
+  tested at an analysis (#287).
+- Alternate-alpha summaries are now limited to one-sided and non-binding test
+  types 1, 4, 6, and 8. Binding test type 7 is no longer presented as
+  compatible with the Maurer--Bretz graphical multiple-testing framework
+  (#287).
 
 # gsDesign 3.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,10 @@
 
 ## Bug fixes
 
-- Sample-size derivation now accounts for analyses where futility testing is
-  skipped, avoiding power above the requested target (#287).
+- Sample-size derivation now accounts for analyses where futility or harm
+  testing is skipped, avoiding power above the requested target. Harm,
+  futility, and efficacy crossing probabilities are reported as mutually
+  exclusive outcomes (#287).
 
 # gsDesign 3.10.1
 

--- a/R/binomialExactPValues.R
+++ b/R/binomialExactPValues.R
@@ -4,12 +4,12 @@
 #' [gsSurv()] object. The p-value at analysis `j` is the smallest local
 #' one-sided alpha level for which the observed experimental-arm event count
 #' crosses the exact lower efficacy bound at that analysis. Non-binding
-#' futility bounds are ignored for the Type I error calculation.
+#' futility and harm bounds are ignored for the Type I error calculation.
 #'
-#' @param gsD A `gsSurv` object with `test.type` 1 or 4.
+#' @param gsD A `gsSurv` object with non-binding `test.type` 1, 4, 6, or 8.
 #' @param n.I Increasing integer total event counts at completed analyses. If
-#'   `NULL`, the planned exact binomial event counts from `toBinomialExact(gsD)`
-#'   are used. This must have at most 1 value greater than or equal to planned
+#'   `NULL`, the planned integer event counts from `toInteger(gsD)` are used.
+#'   This must have at most 1 value greater than or equal to planned
 #'   final events (`gsD$maxn.IPlan` if available, otherwise `max(gsD$n.I)`).
 #' @param x Integer experimental-arm event counts at the analyses in `n.I`.
 #' @param interval Search interval for the p-values. As in [sequentialPValue()],
@@ -55,8 +55,8 @@ repeatedPValueBinomialExact <- function(
   if (!inherits(gsD, "gsSurv")) {
     stop("gsD must be an object of class gsSurv", call. = FALSE)
   }
-  if (!(gsD$test.type %in% c(1, 4))) {
-    stop("gsD$test.type must be 1 or 4", call. = FALSE)
+  if (!(gsD$test.type %in% c(1, 4, 6, 8))) {
+    stop("gsD$test.type must be 1, 4, 6, or 8", call. = FALSE)
   }
   if (is.null(x)) {
     stop("x must contain observed experimental-arm event counts", call. = FALSE)
@@ -73,7 +73,7 @@ repeatedPValueBinomialExact <- function(
   }
 
   if (is.null(n.I)) {
-    n.I <- toBinomialExact(gsD)$n.I
+    n.I <- toInteger(gsD)$n.I
   }
   if (!is.numeric(n.I) || any(!is.finite(n.I)) || any(n.I != floor(n.I))) {
     stop("n.I must be a numeric vector of increasing positive integers", call. = FALSE)
@@ -187,11 +187,11 @@ repeatedPValueBinomialExact <- function(
 #'
 #' Computes the alpha-indexed exact lower-tail event-count efficacy bounds used
 #' by [repeatedPValueBinomialExact()]. This helper intentionally ignores
-#' non-binding futility bounds and avoids the normal-theory design checks in
+#' non-binding futility and harm bounds and avoids the normal-theory design checks in
 #' [gsDesign()], since very small alpha values may be needed while searching
 #' for exact p-values.
 #'
-#' @param gsD A `gsSurv` object with `test.type` 1 or 4.
+#' @param gsD A `gsSurv` object with non-binding `test.type` 1, 4, 6, or 8.
 #' @param n.I Increasing integer total event counts at analyses with at most
 #'   1 value greater than or equal to planned final events.
 #' @param alpha Local one-sided Type I error level.
@@ -214,8 +214,8 @@ binomialExactLowerBound <- function(
   if (!inherits(gsD, "gsSurv")) {
     stop("gsD must be an object of class gsSurv", call. = FALSE)
   }
-  if (!(gsD$test.type %in% c(1, 4))) {
-    stop("gsD$test.type must be 1 or 4", call. = FALSE)
+  if (!(gsD$test.type %in% c(1, 4, 6, 8))) {
+    stop("gsD$test.type must be 1, 4, 6, or 8", call. = FALSE)
   }
   if (!is.numeric(alpha) || length(alpha) != 1 || !is.finite(alpha) ||
       alpha <= 0 || alpha >= 1) {

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -624,11 +624,12 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
   x <- gsApplyTestBounds(x_all_bounds, testBounds)
 
   # When analyses are skipped, solve information using the bounds that will
-  # actually be tested. The usual beta-spending sizing assumes all planned
-  # lower bounds are present, so applying selective bounds only afterward can
-  # leave power above its requested target.
-  selective <- x$test.type %in% c(3, 4, 7, 8) &&
+  # actually be tested. Applying selective efficacy or lower bounds only after
+  # the usual sizing calculation can leave power above its requested target.
+  selective_upper <- !all(testBounds$testUpper)
+  selective_lower <- x$test.type %in% c(3, 4, 7, 8) &&
     !all(testBounds$testLower)
+  selective <- selective_upper || selective_lower
   if (size_design && selective) {
     target_power <- 1 - x$beta
     power_diff <- function(scale, return_design = FALSE) {
@@ -649,7 +650,7 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
       upper_diff <- power_diff(upper_scale)
     }
     if (upper_diff < 0) {
-      stop("Unable to derive sample size with selective lower bounds")
+      stop("Unable to derive sample size with selective bounds")
     }
     scale <- stats::uniroot(power_diff, interval = c(0.2, upper_scale), tol = x$tol)$root
     x <- power_diff(scale, return_design = TRUE)

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -513,6 +513,7 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 
   # check parameters other than spending functions
   x <- gsDErrorCheck(x)
+  size_design <- max(x$n.I) == 0
 
   # --- Validate and expand testUpper, testLower, testHarm ---
   testBounds <- gsTestBoundsCheck(x$k, x$test.type, testUpper, testLower, testHarm)
@@ -611,7 +612,30 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
   if (x$nFixSurv > 0) x$nSurv <- ceiling(x$nFixSurv * x$n.I[x$k] / n.fix / 2) * 2
 
   # --- Apply testUpper/testLower/testHarm: recompute bounds at active analyses ---
-  x <- gsApplyTestBounds(x, testBounds)
+  x_all_bounds <- x
+  x <- gsApplyTestBounds(x_all_bounds, testBounds)
+
+  # When analyses are skipped, solve information using the bounds that will
+  # actually be tested. The usual beta-spending sizing assumes all planned
+  # lower bounds are present, so applying selective bounds only afterward can
+  # leave power above its requested target.
+  selective <- x$test.type %in% c(3, 4, 7, 8) &&
+    !all(testBounds$testLower)
+  if (size_design && selective) {
+    target_power <- 1 - x$beta
+    power_diff <- function(scale, return_design = FALSE) {
+      candidate <- x_all_bounds
+      candidate$n.I <- x_all_bounds$n.I * scale
+      if (candidate$maxn.IPlan > 0) {
+        candidate$maxn.IPlan <- candidate$n.I[candidate$k]
+      }
+      candidate <- gsApplyTestBounds(candidate, testBounds)
+      if (return_design) return(candidate)
+      sum(candidate$upper$prob[, 2]) - target_power
+    }
+    scale <- stats::uniroot(power_diff, interval = c(0.2, 2), tol = x$tol)$root
+    x <- power_diff(scale, return_design = TRUE)
+  }
 
   x
 }

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -384,7 +384,9 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #' Only used for \code{test.type} 7 or 8; at least one analysis must be
 #' \code{TRUE} for those types.
 #' Where \code{testHarm} is \code{FALSE}, the harm bound is set to
-#' \code{-20} (effectively \code{-Inf}) and displayed as \code{NA} in output.
+#' \code{-20} (effectively \code{-Inf}) and the bound is displayed as
+#' \code{NA} in output. Cumulative harm crossing probability from earlier
+#' analyses is still displayed.
 #' @return An object of the class \code{gsDesign}. This class has the following
 #' elements and upon return from \code{gsDesign()} contains: \item{k}{As
 #' input.} \item{test.type}{As input.} \item{alpha}{As input.} \item{beta}{As
@@ -427,7 +429,12 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #' hypothesis (beta spending) for \code{test.type=3} or \code{4}.  For
 #' \code{test.type=2}, \code{5} or \code{6}, lower spending is under the null
 #' hypothesis. For \code{test.type=1}, output value is \code{NULL}. See
-#' \code{vignette("SpendingFunctionOverview")} and manual.} \item{theta}{Standarized
+#' \code{vignette("SpendingFunctionOverview")} and manual. For
+#' \code{test.type=7} or \code{8}, crossing probabilities exclude harm
+#' crossings.} \item{harm}{Harm bound spending function, boundary, and crossing
+#' probabilities at each analysis for \code{test.type=7} or \code{8}. Harm,
+#' lower, and upper crossing probabilities are mutually exclusive.}
+#' \item{theta}{Standarized
 #' effect size under null (0) and alternate hypothesis. If \code{delta} is
 #' input, \code{theta[1]=delta}. If \code{n.fix} is input, \code{theta[1]} is
 #' computed using a standard sample size formula (pseudocode):
@@ -517,6 +524,9 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
 
   # --- Validate and expand testUpper, testLower, testHarm ---
   testBounds <- gsTestBoundsCheck(x$k, x$test.type, testUpper, testLower, testHarm)
+  x$testUpper <- testBounds$testUpper
+  x$testLower <- testBounds$testLower
+  x$testHarm <- testBounds$testHarm
   # if usTime (upper spending time) is specified, check it
   if (!is.null(usTime)){
     checkVector(usTime[1:(x$k-1)],"numeric",c(0,1),c(FALSE,FALSE)) # interim fractions in (0,1)
@@ -609,8 +619,6 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
     gsDType7(x),
     gsDType8(x)
   )
-  if (x$nFixSurv > 0) x$nSurv <- ceiling(x$nFixSurv * x$n.I[x$k] / n.fix / 2) * 2
-
   # --- Apply testUpper/testLower/testHarm: recompute bounds at active analyses ---
   x_all_bounds <- x
   x <- gsApplyTestBounds(x_all_bounds, testBounds)
@@ -626,6 +634,7 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
     power_diff <- function(scale, return_design = FALSE) {
       candidate <- x_all_bounds
       candidate$n.I <- x_all_bounds$n.I * scale
+      candidate$preserve.k <- TRUE
       if (candidate$maxn.IPlan > 0) {
         candidate$maxn.IPlan <- candidate$n.I[candidate$k]
       }
@@ -633,9 +642,21 @@ gsDesign <- function(k = 3, test.type = 4, alpha = 0.025, beta = 0.1, astar = 0,
       if (return_design) return(candidate)
       sum(candidate$upper$prob[, 2]) - target_power
     }
-    scale <- stats::uniroot(power_diff, interval = c(0.2, 2), tol = x$tol)$root
+    upper_scale <- 1.05
+    upper_diff <- power_diff(upper_scale)
+    while (upper_diff < 0 && upper_scale < 10) {
+      upper_scale <- min(1.25 * upper_scale, 10)
+      upper_diff <- power_diff(upper_scale)
+    }
+    if (upper_diff < 0) {
+      stop("Unable to derive sample size with selective lower bounds")
+    }
+    scale <- stats::uniroot(power_diff, interval = c(0.2, upper_scale), tol = x$tol)$root
     x <- power_diff(scale, return_design = TRUE)
+    x$preserve.k <- NULL
   }
+
+  if (x$nFixSurv > 0) x$nSurv <- ceiling(x$nFixSurv * x$n.I[x$k] / n.fix / 2) * 2
 
   x
 }
@@ -1180,6 +1201,9 @@ gsDType3a <- function(x) {
 
   # try to match spending
   x <- gsDType3b(x)
+  if (isTRUE(x$preserve.k)) {
+    return(x)
+  }
   if (x$test.type == 4) {
     return(x)
   }
@@ -1447,10 +1471,15 @@ gsDType7 <- function(x) {
   # Step 1: Compute design as test.type 3 (binding beta-spending futility bound)
   saved_test_type <- x$test.type
   saved_harm <- x$harm
+  saved_preserve_k <- x$preserve.k
+  if (length(x$n.I) == x$k && any(x$testHarm & !x$testLower)) {
+    x$preserve.k <- TRUE
+  }
   x$test.type <- 3L
   x <- gsDType3(x)
   x$test.type <- saved_test_type
   x$harm <- saved_harm
+  x$preserve.k <- saved_preserve_k
 
   # Step 2: Compute harm bound under H0
   harm_spend <- x$harm$spend
@@ -1602,7 +1631,11 @@ gsprob <- function(theta, I, a, b, r = 18, overrun = 0) {
   phi <- matrix(xx[[8]], nanal, ntheta)
   powr <- rep(1, nanal) %*% phi
   futile <- rep(1, nanal) %*% plo
-  IOver <- c(I[1:(nanal - 1)] + overrun, I[nanal])
+  if (nanal == 1) {
+    IOver <- I
+  } else {
+    IOver <- c(I[1:(nanal - 1)] + overrun, I[nanal])
+  }
   IOver[IOver > I[nanal]] <- I[nanal]
   en <- as.vector(IOver %*% (plo + phi) + I[nanal] * (t(rep(1, ntheta)) - powr - futile))
   list(
@@ -1611,8 +1644,187 @@ gsprob <- function(theta, I, a, b, r = 18, overrun = 0) {
   )
 }
 
+# gsHarmProbability: mutually exclusive efficacy, futility, and harm probabilities ----
+gsHarmProbability <- function(theta, d) {
+  k <- d$k
+  test_lower <- if (is.null(d$testLower)) rep(TRUE, k) else d$testLower
+  test_harm <- if (is.null(d$testHarm)) rep(TRUE, k) else d$testHarm
+
+  # A trial stops at the less extreme active lower boundary. When both lower
+  # boundaries are active, harm is the subset at or below the harm boundary.
+  stop_bound <- rep(-20, k)
+  stop_bound[test_harm] <- d$harm$bound[test_harm]
+  stop_bound[test_lower] <- pmax(
+    stop_bound[test_lower],
+    d$lower$bound[test_lower]
+  )
+
+  total <- gsprob(
+    theta = theta, I = d$n.I, a = stop_bound, b = d$upper$bound,
+    r = d$r, overrun = d$overrun
+  )
+  harm_prob <- matrix(0, nrow = k, ncol = length(theta))
+  for (j in which(test_harm)) {
+    harm_bound <- if (j == 1) {
+      d$harm$bound[j]
+    } else {
+      c(stop_bound[seq_len(j - 1)], d$harm$bound[j])
+    }
+    harm_at_j <- gsprob(
+      theta = theta, I = d$n.I[seq_len(j)], a = harm_bound,
+      b = d$upper$bound[seq_len(j)], r = d$r
+    )
+    harm_prob[j, ] <- harm_at_j$problo[j, ]
+  }
+
+  futility_prob <- total$problo - harm_prob
+  futility_prob[abs(futility_prob) < d$tol] <- 0
+
+  list(
+    upper = total$probhi,
+    lower = futility_prob,
+    harm = harm_prob,
+    en = total$en,
+    stop_bound = stop_bound
+  )
+}
+
+# gsHarmBoundUpdate: derive exclusive harm spending under H0 ----
+gsHarmBoundUpdate <- function(x) {
+  target <- cumsum(x$harm$spend)
+  previous_stop <- numeric(0)
+  cumulative_harm <- 0
+
+  for (j in seq_len(x$k)) {
+    if (x$testHarm[j]) {
+      desired <- max(target[j] - cumulative_harm, 0)
+      upper_limit <- x$upper$bound[j]
+      if (x$testLower[j]) {
+        upper_limit <- min(upper_limit, x$lower$bound[j])
+      }
+      crossing <- function(bound) {
+        lower <- c(previous_stop, bound)
+        probability <- gsprob(
+          theta = 0, I = x$n.I[seq_len(j)], a = lower,
+          b = x$upper$bound[seq_len(j)], r = x$r
+        )
+        probability$problo[j, 1]
+      }
+      low_probability <- crossing(-20)
+      high_probability <- crossing(upper_limit)
+      if (desired <= low_probability + x$tol) {
+        bound <- -20
+      } else if (desired >= high_probability - x$tol) {
+        bound <- upper_limit
+      } else {
+        bound <- stats::uniroot(
+          function(z) crossing(z) - desired,
+          interval = c(-20, upper_limit), tol = x$tol
+        )$root
+      }
+      x$harm$bound[j] <- bound
+      cumulative_harm <- cumulative_harm + crossing(bound)
+    } else {
+      x$harm$bound[j] <- -20
+    }
+
+    stop_at_j <- -20
+    if (x$testHarm[j]) stop_at_j <- x$harm$bound[j]
+    if (x$testLower[j]) stop_at_j <- max(stop_at_j, x$lower$bound[j])
+    previous_stop <- c(previous_stop, stop_at_j)
+  }
+
+  x
+}
+
+# gsFutilityBoundUpdate: include prior harm stopping in beta spending ----
+gsFutilityBoundUpdate <- function(x) {
+  target <- cumsum(x$lower$spend)
+  previous_stop <- numeric(0)
+  cumulative_lower <- 0
+
+  for (j in seq_len(x$k)) {
+    lower_limit <- if (x$testHarm[j]) x$harm$bound[j] else -20
+    crossing <- function(bound) {
+      lower <- c(previous_stop, bound)
+      probability <- gsprob(
+        theta = x$delta, I = x$n.I[seq_len(j)], a = lower,
+        b = x$upper$bound[seq_len(j)], r = x$r
+      )
+      probability$problo[j, 1]
+    }
+
+    if (x$testLower[j] && j == x$k) {
+      bound <- x$upper$bound[j]
+      x$lower$bound[j] <- bound
+    } else if (x$testLower[j]) {
+      desired <- max(target[j] - cumulative_lower, 0)
+      upper_limit <- x$upper$bound[j]
+      low_probability <- crossing(lower_limit)
+      high_probability <- crossing(upper_limit)
+      if (desired <= low_probability + x$tol) {
+        bound <- lower_limit
+      } else if (desired >= high_probability - x$tol) {
+        bound <- upper_limit
+      } else {
+        bound <- stats::uniroot(
+          function(z) crossing(z) - desired,
+          interval = c(lower_limit, upper_limit), tol = x$tol
+        )$root
+      }
+      x$lower$bound[j] <- bound
+    } else {
+      x$lower$bound[j] <- -20
+      bound <- lower_limit
+    }
+
+    current_probability <- crossing(bound)
+    cumulative_lower <- cumulative_lower + current_probability
+    previous_stop <- c(previous_stop, bound)
+  }
+
+  x
+}
+
+# gsJointHarmBounds: jointly derive selective futility, harm, and efficacy bounds ----
+gsJointHarmBounds <- function(x) {
+  if (!any(x$testHarm & !x$testLower)) return(x)
+
+  x$lower$bound <- pmin(x$lower$bound, x$upper$bound)
+  for (iteration in seq_len(100)) {
+    old_bound <- c(x$upper$bound, x$lower$bound, x$harm$bound)
+    x <- gsHarmBoundUpdate(x)
+    x <- gsFutilityBoundUpdate(x)
+
+    if (x$test.type == 7) {
+      probability <- gsHarmProbability(theta = x$theta, d = x)
+      upper <- gsBound1(
+        theta = 0, I = x$n.I, a = probability$stop_bound,
+        probhi = x$upper$spend, tol = x$tol, r = x$r
+      )
+      x$upper$bound <- upper$b
+      x$upper$bound[!x$testUpper] <- 20
+    }
+
+    change <- max(abs(c(x$upper$bound, x$lower$bound, x$harm$bound) - old_bound))
+    if (change <= x$tol) break
+  }
+
+  x
+}
+
 # gsDProb function [sinew] ----
 gsDProb <- function(theta, d) {
+  if (d$test.type %in% c(7, 8)) {
+    probability <- gsHarmProbability(theta = theta, d = d)
+    d$en <- probability$en
+    d$theta <- theta
+    d$upper$prob <- probability$upper
+    d$lower$prob <- probability$lower
+    d$harm$prob <- probability$harm
+    return(d)
+  }
+
   k <- d$k
   n.I <- d$n.I
 
@@ -1803,23 +2015,25 @@ gsApplyTestBounds <- function(x, testBounds) {
     }
   }
 
-  # Recompute crossing probabilities with the final bounds
-  if (x$test.type == 1) {
-    a <- rep(-20, x$k)
-  } else {
-    a <- x$lower$bound
-  }
-  y <- gsprob(x$theta, x$n.I, a, x$upper$bound, r = x$r, overrun = x$overrun)
-  x$upper$prob <- y$probhi
-  x$en <- as.vector(y$en)
-  if (x$test.type > 1) {
-    x$lower$prob <- y$problo
-  }
+  x <- gsJointHarmBounds(x)
 
-  # Recompute harm crossing probabilities
+  # Recompute crossing probabilities with the final bounds
   if (x$test.type %in% c(7, 8)) {
-    y2 <- gsprob(x$theta, x$n.I, x$harm$bound, x$upper$bound, r = x$r)
-    x$harm$prob <- y2$problo
+    probability <- gsHarmProbability(theta = x$theta, d = x)
+    x$upper$prob <- probability$upper
+    x$lower$prob <- probability$lower
+    x$harm$prob <- probability$harm
+    x$en <- probability$en
+  } else if (x$test.type == 1) {
+    a <- rep(-20, x$k)
+    y <- gsprob(x$theta, x$n.I, a, x$upper$bound, r = x$r, overrun = x$overrun)
+    x$upper$prob <- y$probhi
+    x$en <- as.vector(y$en)
+  } else {
+    y <- gsprob(x$theta, x$n.I, x$lower$bound, x$upper$bound, r = x$r, overrun = x$overrun)
+    x$upper$prob <- y$probhi
+    x$lower$prob <- y$problo
+    x$en <- as.vector(y$en)
   }
 
   x

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -595,25 +595,23 @@ gsBoundSummary0 <- function(
   if (x$test.type > 1) rval$Futility <- round(rval$Futility, digits)
   if (x$test.type %in% c(7, 8)) rval$Harm <- round(rval$Harm, digits)
 
-  # Mask inactive bounds as NA based on testUpper/testLower/testHarm
-  probability_row <- grepl("^P\\(Cross\\)", rval$Value)
+  # Mask every characteristic for inactive bounds as NA based on
+  # testUpper/testLower/testHarm, including cumulative P(Cross) rows.
   inactive_upper <- which(gsBoundDisplayInactive(x$upper, x$testUpper))
   if (length(inactive_upper) > 0 && "Efficacy" %in% names(rval)) {
-    mask <- analysis_i %in% inactive_upper & (!probability_row | x$testUpper[analysis_i])
-    rval$Efficacy[mask] <- NA
+    rval$Efficacy[analysis_i %in% inactive_upper] <- NA
   }
   inactive_lower <- which(gsBoundDisplayInactive(x$lower, x$testLower))
   if (length(inactive_lower) > 0 && "Futility" %in% names(rval)) {
-    mask <- analysis_i %in% inactive_lower & (!probability_row | x$testLower[analysis_i])
-    rval$Futility[mask] <- NA
+    rval$Futility[analysis_i %in% inactive_lower] <- NA
   }
   inactive_harm <- which(gsBoundDisplayInactive(x$harm, x$testHarm))
   if (length(inactive_harm) > 0 && "Harm" %in% names(rval)) {
-    mask <- analysis_i %in% inactive_harm & (!probability_row | x$testHarm[analysis_i])
-    rval$Harm[mask] <- NA
+    rval$Harm[analysis_i %in% inactive_harm] <- NA
   }
 
   class(rval) <- c("gsBoundSummary", "data.frame")
+  attr(rval, "analysis_i") <- analysis_i
   if ("gsSurv" %in% class(x) && !is.null(x$method)) {
     attr(rval, "method") <- x$method
   }
@@ -698,7 +696,11 @@ gsBoundSummary0 <- function(
 #' \code{x}, the probability of crossing either bound given that treatment
 #' effect is computed. This value is cumulative for each bound. For example,
 #' the probability of crossing the efficacy bound at or before the analysis of
-#' interest.
+#' interest. For test types 7 and 8, harm, futility, and efficacy crossing
+#' probabilities are mutually exclusive. Every characteristic for a bound,
+#' including its cumulative crossing probability, is shown as \code{NA} at an
+#' analysis where that bound is inactive. The underlying probability arrays on
+#' \code{x} retain the cumulative crossing information.
 #'
 #' @param x An item of class \code{gsDesign} or \code{gsSurv}, except for
 #' \code{print.gsBoundSummary()} where \code{x} is an object created by
@@ -758,9 +760,14 @@ gsBoundSummary0 <- function(
 #' degree of accuracy of group sequential calculations which will normally not
 #' be changed.
 #' @param alpha If used, a vector of alternate alpha-levels to print boundaries
-#' for. Only works with test.type 1, 4, 6, 7, and 8. If specified, efficacy bound
+#' for. Only works with non-binding test types 1, 4, 6, and 8. If specified,
+#' efficacy bound
 #' columns are headed by individual alpha levels. The alpha level of the input
-#' design is always included as the first column.
+#' design is always included as the first column. Alternate alpha levels retain
+#' the efficacy testing schedule in \code{x$testUpper}. Binding lower-bound
+#' designs, including test type 7, are not supported for alternate-alpha
+#' summaries because they do not satisfy the non-binding framework used for
+#' Maurer--Bretz graphical multiple testing.
 #' @param row.names indicator of whether or not to print row names
 #' @param include.rownames indicator of whether or not to include row names in
 #' output.
@@ -909,12 +916,14 @@ gsBoundSummary <- function(
     x, deltaname, logdelta, Nname, digits, ddigits, tdigits, timename,
     exclude = exclude, POS = POS, ratio = ratio, r = r, prior = prior
   )
+  analysis_i <- attr(out, "analysis_i")
+  attr(out, "analysis_i") <- NULL
   # Return unchanged if alpha is NULL or if test.type is not supported
   if (is.null(alpha)) {
     return(out)
   }
-  if (!(x$test.type %in% c(1, 4, 6, 7, 8))) {
-    message("Alternate alpha levels only available for test.type 1, 4, 6, 7, and 8. Ignoring alpha levels.")
+  if (!(x$test.type %in% c(1, 4, 6, 8))) {
+    message("Alternate alpha levels only available for non-binding test.type 1, 4, 6, and 8. Ignoring alpha levels.")
     return(out)
   }
 
@@ -931,12 +940,12 @@ gsBoundSummary <- function(
     stop("alpha must be NULL or a numeric vector with values strictly between 0 and 1 - x$beta")
   }
 
-  # For test.type 4, 6, 7, or 8, save Futility (and Harm) columns
+  # For test.type 4, 6, or 8, save Futility (and Harm) columns
   if (x$test.type %in% c(4, 6)) {
     # save futility column for later
     fut_col <- out$Futility
     out <- out[, 1:3]
-  } else if (x$test.type %in% c(7, 8)) {
+  } else if (x$test.type == 8) {
     # save harm and futility columns for later
     harm_col <- out$Harm
     fut_col <- out$Futility
@@ -976,27 +985,8 @@ gsBoundSummary <- function(
     if (isTRUE(all.equal(a, x$alpha, tolerance = 1e-7))) next # Skip if it's the original alpha
     n_alpha <- n_alpha + 1 # increment # of alpha columns
 
-    # Create design with new alpha
-    y <- gsDesign(
-      k = x$k,
-      n.I = x$n.I,
-      maxn.IPlan = max(x$n.I),
-      test.type = 1, # Use test.type = 1 for all new alpha levels
-      alpha = a,
-      beta = x$beta,
-      timing = x$timing,
-      sfu = x$upper$sf,
-      sfupar = x$upper$param,
-      sfl = x$lower$sf,
-      sflpar = x$lower$param,
-      endpoint = x$endpoint,
-      delta = x$delta,
-      delta1 = x$delta1,
-      delta0 = x$delta0,
-      r = r,
-      usTime = x$upper$sTime,
-      lsTime = x$lower$sTime
-    )
+    # Create design with new alpha and the original efficacy testing schedule
+    y <- gsAlternateAlphaDesign(x = x, alpha = a, r = r)
 
     # Get summary for design with new alpha
     yout <- gsBoundSummary0(
@@ -1010,10 +1000,17 @@ gsBoundSummary <- function(
     # now if test.type is not 1, we need to add futility bounds
     # from original and recompute conditional power, and boundary crossing probabilities
     if (x$test.type > 1) {
-      y2 <- gsProbability(
-        k = x$k, theta = x$theta, a = x$lower$bound, b = y$upper$bound, r = r,
-        n.I = x$n.I
-      )
+      y2 <- x
+      y2$upper$bound <- y$upper$bound
+      y2$lower$bound <- pmin(x$lower$bound, y$upper$bound)
+      if (x$test.type == 8 && !is.null(y2$harm)) {
+        both_active <- y2$testLower & y2$testHarm
+        y2$harm$bound[both_active] <- pmin(
+          y2$harm$bound[both_active],
+          y2$lower$bound[both_active]
+        )
+      }
+      y2 <- gsDProb(theta = x$theta, d = y2)
 
       # We only need to fix rows for CP, CP H1, PP, and P(Cross), if test.type is not 1;
       # This uses futility bound from original alpha level
@@ -1037,17 +1034,61 @@ gsBoundSummary <- function(
     }
   }
 
+  # Reapply the original efficacy schedule after alternate-alpha probability
+  # rows are recomputed so no characteristic is reintroduced at a skipped look.
+  inactive_upper <- which(gsBoundDisplayInactive(x$upper, x$testUpper))
+  if (length(inactive_upper) > 0) {
+    out[analysis_i %in% inactive_upper, 3:ncol(out)] <- NA
+  }
+
   # Add futility (and harm) columns back
   if (x$test.type %in% c(4, 6)) {
     out <- cbind(out, fut_col)
     names(out)[ncol(out)] <- "Futility"
-  } else if (x$test.type %in% c(7, 8)) {
+  } else if (x$test.type == 8) {
     out <- cbind(out, fut_col, harm_col)
     names(out)[(ncol(out) - 1):ncol(out)] <- c("Futility", "Harm")
   }
 
   class(out) <- c("gsBoundSummary", "data.frame")
   return(out)
+}
+
+# gsAlternateAlphaDesign: non-binding efficacy bounds at alternate alpha ----
+gsAlternateAlphaDesign <- function(
+    x, alpha, r,
+    sfu = x$upper$sf,
+    sfupar = x$upper$param,
+    usTime = x$upper$sTime) {
+  test_upper <- if (is.null(x$testUpper)) rep(TRUE, x$k) else x$testUpper
+  lower_sf <- if (is.null(x$lower) || is.null(x$lower$sf)) sfHSD else x$lower$sf
+  lower_param <- if (is.null(x$lower) || is.null(x$lower$param)) -2 else x$lower$param
+  lower_time <- if (is.null(x$lower)) NULL else x$lower$sTime
+
+  # A type 4 helper gives the same non-binding efficacy calculation as type 1
+  # while allowing the original selective efficacy schedule to be retained.
+  gsDesign(
+    k = x$k,
+    n.I = x$n.I,
+    maxn.IPlan = max(x$n.I),
+    test.type = 4,
+    alpha = alpha,
+    beta = x$beta,
+    timing = x$timing,
+    sfu = sfu,
+    sfupar = sfupar,
+    sfl = lower_sf,
+    sflpar = lower_param,
+    endpoint = x$endpoint,
+    delta = x$delta,
+    delta1 = x$delta1,
+    delta0 = x$delta0,
+    r = r,
+    usTime = usTime,
+    lsTime = lower_time,
+    testUpper = test_upper,
+    testLower = TRUE
+  )
 }
 
 # xprint roxy [sinew] ----

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -596,17 +596,21 @@ gsBoundSummary0 <- function(
   if (x$test.type %in% c(7, 8)) rval$Harm <- round(rval$Harm, digits)
 
   # Mask inactive bounds as NA based on testUpper/testLower/testHarm
+  probability_row <- grepl("^P\\(Cross\\)", rval$Value)
   inactive_upper <- which(gsBoundDisplayInactive(x$upper, x$testUpper))
   if (length(inactive_upper) > 0 && "Efficacy" %in% names(rval)) {
-    rval$Efficacy[analysis_i %in% inactive_upper] <- NA
+    mask <- analysis_i %in% inactive_upper & (!probability_row | x$testUpper[analysis_i])
+    rval$Efficacy[mask] <- NA
   }
   inactive_lower <- which(gsBoundDisplayInactive(x$lower, x$testLower))
   if (length(inactive_lower) > 0 && "Futility" %in% names(rval)) {
-    rval$Futility[analysis_i %in% inactive_lower] <- NA
+    mask <- analysis_i %in% inactive_lower & (!probability_row | x$testLower[analysis_i])
+    rval$Futility[mask] <- NA
   }
   inactive_harm <- which(gsBoundDisplayInactive(x$harm, x$testHarm))
   if (length(inactive_harm) > 0 && "Harm" %in% names(rval)) {
-    rval$Harm[analysis_i %in% inactive_harm] <- NA
+    mask <- analysis_i %in% inactive_harm & (!probability_row | x$testHarm[analysis_i])
+    rval$Harm[mask] <- NA
   }
 
   class(rval) <- c("gsBoundSummary", "data.frame")

--- a/R/gsSurv-nSurv.R
+++ b/R/gsSurv-nSurv.R
@@ -95,6 +95,11 @@
 #'
 #' The input to \code{gsSurv} is a combination of the input to \code{nSurv()}
 #' and \code{gsDesign()}.
+#' The original call is stored in \code{call}. The \code{inputs} component
+#' retains evaluated survival-model inputs used for printing and the applicable
+#' \code{testUpper}, \code{testLower}, and \code{testHarm} arguments. The
+#' normalized testing schedules used by the design are stored directly in the
+#' corresponding top-level components.
 #' When \code{T = NULL} and \code{minfup} is specified, \code{gsSurv()}
 #' preserves the input accrual rate and minimum follow-up, applies the group
 #' sequential design, and solves the accrual duration needed for the final

--- a/R/gsSurv.R
+++ b/R/gsSurv.R
@@ -138,6 +138,9 @@ gsSurv <- function(
   y$tol <- tol
   y$method <- x$method
   y$call <- match.call()
+  input_vals$testUpper <- testUpper
+  if (test.type > 2) input_vals$testLower <- testLower
+  if (test.type > 6) input_vals$testHarm <- testHarm
   y$inputs <- input_vals
   class(y) <- c("gsSurv", "gsDesign")
 

--- a/R/gsSurvCalendar.R
+++ b/R/gsSurvCalendar.R
@@ -163,6 +163,9 @@ gsSurvCalendar <- function(
   y$T <- calendarTime
   y$method <- x$method
   y$call <- match.call()
+  input_vals$testUpper <- testUpper
+  if (test.type > 2) input_vals$testLower <- testLower
+  if (test.type > 6) input_vals$testHarm <- testHarm
   y$inputs <- input_vals
   class(y) <- c("gsSurv", "gsDesign")
 

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -96,12 +96,18 @@
 #'     exactly.
 #'   \item \strong{Upper-bound parameters changed} (\code{alpha}, \code{sfu},
 #'     or \code{sfupar}) but timing matches: new efficacy bounds are computed
-#'     via \code{gsDesign(test.type = 1)} at the new alpha, while the
-#'     original futility bounds from \code{x} are preserved. Any futility
-#'     bound that exceeds the new efficacy bound is clipped. This follows
-#'     the same convention as \code{gsBoundSummary()}. Lower-bound spending
-#'     settings from \code{x} are intentionally kept in this branch, which
-#'     avoids complications with \code{astar} validation for binding types.
+#'     using the non-binding efficacy convention at the new alpha while
+#'     preserving the original \code{testUpper} schedule and futility bounds
+#'     from \code{x}. Any futility bound that exceeds the new efficacy bound
+#'     is clipped. This follows the same convention as
+#'     \code{gsBoundSummary()}. Lower-bound spending settings from \code{x}
+#'     are intentionally kept in this branch, which avoids complications with
+#'     \code{astar} validation for binding types.
+#'     For non-binding test types 1, 4, 6, and 8, this calculation can be used
+#'     to evaluate alpha propagated by a graphical multiple-testing procedure.
+#'     For binding test types 2, 3, 5, and 7, it is a planning sensitivity
+#'     calculation only; it is not a Maurer--Bretz sequential-p-value or
+#'     graphical alpha-recycling procedure.
 #'   \item \strong{Timing changed} (different target events or calendar
 #'     times): both bounds are recomputed from scratch using the full
 #'     \code{test.type} and all spending parameters.
@@ -998,20 +1004,13 @@ gsSurvPower <- function(
     upper_bounds <- settings$x$upper$bound
     lower_bounds <- settings$x$lower$bound
   } else if (bound_strategy == "update_upper") {
-    design_object <- gsDesign::gsDesign(
-      k = settings$k,
-      test.type = 1,
+    design_object <- gsAlternateAlphaDesign(
+      x = settings$x,
       alpha = settings$alpha,
-      beta = settings$beta_design,
-      n.fix = n_fix,
-      timing = current_timing,
+      r = settings$r,
       sfu = settings$sfu,
       sfupar = settings$sfupar,
-      tol = settings$tol,
-      delta1 = log(settings$hr1),
-      delta0 = log(settings$hr0),
-      usTime = spending_times$usTime,
-      r = settings$r
+      usTime = settings$x$upper$sTime
     )
     upper_bounds <- design_object$upper$bound
     if (!is.null(settings$x$lower$bound)) {
@@ -1060,13 +1059,30 @@ gsSurvPower <- function(
     settings$hr1,
     settings
   )
-  probabilities <- gsDesign::gsProbability(
-    k = settings$k,
+  probability_design <- design_object
+  probability_design$test.type <- settings$test.type
+  probability_design$n.I <- total_events
+  probability_design$upper$bound <- upper_bounds
+  probability_design$lower$bound <- lower_bounds
+  probability_design$testUpper <- .gsSurvPower_format_test_flag(
+    settings$testUpper, settings$k
+  )
+  probability_design$testLower <- .gsSurvPower_format_test_flag(
+    settings$testLower, settings$k
+  )
+  if (settings$test.type %in% c(7, 8)) {
+    probability_design$testHarm <- .gsSurvPower_format_test_flag(
+      settings$testHarm, settings$k
+    )
+    both_active <- probability_design$testLower & probability_design$testHarm
+    probability_design$harm$bound[both_active] <- pmin(
+      probability_design$harm$bound[both_active],
+      probability_design$lower$bound[both_active]
+    )
+  }
+  probabilities <- gsDProb(
     theta = c(0, theta_assumed),
-    n.I = total_events,
-    a = lower_bounds,
-    b = upper_bounds,
-    r = settings$r
+    d = probability_design
   )
 
   list(
@@ -1148,6 +1164,9 @@ gsSurvPower <- function(
   result$upper$bound <- bound_result$upper_bounds
   result$lower$prob <- bound_result$probabilities$lower$prob
   result$lower$bound <- bound_result$lower_bounds
+  if (settings$test.type %in% c(7, 8)) {
+    result$harm$prob <- bound_result$probabilities$harm$prob
+  }
   result$en <- bound_result$probabilities$en
   result$theta <- bound_result$probabilities$theta
   result$power <- sum(bound_result$probabilities$upper$prob[, 2])

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -19,6 +19,13 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #' overridden when \code{plottype=2}. Default values for labels depend on
 #' \code{plottype} and the class of \code{x}.
 #'
+#' For test types 7 and 8, harm and futility probabilities stored on the
+#' design are mutually exclusive stopping outcomes. In a type 2 plot, the
+#' futility-threshold curve is inclusive: it uses the sum of futility-only and
+#' harm crossing probabilities. The separate harm curve continues to show
+#' harm crossings only. This plotting convention does not modify the
+#' probabilities stored on \code{x}.
+#'
 #' Note that there is some special behavior for values plotted and returned for
 #' power and expected sample size (ASN) plots for a \code{gsDesign} object. A
 #' call to \code{x<-gsDesign()} produces power and expected sample size for
@@ -978,6 +985,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
   }
   test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
   has_harm <- test.type %in% c(7, 8) && !is.null(x$harm)
+  lower_prob <- if (has_harm) x$lower$prob + x$harm$prob else x$lower$prob
   theta <- xval
   if (!base && outtype == 1) {
     if (is.null(lty)) lty <- x$k:1
@@ -985,9 +993,9 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     y <- cbind(stats::reshape(xu, varying = names(xu), v.names = "Probability", timevar = "thetaidx", direction = "long"), Bound = "Upper bound")
     if (is.null(col)) col <- 1
     if (is.null(x$test.type) || x$test.type > 1) {
-      lower_label <- if (has_harm) "1-Futility bound" else "1-Lower bound"
+      lower_label <- if (has_harm) "1-(Futility or harm)" else "1-Lower bound"
       y <- rbind(
-        cbind(stats::reshape(data.frame(x$lower$prob), varying = names(xu), v.names = "Probability", timevar = "thetaidx", direction = "long"), Bound = lower_label),
+        cbind(stats::reshape(data.frame(lower_prob), varying = names(xu), v.names = "Probability", timevar = "thetaidx", direction = "long"), Bound = lower_label),
         y
       )
       if (length(col) == 1) col <- c(2, 1)
@@ -995,7 +1003,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     # Add harm bound for test.type 7/8
     if (has_harm) {
       y <- rbind(
-        cbind(stats::reshape(data.frame(x$harm$prob), varying = names(xu), v.names = "Probability", timevar = "thetaidx", direction = "long"), Bound = "1-Harm bound"),
+        cbind(stats::reshape(data.frame(x$harm$prob), varying = names(xu), v.names = "Probability", timevar = "thetaidx", direction = "long"), Bound = "1-Harm"),
         y
       )
       if (length(col) == 2) col <- c(4, col)
@@ -1007,10 +1015,10 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
              dplyr::group_by(Bound, thetaidx) |>
              dplyr::reframe(Probability = cumsum(Probability))
     
-    lower_label <- if (has_harm) "1-Futility bound" else "1-Lower bound"
+    lower_label <- if (has_harm) "1-(Futility or harm)" else "1-Lower bound"
     y2$Probability[y2$Bound == lower_label] <- 1 - y2$Probability[y2$Bound == lower_label]
     if (has_harm) {
-      y2$Probability[y2$Bound == "1-Harm bound"] <- 1 - y2$Probability[y2$Bound == "1-Harm bound"]
+      y2$Probability[y2$Bound == "1-Harm"] <- 1 - y2$Probability[y2$Bound == "1-Harm"]
     }
     
     y2$Analysis <- factor(y$id + offset)
@@ -1094,7 +1102,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     {
       theta <- c(theta, xval)
       interim <- c(interim, rep(j, length(xval)))
-      boundprob <- boundprob - x$lower$prob[j, ]
+      boundprob <- boundprob - lower_prob[j, ]
       prob <- c(prob, boundprob)
       ymid <- mean(range(boundprob))
       yval <- c(yval, min(boundprob[boundprob >= ymid]))
@@ -1160,12 +1168,12 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
     }
 
     if ((inherits(x, "gsDesign") && test.type > 2) || !inherits(x, "gsDesign")) {
-      graphics::lines(xval, 1 - x$lower$prob[1, ], lty = lty2, col = col2, lwd = lwd2)
-      plo <- x$lower$prob[1, ]
+      graphics::lines(xval, 1 - lower_prob[1, ], lty = lty2, col = col2, lwd = lwd2)
+      plo <- lower_prob[1, ]
 
       for (i in 2:x$k)
       {
-        plo <- plo + x$lower$prob[i, ]
+        plo <- plo + lower_prob[i, ]
         graphics::lines(xval, 1 - plo, lty = lty2, col = col2, lwd = lwd2)
       }
 
@@ -1183,7 +1191,7 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
       }
 
       if (has_harm) {
-        leg_labels <- c("Upper", "Futility", "Harm")
+        leg_labels <- c("Upper", "Futility or harm", "Harm")
         leg_col <- col[1:3]
         leg_lwd <- lwd[1:3]
         leg_lty <- lty[1:3]
@@ -1251,11 +1259,11 @@ plotgsPower <- function(x, main = "Boundary crossing probabilities by effect siz
       p <- p + 
         ggplot2::scale_colour_manual(
         name = "Probability", values = getColor(col[1:3]), breaks = 1:3,
-        labels = c("Upper bound", "1-Futility bound", "1-Harm bound")
+        labels = c("Upper bound", "1-(Futility or harm)", "1-Harm")
       ) +
         ggplot2::scale_linetype_manual(
           name = "Probability", values = lty[1:3], breaks = 1:3,
-          labels = c("Upper bound", "1-Futility bound", "1-Harm bound")
+          labels = c("Upper bound", "1-(Futility or harm)", "1-Harm")
         )
     } else {
       p <- p + 

--- a/R/sequentialPValue.R
+++ b/R/sequentialPValue.R
@@ -6,8 +6,11 @@
 #' where sequential p-values for multiple hypotheses can be used as nominal p-values to plug into a multiplicity graph. 
 #' A sequential p-value is described as the minimum alpha level at which a one-sided group sequential bound would 
 #' be rejected given interim and final observed results.
-#' It is meaningful for both one-sided designs and designs with non-binding futility bounds (\code{test.type} 1, 4, 6), 
-#' but not for 2-sided designs with binding futility bounds (\code{test.type} 2, 3 or 5).
+#' It is meaningful for both one-sided designs and designs with non-binding
+#' futility or harm bounds (\code{test.type} 1, 4, 6, or 8), but not for
+#' 2-sided designs with binding futility or harm bounds (\code{test.type} 2,
+#' 3, 5, or 7). For test type 8, both non-binding lower bounds are ignored in
+#' the Type I error calculation.
 #' Mild restrictions are required on spending functions used, but these are satisfied for commonly used spending functions
 #' such as the Lan-DeMets spending function approximating an O'Brien-Fleming bound or a Hwang-Shih-DeCani spending function; see Maurer and Bretz (2013).
 #' 
@@ -69,8 +72,10 @@ sequentialPValue <- function(gsD = gsDesign(),
                              interval=c(.00001,.9999)){
   # check that gsD has class "gsDesign" (note: this includes "gsSurv" type)
   if (!inherits(gsD, "gsDesign")) stop("d should be an object of class gsDesign or gsSurv")
-  # check that gsD$test.type is 1,4 or 6
-  if(max(gsD$test.type == c(1,4,6)) != 1) stop("gsD$test.type must be 1, 4, or 6 (no binding lower bound allowed)")
+  # Check that lower and harm bounds, if present, are non-binding.
+  if (!(gsD$test.type %in% c(1, 4, 6, 8))) {
+    stop("gsD$test.type must be 1, 4, 6, or 8 (no binding lower or harm bound allowed)")
+  }
   # if n.I not specified, assume planned values used
   if (is.null(n.I)) n.I <- gsD$n.I
   # check that n.I, Z and, if non-NULL, usTime are real vectors of the same length

--- a/R/toBinomialExact.R
+++ b/R/toBinomialExact.R
@@ -15,34 +15,49 @@
 #'   \code{observedEvents} is supplied, or to the planned design timing
 #'   otherwise.
 #' @param lsTime Optional lower spending-time override for \code{test.type = 4}
+#'   or \code{6}
 #'   (same length and monotonicity requirements as \code{usTime}). If
 #'   \code{NULL}, it defaults to \code{usTime}.
 #' @param maxSpend Logical scalar. If `TRUE`, force full alpha spending (and, for
-#'   `test.type = 4`, full beta spending) at the final analysis even when
+#'   `test.type = 4`, full beta spending; for `test.type = 6`, full lower-bound
+#'   spending under the null) at the final analysis even when
 #'   `observedEvents[k] < x$maxn.IPlan`. This keeps earlier analysis spending
 #'   unchanged and applies the override only at the last look.
 #' 
 #' @details
-#' Only \code{test.type} 1 (one-sided) and \code{test.type} 4
-#' (non-binding futility) are supported. Other test types (including
-#' \code{test.type} 7 and 8 with harm bounds) will produce
-#' an error.
+#' Test types 1 (one-sided), 4 (non-binding beta-spending futility), and 6
+#' (non-binding lower-bound spending under the null) are supported for full
+#' conversion.
+#' The current \code{gsBinomialExact} object contains one lower efficacy bound
+#' and one upper stopping bound. Consequently, it cannot represent the
+#' separate futility and harm bounds required by test types 7 and 8. Binding
+#' designs (types 2, 3, 5, and 7) are outside the non-binding exact-efficacy
+#' framework. Exact repeated and sequential efficacy
+#' p-values can nevertheless be computed for non-binding types 1, 4, 6, and 8
+#' with \code{repeatedPValueBinomialExact()} and
+#' \code{sequentialPValueBinomialExact()}, which intentionally ignore
+#' non-binding lower and harm bounds.
 #'
 #' The exact binomial routine \code{gsBinomialExact} has requirements that may not be satisfied
 #' by the initial asymptotic approximation. 
 #' Thus, the approximations are updated to satisfy the following requirements of \code{gsBinomialExact}:
 #' \code{a} (the efficacy bound) must be positive, non-decreasing, and strictly less than n.I
-#' \code{b} (the futility bound) must be positive, non-decreasing, strictly greater than a
+#' \code{b} (the upper event-count stopping bound for futility or the Type 6
+#' lower bound) must be positive, non-decreasing, and strictly greater than a
 #' \code{n.I - b} must be non-decreasing and >= 0
 #'
 #' With `observedEvents`, spending times are based on
 #' \code{observedEvents / x$maxn.IPlan}. If \code{maxSpend = TRUE}, the final
 #' spending time is set to 1 so all remaining spending is used at the last look.
 #' If \code{x$testLower} is present (for example from \code{gsSurv()} with
-#' selective futility looks), futility spending is flattened at analyses where
-#' \code{testLower = FALSE}.
+#' selective lower-bound looks), lower-bound spending is flattened at analyses
+#' where \code{testLower = FALSE}.
 #' 
-#' @return An object of class \code{gsBinomialExact}.
+#' @return An object of class \code{gsBinomialExact}. The returned object also
+#'   records `test.type`, `alpha`, applicable `astar`, and `testLower`. For
+#'   `test.type = 6`, the exact object's upper event-count bound represents the
+#'   non-binding lower stopping bound, with its first probability column
+#'   calibrated under the null hypothesis.
 #'
 #' @seealso \code{\link{gsBinomialExact}}
 #'
@@ -84,7 +99,22 @@
 #' toBinomialExact(x, observedEvents = c(20, 55, 75), maxSpend = TRUE)
 toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NULL, lsTime = NULL, maxSpend = FALSE) {
   if (!inherits(x, "gsSurv")) stop("toBinomialExact must have class gsSurv as input")
-  if (x$test.type != 1 && x$test.type != 4) stop("toBinomialExact input test.type must be 1 or 4")
+  if (!(x$test.type %in% c(1, 4, 6))) {
+    reason <- switch(
+      as.character(x$test.type),
+      `2` = "symmetric two-sided boundaries are not represented by the exact lower-tail efficacy conversion",
+      `3` = "binding futility bounds are outside the non-binding exact-efficacy framework",
+      `5` = "binding lower bounds are outside the non-binding exact-efficacy framework",
+      `7` = "binding futility and harm bounds are outside the non-binding exact-efficacy framework",
+      `8` = "gsBinomialExact has only two boundaries and cannot separately represent futility and harm",
+      "this test type is not supported"
+    )
+    stop(
+      "toBinomialExact input test.type must be 1, 4, or 6; test.type = ",
+      x$test.type, " is unsupported because ", reason,
+      call. = FALSE
+    )
+  }
   if (is.null(alpha)) {
     alpha <- x$alpha
   } else if (!is.numeric(alpha) || length(alpha) != 1 || !is.finite(alpha) || alpha <= 0 || alpha >= 1) {
@@ -93,8 +123,17 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
   if (!is.logical(maxSpend) || length(maxSpend) != 1 || is.na(maxSpend)) {
     stop("toBinomialExact: maxSpend must be TRUE or FALSE")
   }
+  astar_tracks_complement <- x$test.type == 6 &&
+    isTRUE(all.equal(x$astar, 1 - x$alpha, tolerance = 1e-7))
+  effective_astar <- if (astar_tracks_complement) 1 - alpha else x$astar
+  if (x$test.type == 6 && effective_astar > 1 - alpha) {
+    stop(
+      "toBinomialExact: alpha override requires astar <= 1 - alpha for test.type = 6",
+      call. = FALSE
+    )
+  }
   if (x$test.type == 1 && !is.null(lsTime)) {
-    stop("toBinomialExact: lsTime can only be specified for test.type = 4")
+    stop("toBinomialExact: lsTime can only be specified for test.type = 4 or 6")
   }
   # Round interim sample size (or events for gsSurv object)
   xx <- if (max(round(x$n.I) != x$n.I)) toInteger(x) else x
@@ -117,7 +156,7 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
       test.type = x$test.type,
       alpha = alpha,
       beta = x$beta,
-      astar = x$astar,
+      astar = effective_astar,
       sfu = x$upper$sf,
       sfupar = x$upper$param,
       sfl = x$lower$sf,
@@ -164,29 +203,36 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
   if (sum(timing >= 1) > 1) {
     stop("toBinomialExact: usTime must have at most 1 value >= 1")
   }
-  if (x$test.type == 4 && sum(timingl >= 1) > 1) {
+  if (x$test.type %in% c(4, 6) && sum(timingl >= 1) > 1) {
     stop("toBinomialExact: lsTime must have at most 1 value >= 1")
   }
   alpha_spend <- xx$upper$sf(alpha = alpha, t = timing, param = xx$upper$param)$spend
   if (x$test.type != 1) {
-    # Upper bound probabilities are for futility
-    # Compute nominal p-values under H0 for futility and corresponding inverse binomial under H1
+    # Upper event-count probabilities represent the non-binding lower stopping
+    # bound (beta-spending futility for Type 4; H0 spending for Type 6).
     b <- qbinom(p = pnorm(-xx$lower$bound), size = counts, prob = p0)
-    init_approx$b <- b # save initial futility bound approximation
+    init_approx$b <- b # save initial upper event-count bound approximation
 
     # check that b is non-decreasing, > a, and n.I - b is non-decreasing
     b <- pmin(b, counts + 1)
     b <- pmax(a + 1, b)
     b <- pmin(b, counts - dplyr::lag(counts, def = 0) + dplyr::lag(b, def = 1))
-    # Compute target beta-spending
-    beta_spend <- xx$lower$sf(alpha = xx$beta, t = timingl, param = xx$lower$param)$spend
+    # Type 4 targets beta spending under H1. Type 6 targets lower-bound
+    # spending under H0.
+    lower_spend_total <- if (x$test.type == 4) xx$beta else xx$astar
+    lower_spend <- xx$lower$sf(
+      alpha = lower_spend_total,
+      t = timingl,
+      param = xx$lower$param
+    )$spend
+    active_lower <- rep(TRUE, k)
     if (!is.null(x$testLower)) {
       active_lower <- x$testLower
       if (length(active_lower) == 1) active_lower <- rep(active_lower, k)
       if (length(active_lower) == k) {
         for (i in seq_len(k)) {
           if (!isTRUE(active_lower[i])) {
-            beta_spend[i] <- if (i == 1) 0 else beta_spend[i - 1]
+            lower_spend[i] <- if (i == 1) 0 else lower_spend[i - 1]
           }
         }
       }
@@ -250,8 +296,8 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
         k = max(j, 2), theta = p1, n.I = counts[1:max(j, 2)],
         a = a[1:max(j, 2)], b = b[1:max(j, 2)]
       )$upper$prob[1:j])
-      if (upperprob < beta_spend[j]) {
-        while (upperprob < beta_spend[j]) {
+      if (upperprob < lower_spend[j]) {
+        while (upperprob < lower_spend[j]) {
           b[j] <- btem[j]
           if (btem[j] == bmin) break # only lower if range allows
           btem[j] <- btem[j] - 1
@@ -261,8 +307,8 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
           )$upper$prob[1:j])
         }
         
-      } else if (upperprob > beta_spend[j]) {
-        while (upperprob > beta_spend[j] && 
+      } else if (upperprob > lower_spend[j]) {
+        while (upperprob > lower_spend[j] &&
                b[j] < bmax) {
           b[j] <- b[j] + 1
           upperprob <- sum(gsBinomialExact(
@@ -271,10 +317,68 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
           )$upper$prob[1:j])
         }
       }
+    } else if (x$test.type == 6) {
+      # Type 6 uses the same exact two-bound recursion, but chooses the upper
+      # event-count boundary to spend under H0 rather than under H1.
+      bmin <- a[j] + 1
+      bmin <- ifelse(j == 1, bmin, max(bmin, b[j - 1]))
+      bmax <- counts[j] + 1
+      bmax <- ifelse(
+        j == 1,
+        bmax,
+        min(bmax, counts[j] - counts[j - 1] + b[j - 1])
+      )
+      if (bmin > bmax) {
+        stop(paste("bmin > bmax: bmin =", bmin, "bmax =", bmax, "j =", j))
+      }
+
+      # No boundary crossing is allowed at an inactive lower look.
+      if (!isTRUE(active_lower[j])) {
+        b[j] <- bmax
+      } else if (j == k && astar_tracks_complement && timingl[j] >= 1) {
+        # With default astar = 1 - alpha and full spending, use the smallest
+        # allowable upper bound so the final decision regions are exhaustive
+        # to the extent permitted by monotone integer boundaries.
+        b[j] <- bmin
+      } else {
+        candidates <- seq.int(bmin, bmax)
+        upper_probability <- vapply(candidates, function(candidate) {
+          if (j == 1) {
+            return(stats::pbinom(
+              q = candidate - 1,
+              size = counts[j],
+              prob = p0,
+              lower.tail = FALSE
+            ))
+          }
+          b_candidate <- b[seq_len(j)]
+          b_candidate[j] <- candidate
+          sum(gsBinomialExact(
+            k = j,
+            theta = p0,
+            n.I = counts[seq_len(j)],
+            a = a[seq_len(j)],
+            b = b_candidate
+          )$upper$prob[, 1])
+        }, numeric(1))
+        allowed <- which(
+          upper_probability <= lower_spend[j] * (1 + 1e-10) +
+            .Machine$double.xmin
+        )
+        b[j] <- if (length(allowed) > 0) {
+          candidates[allowed[which.max(upper_probability[allowed])]]
+        } else {
+          bmax
+        }
+      }
     }
   }
   xxxx <- gsBinomialExact(k = k, theta = c(p0, p1), n.I = counts, a = a, b = b)
   xxxx$init_approx <- init_approx
+  xxxx$test.type <- x$test.type
+  xxxx$alpha <- alpha
+  xxxx$astar <- if (x$test.type == 6) xx$astar else NULL
+  xxxx$testLower <- if (x$test.type == 1) NULL else active_lower
   return(xxxx)
 }
 

--- a/R/toBinomialExact.R
+++ b/R/toBinomialExact.R
@@ -14,23 +14,23 @@
 #'   this defaults to \code{observedEvents / x$maxn.IPlan} (capped at 1) when
 #'   \code{observedEvents} is supplied, or to the planned design timing
 #'   otherwise.
-#' @param lsTime Optional lower spending-time override for \code{test.type = 4}
-#'   or \code{6}
+#' @param lsTime Optional lower spending-time override for \code{test.type = 4},
+#'   \code{6}, or \code{8}
 #'   (same length and monotonicity requirements as \code{usTime}). If
 #'   \code{NULL}, it defaults to \code{usTime}.
 #' @param maxSpend Logical scalar. If `TRUE`, force full alpha spending (and, for
-#'   `test.type = 4`, full beta spending; for `test.type = 6`, full lower-bound
+#'   `test.type = 4` or `8`, full beta spending; for `test.type = 6`, full
+#'   lower-bound spending under the null; and, for `test.type = 8`, full harm
 #'   spending under the null) at the final analysis even when
 #'   `observedEvents[k] < x$maxn.IPlan`. This keeps earlier analysis spending
 #'   unchanged and applies the override only at the last look.
 #' 
 #' @details
-#' Test types 1 (one-sided), 4 (non-binding beta-spending futility), and 6
-#' (non-binding lower-bound spending under the null) are supported for full
-#' conversion.
-#' The current \code{gsBinomialExact} object contains one lower efficacy bound
-#' and one upper stopping bound. Consequently, it cannot represent the
-#' separate futility and harm bounds required by test types 7 and 8. Binding
+#' Test types 1 (one-sided), 4 (non-binding beta-spending futility), 6
+#' (non-binding lower-bound spending under the null), and 8 (non-binding
+#' futility and harm) are supported for full conversion. For Type 8, the exact
+#' upper event-count stopping probability is partitioned into mutually
+#' exclusive futility and harm components. Binding
 #' designs (types 2, 3, 5, and 7) are outside the non-binding exact-efficacy
 #' framework. Exact repeated and sequential efficacy
 #' p-values can nevertheless be computed for non-binding types 1, 4, 6, and 8
@@ -42,8 +42,8 @@
 #' by the initial asymptotic approximation. 
 #' Thus, the approximations are updated to satisfy the following requirements of \code{gsBinomialExact}:
 #' \code{a} (the efficacy bound) must be positive, non-decreasing, and strictly less than n.I
-#' \code{b} (the upper event-count stopping bound for futility or the Type 6
-#' lower bound) must be positive, non-decreasing, and strictly greater than a
+#' \code{b} (the upper event-count stopping bound for futility, harm, or the
+#' Type 6 lower bound) must be positive, non-decreasing, and strictly greater than a
 #' \code{n.I - b} must be non-decreasing and >= 0
 #'
 #' With `observedEvents`, spending times are based on
@@ -54,10 +54,13 @@
 #' where \code{testLower = FALSE}.
 #' 
 #' @return An object of class \code{gsBinomialExact}. The returned object also
-#'   records `test.type`, `alpha`, applicable `astar`, and `testLower`. For
+#'   records `test.type`, `alpha`, applicable `astar`, `testLower`, and
+#'   applicable `testHarm`. For
 #'   `test.type = 6`, the exact object's upper event-count bound represents the
 #'   non-binding lower stopping bound, with its first probability column
-#'   calibrated under the null hypothesis.
+#'   calibrated under the null hypothesis. For `test.type = 8`, `upper`
+#'   represents all upper event-count stops, while `futility` and `harm`
+#'   partition those stops into mutually exclusive components.
 #'
 #' @seealso \code{\link{gsBinomialExact}}
 #'
@@ -99,18 +102,17 @@
 #' toBinomialExact(x, observedEvents = c(20, 55, 75), maxSpend = TRUE)
 toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NULL, lsTime = NULL, maxSpend = FALSE) {
   if (!inherits(x, "gsSurv")) stop("toBinomialExact must have class gsSurv as input")
-  if (!(x$test.type %in% c(1, 4, 6))) {
+  if (!(x$test.type %in% c(1, 4, 6, 8))) {
     reason <- switch(
       as.character(x$test.type),
       `2` = "symmetric two-sided boundaries are not represented by the exact lower-tail efficacy conversion",
       `3` = "binding futility bounds are outside the non-binding exact-efficacy framework",
       `5` = "binding lower bounds are outside the non-binding exact-efficacy framework",
       `7` = "binding futility and harm bounds are outside the non-binding exact-efficacy framework",
-      `8` = "gsBinomialExact has only two boundaries and cannot separately represent futility and harm",
       "this test type is not supported"
     )
     stop(
-      "toBinomialExact input test.type must be 1, 4, or 6; test.type = ",
+      "toBinomialExact input test.type must be 1, 4, 6, or 8; test.type = ",
       x$test.type, " is unsupported because ", reason,
       call. = FALSE
     )
@@ -123,17 +125,17 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
   if (!is.logical(maxSpend) || length(maxSpend) != 1 || is.na(maxSpend)) {
     stop("toBinomialExact: maxSpend must be TRUE or FALSE")
   }
-  astar_tracks_complement <- x$test.type == 6 &&
+  astar_tracks_complement <- x$test.type %in% c(6, 8) &&
     isTRUE(all.equal(x$astar, 1 - x$alpha, tolerance = 1e-7))
   effective_astar <- if (astar_tracks_complement) 1 - alpha else x$astar
-  if (x$test.type == 6 && effective_astar > 1 - alpha) {
+  if (x$test.type %in% c(6, 8) && effective_astar > 1 - alpha) {
     stop(
-      "toBinomialExact: alpha override requires astar <= 1 - alpha for test.type = 6",
+      "toBinomialExact: alpha override requires astar <= 1 - alpha for test.type = 6 or 8",
       call. = FALSE
     )
   }
   if (x$test.type == 1 && !is.null(lsTime)) {
-    stop("toBinomialExact: lsTime can only be specified for test.type = 4 or 6")
+    stop("toBinomialExact: lsTime can only be specified for test.type = 4, 6, or 8")
   }
   # Round interim sample size (or events for gsSurv object)
   xx <- if (max(round(x$n.I) != x$n.I)) toInteger(x) else x
@@ -151,7 +153,7 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
     if (k < 2) stop("toBinomialExact: must have at least 2 values in observedEvents")
   }
   if (!is.null(observedEvents) || !isTRUE(all.equal(alpha, x$alpha))) {
-    xx <- gsDesign(
+    design_args <- list(
       k = k,
       test.type = x$test.type,
       alpha = alpha,
@@ -167,6 +169,14 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
       delta1 = x$delta1,
       delta0 = x$delta0
     )
+    if (x$test.type == 8) {
+      design_args$sfharm <- x$harm$sf
+      design_args$sfharmparam <- x$harm$param
+      design_args$testUpper <- x$testUpper
+      design_args$testLower <- x$testLower
+      design_args$testHarm <- x$testHarm
+    }
+    xx <- do.call(gsDesign, design_args)
     xx$hr0 <- x$hr0
   }
   # Translate vaccine efficacy to exact binomial probabilities
@@ -203,13 +213,13 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
   if (sum(timing >= 1) > 1) {
     stop("toBinomialExact: usTime must have at most 1 value >= 1")
   }
-  if (x$test.type %in% c(4, 6) && sum(timingl >= 1) > 1) {
+  if (x$test.type %in% c(4, 6, 8) && sum(timingl >= 1) > 1) {
     stop("toBinomialExact: lsTime must have at most 1 value >= 1")
   }
   alpha_spend <- xx$upper$sf(alpha = alpha, t = timing, param = xx$upper$param)$spend
   if (x$test.type != 1) {
     # Upper event-count probabilities represent the non-binding lower stopping
-    # bound (beta-spending futility for Type 4; H0 spending for Type 6).
+    # bound (beta-spending futility for Types 4 and 8; H0 spending for Type 6).
     b <- qbinom(p = pnorm(-xx$lower$bound), size = counts, prob = p0)
     init_approx$b <- b # save initial upper event-count bound approximation
 
@@ -219,7 +229,7 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
     b <- pmin(b, counts - dplyr::lag(counts, def = 0) + dplyr::lag(b, def = 1))
     # Type 4 targets beta spending under H1. Type 6 targets lower-bound
     # spending under H0.
-    lower_spend_total <- if (x$test.type == 4) xx$beta else xx$astar
+    lower_spend_total <- if (x$test.type %in% c(4, 8)) xx$beta else xx$astar
     lower_spend <- xx$lower$sf(
       alpha = lower_spend_total,
       t = timingl,
@@ -239,6 +249,23 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
     }
   } else {
     b <- counts + 1 # test.type = 1 means no futility bound
+  }
+  if (x$test.type == 8) {
+    h <- qbinom(p = pnorm(-xx$harm$bound), size = counts, prob = p0)
+    init_approx$h <- h
+    h <- pmin(counts + 1, pmax(a + 1, h))
+    active_harm <- if (is.null(x$testHarm)) rep(TRUE, k) else x$testHarm
+    if (length(active_harm) == 1) active_harm <- rep(active_harm, k)
+    harm_spend <- xx$harm$sf(
+      alpha = xx$astar,
+      t = timingl,
+      param = xx$harm$param
+    )$spend
+    for (i in seq_len(k)) {
+      if (!isTRUE(active_harm[i])) {
+        harm_spend[i] <- if (i == 1) 0 else harm_spend[i - 1]
+      }
+    }
   }
   for (j in 1:k) {
     # Non-binding bound assumed.
@@ -371,15 +398,173 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
           bmax
         }
       }
+    } else if (x$test.type == 8) {
+      # Type 8 has three clinical regions in event-count space: efficacy at
+      # or below a, futility above b but below h, and harm at or above h.
+      # Efficacy remains non-binding. The first upper event-count stop is
+      # calibrated to beta spending under H1, and h is calibrated to harm
+      # spending under H0.
+      if (isTRUE(active_lower[j])) {
+        candidates <- seq.int(a[j] + 1L, counts[j] + 1L)
+        total_lower_probability <- vapply(candidates, function(candidate) {
+          b_candidate <- b[seq_len(j)]
+          h_candidate <- h[seq_len(j)]
+          b_candidate[j] <- candidate
+          h_candidate[j] <- max(h_candidate[j], candidate)
+          probability <- gsBinomialExactHarm(
+            theta = p1,
+            n.I = counts[seq_len(j)],
+            a = a[seq_len(j)],
+            futility = b_candidate,
+            harm = h_candidate,
+            testLower = active_lower[seq_len(j)],
+            testHarm = active_harm[seq_len(j)]
+          )
+          sum(probability$upper$prob[, 1])
+        }, numeric(1))
+        allowed <- which(
+          total_lower_probability <= lower_spend[j] * (1 + 1e-10) +
+            .Machine$double.xmin
+        )
+        b[j] <- if (length(allowed) > 0) {
+          candidates[allowed[which.max(total_lower_probability[allowed])]]
+        } else {
+          counts[j] + 1L
+        }
+      } else {
+        b[j] <- counts[j] + 1L
+      }
+
+      if (isTRUE(active_harm[j])) {
+        harm_min <- if (isTRUE(active_lower[j])) b[j] else a[j] + 1L
+        candidates <- seq.int(harm_min, counts[j] + 1L)
+        harm_probability <- vapply(candidates, function(candidate) {
+          h_candidate <- h[seq_len(j)]
+          h_candidate[j] <- candidate
+          probability <- gsBinomialExactHarm(
+            theta = p0,
+            n.I = counts[seq_len(j)],
+            a = a[seq_len(j)],
+            futility = b[seq_len(j)],
+            harm = h_candidate,
+            testLower = active_lower[seq_len(j)],
+            testHarm = active_harm[seq_len(j)]
+          )
+          sum(probability$harm$prob[, 1])
+        }, numeric(1))
+        allowed <- which(
+          harm_probability <= harm_spend[j] * (1 + 1e-10) +
+            .Machine$double.xmin
+        )
+        h[j] <- if (length(allowed) > 0) {
+          candidates[allowed[which.max(harm_probability[allowed])]]
+        } else {
+          counts[j] + 1L
+        }
+      } else {
+        h[j] <- counts[j] + 1L
+      }
     }
   }
-  xxxx <- gsBinomialExact(k = k, theta = c(p0, p1), n.I = counts, a = a, b = b)
+  xxxx <- if (x$test.type == 8) {
+    gsBinomialExactHarm(
+      theta = c(p0, p1), n.I = counts, a = a, futility = b, harm = h,
+      testLower = active_lower, testHarm = active_harm
+    )
+  } else {
+    gsBinomialExact(k = k, theta = c(p0, p1), n.I = counts, a = a, b = b)
+  }
   xxxx$init_approx <- init_approx
   xxxx$test.type <- x$test.type
   xxxx$alpha <- alpha
-  xxxx$astar <- if (x$test.type == 6) xx$astar else NULL
+  xxxx$astar <- if (x$test.type %in% c(6, 8)) xx$astar else NULL
   xxxx$testLower <- if (x$test.type == 1) NULL else active_lower
+  xxxx$testHarm <- if (x$test.type == 8) active_harm else NULL
   return(xxxx)
+}
+
+# Exact binomial recursion with mutually exclusive futility and harm regions.
+# The upper event-count stopping probability is partitioned at the harm bound;
+# continuation depends only on the first active upper event-count stop.
+gsBinomialExactHarm <- function(theta, n.I, a, futility, harm, testLower, testHarm) {
+  k <- length(n.I)
+  ntheta <- length(theta)
+  effective_futility <- ifelse(testLower, futility, n.I + 1L)
+  effective_harm <- ifelse(testHarm, harm, n.I + 1L)
+  stop_bound <- pmin(effective_futility, effective_harm)
+  if (any(stop_bound <= a)) {
+    stop("Exact futility and harm bounds must be strictly greater than the efficacy bound")
+  }
+
+  efficacy_prob <- matrix(0, nrow = k, ncol = ntheta)
+  total_upper_prob <- matrix(0, nrow = k, ncol = ntheta)
+  harm_prob <- matrix(0, nrow = k, ncol = ntheta)
+  en <- numeric(ntheta)
+  increments <- c(n.I[1], diff(n.I))
+  count_grid <- 0:n.I[k]
+
+  for (parameter in seq_along(theta)) {
+    p <- theta[parameter]
+    continuing_distribution <- matrix(0, nrow = n.I[k] + 1L, ncol = k)
+    for (analysis in seq_len(k)) {
+      if (analysis == 1L) {
+        continuing_distribution[, analysis] <- stats::dbinom(
+          count_grid, increments[analysis], p
+        )
+      } else {
+        continue_min <- a[analysis - 1L] + 1L
+        continue_max <- stop_bound[analysis - 1L] - 1L
+        if (continue_min <= continue_max) {
+          continuing_counts <- seq.int(continue_min, continue_max)
+          previous_probability <- continuing_distribution[
+            continuing_counts + 1L, analysis - 1L
+          ]
+          increment_probability <- outer(
+            count_grid,
+            continuing_counts,
+            function(total, previous) stats::dbinom(
+              total - previous, increments[analysis], p
+            )
+          )
+          continuing_distribution[, analysis] <- as.vector(
+            increment_probability %*% previous_probability
+          )
+        }
+      }
+      efficacy_prob[analysis, parameter] <- sum(
+        continuing_distribution[count_grid <= a[analysis], analysis]
+      )
+      total_upper_prob[analysis, parameter] <- sum(
+        continuing_distribution[count_grid >= stop_bound[analysis], analysis]
+      )
+      harm_prob[analysis, parameter] <- sum(
+        continuing_distribution[count_grid >= effective_harm[analysis], analysis]
+      )
+    }
+    stopped <- efficacy_prob[, parameter] + total_upper_prob[, parameter]
+    en[parameter] <- sum(n.I * stopped) + n.I[k] * (1 - sum(stopped))
+  }
+
+  row_names <- paste(rep("Analysis ", k), seq_len(k))
+  column_names <- as.character(theta)
+  dimnames(efficacy_prob) <- list(row_names, column_names)
+  dimnames(total_upper_prob) <- list(row_names, column_names)
+  dimnames(harm_prob) <- list(row_names, column_names)
+  futility_prob <- total_upper_prob - harm_prob
+  futility_prob[abs(futility_prob) < 1e-14] <- 0
+
+  result <- list(
+    k = k,
+    theta = theta,
+    n.I = n.I,
+    lower = list(bound = a, prob = efficacy_prob),
+    upper = list(bound = stop_bound, prob = total_upper_prob),
+    futility = list(bound = futility, prob = futility_prob),
+    harm = list(bound = harm, prob = harm_prob),
+    en = en
+  )
+  class(result) <- c("gsBinomialExact", "gsProbability")
+  result
 }
 
 resolveSpendingTime <- function(spendingTime, defaultTime, k, label) {

--- a/man/gsBoundSummary.Rd
+++ b/man/gsBoundSummary.Rd
@@ -133,9 +133,14 @@ degree of accuracy of group sequential calculations which will normally not
 be changed.}
 
 \item{alpha}{If used, a vector of alternate alpha-levels to print boundaries
-for. Only works with test.type 1, 4, 6, 7, and 8. If specified, efficacy bound
+for. Only works with non-binding test types 1, 4, 6, and 8. If specified,
+efficacy bound
 columns are headed by individual alpha levels. The alpha level of the input
-design is always included as the first column.}
+design is always included as the first column. Alternate alpha levels retain
+the efficacy testing schedule in \code{x$testUpper}. Binding lower-bound
+designs, including test type 7, are not supported for alternate-alpha
+summaries because they do not satisfy the non-binding framework used for
+Maurer--Bretz graphical multiple testing.}
 
 \item{include.rownames}{indicator of whether or not to include row names in
 output.}
@@ -263,7 +268,11 @@ value. \code{P{Cross if delta=xx}: }For each of the parameter values in
 \code{x}, the probability of crossing either bound given that treatment
 effect is computed. This value is cumulative for each bound. For example,
 the probability of crossing the efficacy bound at or before the analysis of
-interest.
+interest. For test types 7 and 8, harm, futility, and efficacy crossing
+probabilities are mutually exclusive. Every characteristic for a bound,
+including its cumulative crossing probability, is shown as \code{NA} at an
+analysis where that bound is inactive. The underlying probability arrays on
+\code{x} retain the cumulative crossing information.
 }
 \note{
 The gsDesign technical manual is available at

--- a/man/gsDesign.Rd
+++ b/man/gsDesign.Rd
@@ -208,7 +208,9 @@ Otherwise, a logical vector of length \code{k}.
 Only used for \code{test.type} 7 or 8; at least one analysis must be
 \code{TRUE} for those types.
 Where \code{testHarm} is \code{FALSE}, the harm bound is set to
-\code{-20} (effectively \code{-Inf}) and displayed as \code{NA} in output.}
+\code{-20} (effectively \code{-Inf}) and the bound is displayed as
+\code{NA} in output. Cumulative harm crossing probability from earlier
+analyses is still displayed.}
 
 \item{x}{An \R object of class found among \code{methods(xtable)}.  See
     below on how to write additional method functions for \code{xtable}.}
@@ -313,7 +315,12 @@ crossing probabilities at each analysis. Lower spending is under alternative
 hypothesis (beta spending) for \code{test.type=3} or \code{4}.  For
 \code{test.type=2}, \code{5} or \code{6}, lower spending is under the null
 hypothesis. For \code{test.type=1}, output value is \code{NULL}. See
-\code{vignette("SpendingFunctionOverview")} and manual.} \item{theta}{Standarized
+\code{vignette("SpendingFunctionOverview")} and manual. For
+\code{test.type=7} or \code{8}, crossing probabilities exclude harm
+crossings.} \item{harm}{Harm bound spending function, boundary, and crossing
+probabilities at each analysis for \code{test.type=7} or \code{8}. Harm,
+lower, and upper crossing probabilities are mutually exclusive.}
+\item{theta}{Standarized
 effect size under null (0) and alternate hypothesis. If \code{delta} is
 input, \code{theta[1]=delta}. If \code{n.fix} is input, \code{theta[1]} is
 computed using a standard sample size formula (pseudocode):

--- a/man/gsSurvCalendar.Rd
+++ b/man/gsSurvCalendar.Rd
@@ -196,7 +196,9 @@ Otherwise, a logical vector of length \code{k}.
 Only used for \code{test.type} 7 or 8; at least one analysis must be
 \code{TRUE} for those types.
 Where \code{testHarm} is \code{FALSE}, the harm bound is set to
-\code{-20} (effectively \code{-Inf}) and displayed as \code{NA} in output.}
+\code{-20} (effectively \code{-Inf}) and the bound is displayed as
+\code{NA} in output. Cumulative harm crossing probability from earlier
+analyses is still displayed.}
 
 \item{method}{One of \code{"LachinFoulkes"} (default), \code{"Schoenfeld"},
 \code{"Freedman"}, or \code{"BernsteinLagakos"}.

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -333,12 +333,18 @@ parameters change relative to the original design:
     exactly.
   \item \strong{Upper-bound parameters changed} (\code{alpha}, \code{sfu},
     or \code{sfupar}) but timing matches: new efficacy bounds are computed
-    via \code{gsDesign(test.type = 1)} at the new alpha, while the
-    original futility bounds from \code{x} are preserved. Any futility
-    bound that exceeds the new efficacy bound is clipped. This follows
-    the same convention as \code{gsBoundSummary()}. Lower-bound spending
-    settings from \code{x} are intentionally kept in this branch, which
-    avoids complications with \code{astar} validation for binding types.
+    using the non-binding efficacy convention at the new alpha while
+    preserving the original \code{testUpper} schedule and futility bounds
+    from \code{x}. Any futility bound that exceeds the new efficacy bound
+    is clipped. This follows the same convention as
+    \code{gsBoundSummary()}. Lower-bound spending settings from \code{x}
+    are intentionally kept in this branch, which avoids complications with
+    \code{astar} validation for binding types.
+    For non-binding test types 1, 4, 6, and 8, this calculation can be used
+    to evaluate alpha propagated by a graphical multiple-testing procedure.
+    For binding test types 2, 3, 5, and 7, it is a planning sensitivity
+    calculation only; it is not a Maurer--Bretz sequential-p-value or
+    graphical alpha-recycling procedure.
   \item \strong{Timing changed} (different target events or calendar
     times): both bounds are recomputed from scratch using the full
     \code{test.type} and all spending parameters.

--- a/man/nSurv.Rd
+++ b/man/nSurv.Rd
@@ -526,6 +526,11 @@ calculation.
 
 The input to \code{gsSurv} is a combination of the input to \code{nSurv()}
 and \code{gsDesign()}.
+The original call is stored in \code{call}. The \code{inputs} component
+retains evaluated survival-model inputs used for printing and the applicable
+\code{testUpper}, \code{testLower}, and \code{testHarm} arguments. The
+normalized testing schedules used by the design are stored directly in the
+corresponding top-level components.
 When \code{T = NULL} and \code{minfup} is specified, \code{gsSurv()}
 preserves the input accrual rate and minimum follow-up, applies the group
 sequential design, and solves the accrual duration needed for the final

--- a/man/nSurv.Rd
+++ b/man/nSurv.Rd
@@ -312,7 +312,9 @@ Otherwise, a logical vector of length \code{k}.
 Only used for \code{test.type} 7 or 8; at least one analysis must be
 \code{TRUE} for those types.
 Where \code{testHarm} is \code{FALSE}, the harm bound is set to
-\code{-20} (effectively \code{-Inf}) and displayed as \code{NA} in output.}
+\code{-20} (effectively \code{-Inf}) and the bound is displayed as
+\code{NA} in output. Cumulative harm crossing probability from earlier
+analyses is still displayed.}
 
 \item{show_gsDesign}{Logical; for \code{print.gsSurv()}, include gsDesign details.}
 }

--- a/man/plot.gsDesign.Rd
+++ b/man/plot.gsDesign.Rd
@@ -78,6 +78,13 @@ values of \code{plottype}; one exception is that \code{type="l"} cannot be
 overridden when \code{plottype=2}. Default values for labels depend on
 \code{plottype} and the class of \code{x}.
 
+For test types 7 and 8, harm and futility probabilities stored on the
+design are mutually exclusive stopping outcomes. In a type 2 plot, the
+futility-threshold curve is inclusive: it uses the sum of futility-only and
+harm crossing probabilities. The separate harm curve continues to show
+harm crossings only. This plotting convention does not modify the
+probabilities stored on \code{x}.
+
 Note that there is some special behavior for values plotted and returned for
 power and expected sample size (ASN) plots for a \code{gsDesign} object. A
 call to \code{x<-gsDesign()} produces power and expected sample size for

--- a/man/repeatedPValueBinomialExact.Rd
+++ b/man/repeatedPValueBinomialExact.Rd
@@ -15,11 +15,11 @@ repeatedPValueBinomialExact(
 )
 }
 \arguments{
-\item{gsD}{A `gsSurv` object with `test.type` 1 or 4.}
+\item{gsD}{A `gsSurv` object with non-binding `test.type` 1, 4, 6, or 8.}
 
 \item{n.I}{Increasing integer total event counts at completed analyses. If
-`NULL`, the planned exact binomial event counts from `toBinomialExact(gsD)`
-are used. This must have at most 1 value greater than or equal to planned
+`NULL`, the planned integer event counts from `toInteger(gsD)` are used.
+This must have at most 1 value greater than or equal to planned
 final events (`gsD$maxn.IPlan` if available, otherwise `max(gsD$n.I)`).}
 
 \item{x}{Integer experimental-arm event counts at the analyses in `n.I`.}
@@ -50,7 +50,7 @@ Computes repeated p-values for the exact binomial design implied by a
 [gsSurv()] object. The p-value at analysis `j` is the smallest local
 one-sided alpha level for which the observed experimental-arm event count
 crosses the exact lower efficacy bound at that analysis. Non-binding
-futility bounds are ignored for the Type I error calculation.
+futility and harm bounds are ignored for the Type I error calculation.
 }
 \examples{
 x <- gsSurv(

--- a/man/sequentiaPValue.Rd
+++ b/man/sequentiaPValue.Rd
@@ -41,8 +41,11 @@ This is particularly useful for multiplicity methods such as the graphical metho
 where sequential p-values for multiple hypotheses can be used as nominal p-values to plug into a multiplicity graph. 
 A sequential p-value is described as the minimum alpha level at which a one-sided group sequential bound would 
 be rejected given interim and final observed results.
-It is meaningful for both one-sided designs and designs with non-binding futility bounds (\code{test.type} 1, 4, 6), 
-but not for 2-sided designs with binding futility bounds (\code{test.type} 2, 3 or 5).
+It is meaningful for both one-sided designs and designs with non-binding
+futility or harm bounds (\code{test.type} 1, 4, 6, or 8), but not for
+2-sided designs with binding futility or harm bounds (\code{test.type} 2,
+3, 5, or 7). For test type 8, both non-binding lower bounds are ignored in
+the Type I error calculation.
 Mild restrictions are required on spending functions used, but these are satisfied for commonly used spending functions
 such as the Lan-DeMets spending function approximating an O'Brien-Fleming bound or a Hwang-Shih-DeCani spending function; see Maurer and Bretz (2013).
 }

--- a/man/sequentialPValueBinomialExact.Rd
+++ b/man/sequentialPValueBinomialExact.Rd
@@ -15,11 +15,11 @@ sequentialPValueBinomialExact(
 )
 }
 \arguments{
-\item{gsD}{A `gsSurv` object with `test.type` 1 or 4.}
+\item{gsD}{A `gsSurv` object with non-binding `test.type` 1, 4, 6, or 8.}
 
 \item{n.I}{Increasing integer total event counts at completed analyses. If
-`NULL`, the planned exact binomial event counts from `toBinomialExact(gsD)`
-are used. This must have at most 1 value greater than or equal to planned
+`NULL`, the planned integer event counts from `toInteger(gsD)` are used.
+This must have at most 1 value greater than or equal to planned
 final events (`gsD$maxn.IPlan` if available, otherwise `max(gsD$n.I)`).}
 
 \item{x}{Integer experimental-arm event counts at the analyses in `n.I`.}

--- a/man/toBinomialExact.Rd
+++ b/man/toBinomialExact.Rd
@@ -32,34 +32,37 @@ this defaults to \code{observedEvents / x$maxn.IPlan} (capped at 1) when
 \code{observedEvents} is supplied, or to the planned design timing
 otherwise.}
 
-\item{lsTime}{Optional lower spending-time override for \code{test.type = 4}
-or \code{6}
+\item{lsTime}{Optional lower spending-time override for \code{test.type = 4},
+\code{6}, or \code{8}
 (same length and monotonicity requirements as \code{usTime}). If
 \code{NULL}, it defaults to \code{usTime}.}
 
 \item{maxSpend}{Logical scalar. If `TRUE`, force full alpha spending (and, for
-`test.type = 4`, full beta spending; for `test.type = 6`, full lower-bound
+`test.type = 4` or `8`, full beta spending; for `test.type = 6`, full
+lower-bound spending under the null; and, for `test.type = 8`, full harm
 spending under the null) at the final analysis even when
 `observedEvents[k] < x$maxn.IPlan`. This keeps earlier analysis spending
 unchanged and applies the override only at the last look.}
 }
 \value{
 An object of class \code{gsBinomialExact}. The returned object also
-  records `test.type`, `alpha`, applicable `astar`, and `testLower`. For
+  records `test.type`, `alpha`, applicable `astar`, `testLower`, and
+  applicable `testHarm`. For
   `test.type = 6`, the exact object's upper event-count bound represents the
   non-binding lower stopping bound, with its first probability column
-  calibrated under the null hypothesis.
+  calibrated under the null hypothesis. For `test.type = 8`, `upper`
+  represents all upper event-count stops, while `futility` and `harm`
+  partition those stops into mutually exclusive components.
 }
 \description{
 Translate survival design bounds to exact binomial bounds
 }
 \details{
-Test types 1 (one-sided), 4 (non-binding beta-spending futility), and 6
-(non-binding lower-bound spending under the null) are supported for full
-conversion.
-The current \code{gsBinomialExact} object contains one lower efficacy bound
-and one upper stopping bound. Consequently, it cannot represent the
-separate futility and harm bounds required by test types 7 and 8. Binding
+Test types 1 (one-sided), 4 (non-binding beta-spending futility), 6
+(non-binding lower-bound spending under the null), and 8 (non-binding
+futility and harm) are supported for full conversion. For Type 8, the exact
+upper event-count stopping probability is partitioned into mutually
+exclusive futility and harm components. Binding
 designs (types 2, 3, 5, and 7) are outside the non-binding exact-efficacy
 framework. Exact repeated and sequential efficacy
 p-values can nevertheless be computed for non-binding types 1, 4, 6, and 8
@@ -71,8 +74,8 @@ The exact binomial routine \code{gsBinomialExact} has requirements that may not 
 by the initial asymptotic approximation. 
 Thus, the approximations are updated to satisfy the following requirements of \code{gsBinomialExact}:
 \code{a} (the efficacy bound) must be positive, non-decreasing, and strictly less than n.I
-\code{b} (the upper event-count stopping bound for futility or the Type 6
-lower bound) must be positive, non-decreasing, and strictly greater than a
+\code{b} (the upper event-count stopping bound for futility, harm, or the
+Type 6 lower bound) must be positive, non-decreasing, and strictly greater than a
 \code{n.I - b} must be non-decreasing and >= 0
 
 With `observedEvents`, spending times are based on

--- a/man/toBinomialExact.Rd
+++ b/man/toBinomialExact.Rd
@@ -33,39 +33,54 @@ this defaults to \code{observedEvents / x$maxn.IPlan} (capped at 1) when
 otherwise.}
 
 \item{lsTime}{Optional lower spending-time override for \code{test.type = 4}
+or \code{6}
 (same length and monotonicity requirements as \code{usTime}). If
 \code{NULL}, it defaults to \code{usTime}.}
 
 \item{maxSpend}{Logical scalar. If `TRUE`, force full alpha spending (and, for
-`test.type = 4`, full beta spending) at the final analysis even when
+`test.type = 4`, full beta spending; for `test.type = 6`, full lower-bound
+spending under the null) at the final analysis even when
 `observedEvents[k] < x$maxn.IPlan`. This keeps earlier analysis spending
 unchanged and applies the override only at the last look.}
 }
 \value{
-An object of class \code{gsBinomialExact}.
+An object of class \code{gsBinomialExact}. The returned object also
+  records `test.type`, `alpha`, applicable `astar`, and `testLower`. For
+  `test.type = 6`, the exact object's upper event-count bound represents the
+  non-binding lower stopping bound, with its first probability column
+  calibrated under the null hypothesis.
 }
 \description{
 Translate survival design bounds to exact binomial bounds
 }
 \details{
-Only \code{test.type} 1 (one-sided) and \code{test.type} 4
-(non-binding futility) are supported. Other test types (including
-\code{test.type} 7 and 8 with harm bounds) will produce
-an error.
+Test types 1 (one-sided), 4 (non-binding beta-spending futility), and 6
+(non-binding lower-bound spending under the null) are supported for full
+conversion.
+The current \code{gsBinomialExact} object contains one lower efficacy bound
+and one upper stopping bound. Consequently, it cannot represent the
+separate futility and harm bounds required by test types 7 and 8. Binding
+designs (types 2, 3, 5, and 7) are outside the non-binding exact-efficacy
+framework. Exact repeated and sequential efficacy
+p-values can nevertheless be computed for non-binding types 1, 4, 6, and 8
+with \code{repeatedPValueBinomialExact()} and
+\code{sequentialPValueBinomialExact()}, which intentionally ignore
+non-binding lower and harm bounds.
 
 The exact binomial routine \code{gsBinomialExact} has requirements that may not be satisfied
 by the initial asymptotic approximation. 
 Thus, the approximations are updated to satisfy the following requirements of \code{gsBinomialExact}:
 \code{a} (the efficacy bound) must be positive, non-decreasing, and strictly less than n.I
-\code{b} (the futility bound) must be positive, non-decreasing, strictly greater than a
+\code{b} (the upper event-count stopping bound for futility or the Type 6
+lower bound) must be positive, non-decreasing, and strictly greater than a
 \code{n.I - b} must be non-decreasing and >= 0
 
 With `observedEvents`, spending times are based on
 \code{observedEvents / x$maxn.IPlan}. If \code{maxSpend = TRUE}, the final
 spending time is set to 1 so all remaining spending is used at the last look.
 If \code{x$testLower} is present (for example from \code{gsSurv()} with
-selective futility looks), futility spending is flattened at analyses where
-\code{testLower = FALSE}.
+selective lower-bound looks), lower-bound spending is flattened at analyses
+where \code{testLower = FALSE}.
 }
 \examples{
 # The following code derives the group sequential design using the method

--- a/src/gsdensity.c
+++ b/src/gsdensity.c
@@ -31,7 +31,7 @@
  */
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
                double *a, double *b, double *xz, int *zlen, int *xr) {
-  int r, i, j, k, m1, m2, nanal, nz;
+  int r, i, j, k, m1, m2, nanal, nz, wklen;
   double z, mu, theta;
   double *zwk, *wwk, *hwk, *zwk2, *wwk2, *hwk2;
   double *z1, *z2, *w1, *w2, *h, *h2, *tem;
@@ -42,6 +42,9 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
   r = xr[0];
   nanal = xnanal[0];
   nz = zlen[0];
+  wklen = r * 12 - 3;
+  if (wklen < nz)
+    wklen = nz;
   /* if density is at 1st analysis, just return normal density */
   if (nanal < 1)
     return;
@@ -57,12 +60,12 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
     return;
   }
   /* otherwise, compute density like in probrej */
-  zwk = (double *)R_alloc(r * 12 - 3, sizeof(double));
-  wwk = (double *)R_alloc(r * 12 - 3, sizeof(double));
-  hwk = (double *)R_alloc(r * 12 - 3, sizeof(double));
-  zwk2 = (double *)R_alloc(r * 12 - 3, sizeof(double));
-  wwk2 = (double *)R_alloc(r * 12 - 3, sizeof(double));
-  hwk2 = (double *)R_alloc(r * 12 - 3, sizeof(double));
+  zwk = (double *)R_alloc(wklen, sizeof(double));
+  wwk = (double *)R_alloc(wklen, sizeof(double));
+  hwk = (double *)R_alloc(wklen, sizeof(double));
+  zwk2 = (double *)R_alloc(wklen, sizeof(double));
+  wwk2 = (double *)R_alloc(wklen, sizeof(double));
+  hwk2 = (double *)R_alloc(wklen, sizeof(double));
   for (k = 0; k < ntheta[0]; k++) {
     theta = xtheta[k];
     mu = theta * sqrt(I[0]);

--- a/tests/testthat/test-developer-test-toBinomialExact.R
+++ b/tests/testthat/test-developer-test-toBinomialExact.R
@@ -7,7 +7,7 @@ test_that("toBinomialExact validates inputs", {
     lambdaC = 0.1, hr = 0.7, hr0 = 1, eta = 0.01,
     gamma = 5, R = 6, T = 12, minfup = 6
   )
-  expect_error(toBinomialExact(x_bad), "test.type must be 1 or 4")
+  expect_error(toBinomialExact(x_bad), "test.type must be 1, 4, or 6")
 
   x <- gsSurv(
     k = 2, test.type = 4, alpha = 0.025, beta = 0.1,

--- a/tests/testthat/test-developer-test-toBinomialExact.R
+++ b/tests/testthat/test-developer-test-toBinomialExact.R
@@ -7,7 +7,7 @@ test_that("toBinomialExact validates inputs", {
     lambdaC = 0.1, hr = 0.7, hr0 = 1, eta = 0.01,
     gamma = 5, R = 6, T = 12, minfup = 6
   )
-  expect_error(toBinomialExact(x_bad), "test.type must be 1, 4, or 6")
+  expect_error(toBinomialExact(x_bad), "test.type must be 1, 4, 6, or 8")
 
   x <- gsSurv(
     k = 2, test.type = 4, alpha = 0.025, beta = 0.1,

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -1035,6 +1035,32 @@ test_that("gsSurvPower matches gsBoundSummary for alternate alpha", {
   expect_equal(pwr_a05$upper$bound, gs_check$upper$bound, tolerance = 1e-3)
 })
 
+test_that("alternate alpha preserves a selective efficacy schedule", {
+  design <- gsSurv(
+    k = 3, test.type = 4, alpha = 0.025, sided = 1, beta = 0.1,
+    lambdaC = log(2) / 6, hr = 0.6, eta = 0.01,
+    gamma = 10, R = 12, minfup = 18, T = 30,
+    testUpper = c(FALSE, TRUE, TRUE)
+  )
+  pwr_a05 <- gsSurvPower(
+    x = design, alpha = 0.05,
+    targetEvents = design$n.I
+  )
+
+  summary_a05 <- gsBoundSummary(design, alpha = 0.05, digits = 8)
+  z_rows <- which(summary_a05$Value == "Z")
+
+  expect_equal(pwr_a05$testUpper, c(FALSE, TRUE, TRUE))
+  expect_equal(pwr_a05$upper$bound[1], 20)
+  expect_lt(max(pwr_a05$upper$prob[1, ]), 1e-20)
+  expect_true(is.na(summary_a05[["\u03b1=0.05"]][z_rows[1]]))
+  expect_equal(
+    pwr_a05$upper$bound[2:3],
+    summary_a05[["\u03b1=0.05"]][z_rows[2:3]],
+    tolerance = 1e-3
+  )
+})
+
 test_that("sided defaults to x$sided when stored on gsSurvPower output", {
   pwr1 <- gsSurvPower(
     k = 2, test.type = 4, alpha = 0.05, sided = 2,

--- a/tests/testthat/test-independent-test-binomialExactPValues.R
+++ b/tests/testthat/test-independent-test-binomialExactPValues.R
@@ -33,7 +33,7 @@ test_that("binomialExactLowerBound validates inputs", {
   bad_design$test.type <- 2
   expect_error(
     gsDesign:::binomialExactLowerBound(bad_design, c(10, 20), 0.025),
-    "test.type must be 1 or 4"
+    "test.type must be 1, 4, 6, or 8"
   )
 
   expect_error(
@@ -85,7 +85,7 @@ test_that("repeatedPValueBinomialExact validates inputs", {
   bad_design$test.type <- 2
   expect_error(
     repeatedPValueBinomialExact(gsD = bad_design, n.I = counts, x = c(1, 2, 3)),
-    "test.type must be 1 or 4"
+    "test.type must be 1, 4, 6, or 8"
   )
 
   expect_error(
@@ -165,4 +165,37 @@ test_that("repeated and sequential exact p-values are coherent", {
 
   seq_p <- sequentialPValueBinomialExact(gsD = design, n.I = counts, x = harder_counts)
   expect_equal(seq_p, min(repeated_harder$repeated_p_value))
+})
+
+test_that("exact efficacy p-values support every non-binding test type", {
+  for (test_type in c(1, 4, 6, 8)) {
+    design <- surv_design_exact_p(test.type = test_type)
+    counts <- toInteger(design)$n.I
+    efficacy_bound <- gsDesign:::binomialExactLowerBound(
+      gsD = design,
+      n.I = counts,
+      alpha = design$alpha
+    )
+    observed <- pmax(efficacy_bound, 0L)
+    repeated <- repeatedPValueBinomialExact(
+      gsD = design,
+      n.I = counts,
+      x = observed
+    )
+
+    expect_equal(repeated$n.I, counts, label = paste("test.type", test_type))
+    expect_equal(
+      sequentialPValueBinomialExact(gsD = design, n.I = counts, x = observed),
+      min(repeated$repeated_p_value),
+      label = paste("test.type", test_type)
+    )
+  }
+
+  design8 <- surv_design_exact_p(test.type = 8)
+  counts8 <- toInteger(design8)$n.I
+  default_result <- repeatedPValueBinomialExact(
+    gsD = design8,
+    x = rep(0L, design8$k)
+  )
+  expect_equal(default_result$n.I, counts8)
 })

--- a/tests/testthat/test-independent-test-plotgsPower.R
+++ b/tests/testthat/test-independent-test-plotgsPower.R
@@ -99,6 +99,42 @@ test_that("plotgsPower: plots are correctly rendered, test.type = 2", {
   )
 })
 
+test_that("plotgsPower includes harm in the futility-threshold curve", {
+  for (test_type in c(7, 8)) {
+    x <- gsDesign(
+      k = 3, test.type = test_type, alpha = 0.025, beta = 0.1,
+      astar = 0.1, delta = 0.3, sfu = sfLDOF,
+      sfl = sfHSD, sflpar = -2, sfharm = sfLDPocock
+    )
+    theta <- c(0, x$delta)
+    probability <- gsProbability(d = x, theta = theta)
+    lower_before_plot <- x$lower$prob
+    harm_before_plot <- x$harm$prob
+
+    plotobj <- plotgsPower(x, theta = theta, xval = theta)
+    inclusive <- subset(
+      plotobj$data,
+      Bound == "1-(Futility or harm)"
+    )$Probability
+    harm_only <- subset(plotobj$data, Bound == "1-Harm")$Probability
+    expected_inclusive <- apply(
+      probability$lower$prob + probability$harm$prob,
+      2,
+      function(z) 1 - cumsum(z)
+    )
+    expected_harm <- apply(
+      probability$harm$prob,
+      2,
+      function(z) 1 - cumsum(z)
+    )
+
+    expect_equal(inclusive, as.vector(expected_inclusive))
+    expect_equal(harm_only, as.vector(expected_harm))
+    expect_equal(x$lower$prob, lower_before_plot)
+    expect_equal(x$harm$prob, harm_before_plot)
+  }
+})
+
 test_that(desc = 'Test: plotgsPower graphs can use offset arg for Future Analysis legend',
           code = {
   x <- gsDesign(k = 3, test.type = 1, alpha = 0.025, beta = 0.1,

--- a/tests/testthat/test-independent-test-toBinomialExact.R
+++ b/tests/testthat/test-independent-test-toBinomialExact.R
@@ -1,9 +1,10 @@
-surv_design <- function(test.type = 4, testLower = TRUE) {
+surv_design <- function(test.type = 4, testLower = TRUE, astar = 0) {
   gsSurv(
     k = 3,
     test.type = test.type,
     alpha = 0.025,
     beta = 0.1,
+    astar = astar,
     timing = c(0.45, 0.7),
     sfu = sfHSD,
     sfupar = -4,
@@ -28,7 +29,7 @@ test_that("toBinomialExact validates inputs", {
   design <- surv_design()
   design_bad <- design
   design_bad$test.type <- 2
-  expect_error(toBinomialExact(design_bad), "test.type must be 1 or 4")
+  expect_error(toBinomialExact(design_bad), "test.type must be 1, 4, or 6")
 
   expect_error(
     toBinomialExact(design, alpha = c(0.01, 0.02)),
@@ -68,6 +69,97 @@ test_that("toBinomialExact validates inputs", {
   expect_error(
     toBinomialExact(design, observedEvents = too_many_final),
     "at most 1 value in observedEvents"
+  )
+})
+
+test_that("toBinomialExact documents its test.type support matrix", {
+  expect_s3_class(toBinomialExact(surv_design(test.type = 1)), "gsBinomialExact")
+  expect_s3_class(toBinomialExact(surv_design(test.type = 4)), "gsBinomialExact")
+  expect_s3_class(toBinomialExact(surv_design(test.type = 6)), "gsBinomialExact")
+
+  expected_reason <- c(
+    `2` = "symmetric two-sided boundaries",
+    `3` = "binding futility bounds",
+    `5` = "binding lower bounds",
+    `7` = "binding futility and harm bounds",
+    `8` = "cannot separately represent futility and harm"
+  )
+  for (test_type in as.integer(names(expected_reason))) {
+    expect_error(
+      toBinomialExact(surv_design(test.type = test_type)),
+      expected_reason[[as.character(test_type)]],
+      label = paste("test.type", test_type)
+    )
+  }
+})
+
+test_that("toBinomialExact converts test.type 6 lower spending under H0", {
+  design <- surv_design(test.type = 6, astar = 0.2)
+  design_integer <- toInteger(design)
+  result <- toBinomialExact(design)
+  spending_time <- pmin(result$n.I / design_integer$maxn.IPlan, 1)
+  target <- design$lower$sf(
+    alpha = design$astar,
+    t = spending_time,
+    param = design$lower$param
+  )$spend
+  realized <- cumsum(result$upper$prob[, 1])
+
+  expect_equal(result$test.type, 6)
+  expect_equal(result$astar, design$astar)
+  expect_equal(result$testLower, rep(TRUE, design$k))
+  expect_true(all(diff(result$lower$bound) >= 0))
+  expect_true(all(diff(result$upper$bound) >= 0))
+  expect_true(all(result$lower$bound < result$upper$bound))
+  expect_true(all(realized <= target + 1e-10))
+})
+
+test_that("default test.type 6 has exhaustive final exact decision regions", {
+  design <- surv_design(test.type = 6)
+  result <- toBinomialExact(design)
+
+  expect_equal(result$astar, 1 - result$alpha)
+  expect_equal(result$upper$bound[design$k], result$lower$bound[design$k] + 1L)
+  expect_equal(
+    sum(result$lower$prob[, 1]) + sum(result$upper$prob[, 1]),
+    1,
+    tolerance = 1e-10
+  )
+})
+
+test_that("test.type 6 honors selective lower looks", {
+  design <- surv_design(
+    test.type = 6,
+    astar = 0.2,
+    testLower = c(TRUE, FALSE, TRUE)
+  )
+  result <- toBinomialExact(design)
+
+  expect_identical(result$testLower, c(TRUE, FALSE, TRUE))
+  expect_equal(unname(result$upper$prob[2, ]), c(0, 0), tolerance = 1e-12)
+})
+
+test_that("test.type 6 supports alpha and spending-time overrides", {
+  design_default <- surv_design(test.type = 6)
+  observed <- c(20L, 55L, 75L)
+  updated <- toBinomialExact(
+    design_default,
+    observedEvents = observed,
+    alpha = 0.01,
+    usTime = c(0.25, 0.65, 0.95),
+    lsTime = c(0.2, 0.55, 0.9),
+    maxSpend = TRUE
+  )
+
+  expect_equal(updated$n.I, observed)
+  expect_equal(updated$alpha, 0.01)
+  expect_equal(updated$astar, 0.99)
+  expect_equal(updated$upper$bound[3], updated$lower$bound[3] + 1L)
+
+  design_custom <- surv_design(test.type = 6, astar = 0.97)
+  expect_error(
+    toBinomialExact(design_custom, alpha = 0.05),
+    "alpha override requires astar <= 1 - alpha"
   )
 })
 
@@ -141,7 +233,7 @@ test_that("toBinomialExact works for one-sided designs with observedEvents", {
   expect_true(all(result$lower$bound < result$upper$bound))
   expect_error(
     toBinomialExact(design_one_sided, observedEvents = observed, lsTime = c(0.2, 0.6, 1)),
-    "lsTime can only be specified for test.type = 4"
+    "lsTime can only be specified for test.type = 4 or 6"
   )
 })
 

--- a/tests/testthat/test-independent-test-toBinomialExact.R
+++ b/tests/testthat/test-independent-test-toBinomialExact.R
@@ -1,4 +1,8 @@
-surv_design <- function(test.type = 4, testLower = TRUE, astar = 0) {
+surv_design <- function(
+    test.type = 4,
+    testLower = TRUE,
+    astar = 0,
+    testHarm = TRUE) {
   gsSurv(
     k = 3,
     test.type = test.type,
@@ -10,6 +14,8 @@ surv_design <- function(test.type = 4, testLower = TRUE, astar = 0) {
     sfupar = -4,
     sfl = sfLDOF,
     sflpar = 0,
+    sfharm = sfHSD,
+    sfharmparam = 2,
     lambdaC = 0.001,
     hr = 0.3,
     hr0 = 0.7,
@@ -19,7 +25,8 @@ surv_design <- function(test.type = 4, testLower = TRUE, astar = 0) {
     T = 24,
     minfup = 8,
     ratio = 3,
-    testLower = testLower
+    testLower = testLower,
+    testHarm = testHarm
   )
 }
 
@@ -29,7 +36,7 @@ test_that("toBinomialExact validates inputs", {
   design <- surv_design()
   design_bad <- design
   design_bad$test.type <- 2
-  expect_error(toBinomialExact(design_bad), "test.type must be 1, 4, or 6")
+  expect_error(toBinomialExact(design_bad), "test.type must be 1, 4, 6, or 8")
 
   expect_error(
     toBinomialExact(design, alpha = c(0.01, 0.02)),
@@ -76,13 +83,13 @@ test_that("toBinomialExact documents its test.type support matrix", {
   expect_s3_class(toBinomialExact(surv_design(test.type = 1)), "gsBinomialExact")
   expect_s3_class(toBinomialExact(surv_design(test.type = 4)), "gsBinomialExact")
   expect_s3_class(toBinomialExact(surv_design(test.type = 6)), "gsBinomialExact")
+  expect_s3_class(toBinomialExact(surv_design(test.type = 8)), "gsBinomialExact")
 
   expected_reason <- c(
     `2` = "symmetric two-sided boundaries",
     `3` = "binding futility bounds",
     `5` = "binding lower bounds",
-    `7` = "binding futility and harm bounds",
-    `8` = "cannot separately represent futility and harm"
+    `7` = "binding futility and harm bounds"
   )
   for (test_type in as.integer(names(expected_reason))) {
     expect_error(
@@ -91,6 +98,101 @@ test_that("toBinomialExact documents its test.type support matrix", {
       label = paste("test.type", test_type)
     )
   }
+})
+
+test_that("toBinomialExact partitions test.type 8 futility and harm stops", {
+  design <- surv_design(test.type = 8, astar = 0.2)
+  design_integer <- toInteger(design)
+  result <- toBinomialExact(design)
+  spending_time <- pmin(result$n.I / design_integer$maxn.IPlan, 1)
+  harm_target <- design$harm$sf(
+    alpha = design$astar,
+    t = spending_time,
+    param = design$harm$param
+  )$spend
+  total_lower_target <- design$lower$sf(
+    alpha = design$beta,
+    t = spending_time,
+    param = design$lower$param
+  )$spend
+
+  expect_equal(result$test.type, 8)
+  expect_equal(result$astar, design$astar)
+  expect_equal(result$testLower, rep(TRUE, design$k))
+  expect_equal(result$testHarm, rep(TRUE, design$k))
+  expect_equal(result$upper$prob, result$futility$prob + result$harm$prob)
+  expect_equal(
+    result$upper$bound,
+    pmin(result$futility$bound, result$harm$bound)
+  )
+  expect_true(all(cumsum(result$harm$prob[, 1]) <= harm_target + 1e-10))
+  expect_true(all(cumsum(result$upper$prob[, 2]) <= total_lower_target + 1e-10))
+
+  nonbinding_efficacy <- gsBinomialExact(
+    k = result$k,
+    theta = result$theta[1],
+    n.I = result$n.I,
+    a = result$lower$bound,
+    b = result$n.I + 1L
+  )
+  expect_lte(sum(nonbinding_efficacy$lower$prob), design$alpha)
+})
+
+test_that("test.type 8 honors selective futility and harm looks", {
+  design <- surv_design(
+    test.type = 8,
+    astar = 0.2,
+    testLower = c(FALSE, TRUE, TRUE),
+    testHarm = c(TRUE, FALSE, TRUE)
+  )
+  result <- toBinomialExact(design)
+
+  expect_identical(result$testLower, c(FALSE, TRUE, TRUE))
+  expect_identical(result$testHarm, c(TRUE, FALSE, TRUE))
+  expect_equal(unname(result$futility$prob[1, ]), c(0, 0), tolerance = 1e-12)
+  expect_equal(unname(result$harm$prob[2, ]), c(0, 0), tolerance = 1e-12)
+  expect_equal(result$upper$prob, result$futility$prob + result$harm$prob)
+})
+
+test_that("test.type 8 supports analysis-time overrides", {
+  design <- surv_design(test.type = 8)
+  observed <- c(20L, 55L, 75L)
+  result <- toBinomialExact(
+    design,
+    observedEvents = observed,
+    alpha = 0.01,
+    usTime = c(0.25, 0.65, 0.95),
+    lsTime = c(0.2, 0.55, 0.9),
+    maxSpend = TRUE
+  )
+
+  expect_equal(result$n.I, observed)
+  expect_equal(result$alpha, 0.01)
+  expect_equal(result$astar, 0.99)
+  expect_equal(result$upper$prob, result$futility$prob + result$harm$prob)
+})
+
+test_that("three-region exact recursion reduces to gsBinomialExact", {
+  theta <- c(0.3, 0.5)
+  n.I <- c(20L, 40L, 60L)
+  a <- c(3L, 8L, 15L)
+  b <- c(12L, 23L, 34L)
+  expected <- gsBinomialExact(k = 3, theta = theta, n.I = n.I, a = a, b = b)
+  result <- gsBinomialExactHarm(
+    theta = theta,
+    n.I = n.I,
+    a = a,
+    futility = b,
+    harm = n.I + 1L,
+    testLower = rep(TRUE, 3),
+    testHarm = rep(FALSE, 3)
+  )
+
+  expect_equal(result$lower$prob, expected$lower$prob, tolerance = 1e-12)
+  expect_equal(result$upper$prob, expected$upper$prob, tolerance = 1e-12)
+  expect_equal(result$en, expected$en, tolerance = 1e-12)
+  expect_equal(result$futility$prob, expected$upper$prob, tolerance = 1e-12)
+  expect_equal(result$harm$prob, expected$upper$prob * 0, tolerance = 1e-12)
 })
 
 test_that("toBinomialExact converts test.type 6 lower spending under H0", {
@@ -233,7 +335,7 @@ test_that("toBinomialExact works for one-sided designs with observedEvents", {
   expect_true(all(result$lower$bound < result$upper$bound))
   expect_error(
     toBinomialExact(design_one_sided, observedEvents = observed, lsTime = c(0.2, 0.6, 1)),
-    "lsTime can only be specified for test.type = 4 or 6"
+    "lsTime can only be specified for test.type = 4, 6, or 8"
   )
 })
 

--- a/tests/testthat/test-selective-bounds.R
+++ b/tests/testthat/test-selective-bounds.R
@@ -154,6 +154,47 @@ testthat::test_that("testLower selective: sample size targets requested power", 
   }
 })
 
+testthat::test_that("testUpper selective: sample size targets requested power", {
+  for (test_type in 3:8) {
+    x <- gsDesign(
+      k = 3, test.type = test_type, alpha = 0.025, beta = 0.1,
+      testUpper = c(FALSE, TRUE, TRUE)
+    )
+
+    testthat::expect_equal(
+      sum(x$upper$prob[, 2]), 1 - x$beta,
+      tolerance = 2 * x$tol,
+      info = paste("test.type", test_type)
+    )
+  }
+})
+
+testthat::test_that("testUpper selective: survival sizing targets requested power", {
+  for (test_type in 7:8) {
+    x <- gsSurv(
+      test.type = test_type,
+      testUpper = c(FALSE, TRUE, TRUE),
+      method = "Schoenfeld",
+      sfharm = sfHSD,
+      sfharmparam = 10,
+      sfupar = 10
+    )
+
+    testthat::expect_equal(x$k, 3)
+    testthat::expect_equal(x$testUpper, c(FALSE, TRUE, TRUE))
+    testthat::expect_equal(
+      sum(x$upper$prob[, 2]), 1 - x$beta,
+      tolerance = 2 * x$tol,
+      info = paste("test.type", test_type)
+    )
+    if (test_type == 7) {
+      testthat::expect_equal(sum(x$upper$prob[, 1]), x$alpha, tolerance = 2 * x$tol)
+    } else {
+      testthat::expect_equal(sum(x$falseposnb), x$alpha, tolerance = 2 * x$tol)
+    }
+  }
+})
+
 testthat::test_that("selective futility and harm sizing preserves all analyses", {
   for (test_type in 7:8) {
     testthat::expect_no_warning(
@@ -181,12 +222,17 @@ testthat::test_that("selective futility and harm sizing preserves all analyses",
       c(1, 1), tolerance = 5e-5
     )
 
-    summary <- gsBoundSummary(toInteger(x), digits = 8)
+    xi <- toInteger(x)
+    summary <- gsBoundSummary(xi, digits = 8)
     final_crossing <- tail(which(grepl("^P\\(Cross\\)", summary$Value)), 2)
-    testthat::expect_false(anyNA(summary$Harm[final_crossing]))
+    testthat::expect_true(all(is.na(summary$Harm[final_crossing])))
     testthat::expect_equal(
-      unname(rowSums(summary[final_crossing, c("Harm", "Futility", "Efficacy")])),
-      c(1, 1), tolerance = 1e-5
+      unname(summary$Futility[final_crossing]),
+      unname(apply(xi$lower$prob, 2, cumsum)[xi$k, ]), tolerance = 1e-5
+    )
+    testthat::expect_equal(
+      unname(summary$Efficacy[final_crossing]),
+      unname(apply(xi$upper$prob, 2, cumsum)[xi$k, ]), tolerance = 1e-5
     )
   }
 })
@@ -291,31 +337,85 @@ testthat::test_that("testHarm flags stored for test.type 7", {
   testthat::expect_equal(x$testHarm, c(TRUE, TRUE, FALSE))
 })
 
-# ---- gsBoundSummary NA masking ----
+testthat::test_that("gsSurv inputs retain applicable testing schedules", {
+  x4 <- gsSurv(
+    test.type = 4, method = "Schoenfeld",
+    testLower = c(FALSE, TRUE, TRUE),
+    testHarm = c(TRUE, FALSE, TRUE)
+  )
+  testthat::expect_equal(x4$inputs$testUpper, TRUE)
+  testthat::expect_equal(x4$inputs$testLower, c(FALSE, TRUE, TRUE))
+  testthat::expect_false("testHarm" %in% names(x4$inputs))
+  testthat::expect_equal(x4$testHarm, rep(FALSE, 3))
 
-testthat::test_that("gsBoundSummary shows NA for inactive futility bounds", {
-  x <- gsDesign(k = 3, test.type = 4, testLower = c(TRUE, FALSE, FALSE))
-  r <- gsBoundSummary(x)
-  # Use Z-value rows to identify each analysis
-  z_rows <- which(r$Value == "Z")
-  fut_vals <- r$Futility
-  # IA1 futility should not be NA (active)
-  testthat::expect_false(is.na(fut_vals[z_rows[1]]))
-  # IA2 and Final futility should be NA (inactive)
-  testthat::expect_true(is.na(fut_vals[z_rows[2]]))
-  testthat::expect_true(is.na(fut_vals[z_rows[3]]))
+  x7 <- gsSurv(
+    test.type = 7, method = "Schoenfeld",
+    testUpper = c(FALSE, TRUE, TRUE),
+    testLower = c(FALSE, TRUE, TRUE),
+    testHarm = c(TRUE, FALSE, FALSE)
+  )
+  testthat::expect_equal(x7$inputs$testUpper, c(FALSE, TRUE, TRUE))
+  testthat::expect_equal(x7$inputs$testLower, c(FALSE, TRUE, TRUE))
+  testthat::expect_equal(x7$inputs$testHarm, c(TRUE, FALSE, FALSE))
 })
 
-testthat::test_that("gsBoundSummary shows NA for inactive efficacy bounds", {
+# ---- gsBoundSummary NA masking ----
+
+.summary_analysis_rows <- function(summary, analysis) {
+  starts <- which(summary$Value == "Z")
+  stopifnot(analysis >= 1, analysis <= length(starts))
+  end <- if (analysis < length(starts)) starts[analysis + 1] - 1 else nrow(summary)
+  seq.int(starts[analysis], end)
+}
+
+testthat::test_that("gsBoundSummary shows all characteristics as NA for inactive futility bounds", {
+  x <- gsDesign(k = 3, test.type = 4, testLower = c(TRUE, FALSE, FALSE))
+  r <- gsBoundSummary(x)
+  testthat::expect_false(is.na(r$Futility[.summary_analysis_rows(r, 1)[1]]))
+  testthat::expect_true(all(is.na(r$Futility[.summary_analysis_rows(r, 2)])))
+  testthat::expect_true(all(is.na(r$Futility[.summary_analysis_rows(r, 3)])))
+})
+
+testthat::test_that("gsBoundSummary shows all characteristics as NA for inactive efficacy bounds", {
   x <- gsDesign(k = 3, test.type = 4, testUpper = c(FALSE, TRUE, TRUE))
   r <- gsBoundSummary(x)
-  z_rows <- which(r$Value == "Z")
-  eff_vals <- r$Efficacy
-  # IA1 efficacy should be NA (inactive)
-  testthat::expect_true(is.na(eff_vals[z_rows[1]]))
-  # IA2 and Final efficacy should NOT be NA
-  testthat::expect_false(is.na(eff_vals[z_rows[2]]))
-  testthat::expect_false(is.na(eff_vals[z_rows[3]]))
+  testthat::expect_true(all(is.na(r$Efficacy[.summary_analysis_rows(r, 1)])))
+  testthat::expect_false(is.na(r$Efficacy[.summary_analysis_rows(r, 2)[1]]))
+  testthat::expect_false(is.na(r$Efficacy[.summary_analysis_rows(r, 3)[1]]))
+})
+
+testthat::test_that("alternate alpha preserves inactive efficacy analyses", {
+  for (test_type in c(4, 6, 8)) {
+    x <- gsDesign(
+      k = 3, test.type = test_type,
+      testUpper = c(FALSE, TRUE, TRUE)
+    )
+    summary <- gsBoundSummary(x, alpha = 0.05, digits = 8)
+    alternate_alpha <- setdiff(
+      grep("^\u03b1=", names(summary), value = TRUE),
+      paste0("\u03b1=", x$alpha)
+    )
+    ia1_rows <- .summary_analysis_rows(summary, 1)
+    alpha_cols <- grep("^\u03b1=", names(summary), value = TRUE)
+
+    testthat::expect_length(alternate_alpha, 1)
+    testthat::expect_true(
+      all(is.na(as.matrix(summary[ia1_rows, alpha_cols, drop = FALSE]))),
+      info = paste("test.type", test_type)
+    )
+    testthat::expect_true(all(x$upper$prob[1, ] < 1e-10))
+  }
+})
+
+testthat::test_that("alternate alpha is not offered for binding test.type 7", {
+  x <- gsDesign(k = 3, test.type = 7)
+  baseline <- gsBoundSummary(x)
+
+  testthat::expect_message(
+    alternate <- gsBoundSummary(x, alpha = 0.05),
+    "non-binding test.type 1, 4, 6, and 8"
+  )
+  testthat::expect_identical(alternate, baseline)
 })
 
 testthat::test_that("gsBoundSummary works with exclude = NULL", {
@@ -327,19 +427,32 @@ testthat::test_that("gsBoundSummary works with exclude = NULL", {
   testthat::expect_true(nrow(r) > nrow(r_default))
 })
 
-testthat::test_that("gsBoundSummary shows NA for inactive harm bounds", {
+testthat::test_that("gsBoundSummary shows all characteristics as NA for inactive harm bounds", {
   x <- gsDesign(k = 3, test.type = 8, alpha = 0.025, beta = 0.1, astar = 0.05,
     testHarm = c(TRUE, TRUE, FALSE)
   )
   r <- gsBoundSummary(x)
   testthat::expect_true("Harm" %in% names(r))
-  z_rows <- which(r$Value == "Z")
-  harm_vals <- r$Harm
-  # IA1 and IA2 harm should not be NA (active)
-  testthat::expect_false(is.na(harm_vals[z_rows[1]]))
-  testthat::expect_false(is.na(harm_vals[z_rows[2]]))
-  # Final harm should be NA (inactive)
-  testthat::expect_true(is.na(harm_vals[z_rows[3]]))
+  testthat::expect_false(is.na(r$Harm[.summary_analysis_rows(r, 1)[1]]))
+  testthat::expect_false(is.na(r$Harm[.summary_analysis_rows(r, 2)[1]]))
+  testthat::expect_true(all(is.na(r$Harm[.summary_analysis_rows(r, 3)])))
+})
+
+testthat::test_that("gsBoundSummary fully masks skipped survival bounds", {
+  x <- gsSurv(
+    test.type = 7,
+    testHarm = c(TRUE, FALSE, FALSE),
+    testLower = c(FALSE, TRUE, TRUE),
+    method = "Schoenfeld",
+    sfharm = sfHSD,
+    sfharmparam = 10
+  )
+  r <- gsBoundSummary(toInteger(x), digits = 8)
+
+  testthat::expect_true(all(is.na(r$Futility[.summary_analysis_rows(r, 1)])))
+  testthat::expect_true(all(is.na(r$Harm[.summary_analysis_rows(r, 2)])))
+  testthat::expect_true(all(is.na(r$Harm[.summary_analysis_rows(r, 3)])))
+  testthat::expect_gt(sum(x$harm$prob[, 2]), 0)
 })
 
 # ---- print.gsDesign NA masking ----
@@ -568,13 +681,11 @@ testthat::test_that("Binding test.type 3: alpha preserved when skipping lower bo
   testthat::expect_equal(alpha_sel, 0.025, tolerance = 1e-6)
 })
 
-testthat::test_that("Binding test.type 3: alpha preserved when skipping upper bounds", {
-  d_base <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
-                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2)
+testthat::test_that("Binding test.type 3: power and alpha targeted when skipping upper bounds", {
   d_sel <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
                     testUpper = c(FALSE, TRUE, TRUE))
-  testthat::expect_equal(d_sel$n.I, d_base$n.I)
+  testthat::expect_equal(sum(d_sel$upper$prob[, 2]), 0.9, tolerance = 2e-6)
   alpha_sel <- sum(d_sel$upper$prob[, 1])
   testthat::expect_equal(alpha_sel, 0.025, tolerance = 1e-6)
 })
@@ -607,13 +718,11 @@ testthat::test_that("Non-binding test.type 4: non-binding alpha preserved when s
   testthat::expect_equal(d_sel$upper$bound, d_base$upper$bound)
 })
 
-testthat::test_that("Non-binding test.type 4: non-binding alpha preserved when skipping upper", {
-  d_base <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
-                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2)
+testthat::test_that("Non-binding test.type 4: power and alpha targeted when skipping upper", {
   d_sel <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
                     testUpper = c(FALSE, TRUE, TRUE))
-  testthat::expect_equal(d_sel$n.I, d_base$n.I)
+  testthat::expect_equal(sum(d_sel$upper$prob[, 2]), 0.9, tolerance = 2e-6)
   nb_alpha <- sum(gsprob(0, d_sel$n.I, rep(-20, 3), d_sel$upper$bound, r = d_sel$r)$probhi)
   testthat::expect_equal(nb_alpha, 0.025, tolerance = 1e-6)
 })

--- a/tests/testthat/test-selective-bounds.R
+++ b/tests/testthat/test-selective-bounds.R
@@ -139,6 +139,21 @@ testthat::test_that("testLower selective: cumulative futility prob does not incr
   testthat::expect_equal(cum_fut_h1[1], cum_fut_h1[3], tolerance = 1e-8)
 })
 
+testthat::test_that("testLower selective: sample size targets requested power", {
+  for (test_type in c(3, 4, 7, 8)) {
+    x <- gsDesign(
+      k = 3, test.type = test_type, alpha = 0.025, beta = 0.1,
+      testLower = c(TRUE, FALSE, FALSE)
+    )
+
+    testthat::expect_equal(
+      sum(x$upper$prob[, 2]), 1 - x$beta,
+      tolerance = x$tol * 2,
+      info = paste("test.type", test_type)
+    )
+  }
+})
+
 testthat::test_that("testLower = c(FALSE, TRUE, FALSE) with test.type 3", {
   x <- gsDesign(k = 3, test.type = 3, testLower = c(FALSE, TRUE, FALSE))
   testthat::expect_equal(x$lower$bound[1], -EXTREMEZ)
@@ -509,8 +524,8 @@ testthat::test_that("Binding test.type 3: alpha preserved when skipping lower bo
   d_sel <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
                     testLower = c(TRUE, FALSE, FALSE))
-  # Sample size must be identical
-  testthat::expect_equal(d_sel$n.I, d_base$n.I)
+  testthat::expect_lt(max(d_sel$n.I), max(d_base$n.I))
+  testthat::expect_equal(sum(d_sel$upper$prob[, 2]), 0.9, tolerance = 2e-6)
   # Alpha must be exactly 0.025 for binding design
   alpha_sel <- sum(d_sel$upper$prob[, 1])
   testthat::expect_equal(alpha_sel, 0.025, tolerance = 1e-6)
@@ -534,7 +549,8 @@ testthat::test_that("Binding test.type 3: alpha preserved with mixed skips", {
                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
                     testUpper = c(FALSE, TRUE, TRUE),
                     testLower = c(TRUE, FALSE, TRUE))
-  testthat::expect_equal(d_sel$n.I, d_base$n.I)
+  testthat::expect_lt(max(d_sel$n.I), max(d_base$n.I))
+  testthat::expect_equal(sum(d_sel$upper$prob[, 2]), 0.9, tolerance = 2e-6)
   alpha_sel <- sum(d_sel$upper$prob[, 1])
   testthat::expect_equal(alpha_sel, 0.025, tolerance = 1e-6)
 })
@@ -545,7 +561,8 @@ testthat::test_that("Non-binding test.type 4: non-binding alpha preserved when s
   d_sel <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
                     sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
                     testLower = c(TRUE, FALSE, FALSE))
-  testthat::expect_equal(d_sel$n.I, d_base$n.I)
+  testthat::expect_lt(max(d_sel$n.I), max(d_base$n.I))
+  testthat::expect_equal(sum(d_sel$upper$prob[, 2]), 0.9, tolerance = 2e-6)
   # Non-binding alpha (computed with lower = -20) must equal 0.025
   nb_alpha <- sum(gsprob(0, d_sel$n.I, rep(-20, 3), d_sel$upper$bound, r = d_sel$r)$probhi)
   testthat::expect_equal(nb_alpha, 0.025, tolerance = 1e-6)

--- a/tests/testthat/test-selective-bounds.R
+++ b/tests/testthat/test-selective-bounds.R
@@ -154,6 +154,43 @@ testthat::test_that("testLower selective: sample size targets requested power", 
   }
 })
 
+testthat::test_that("selective futility and harm sizing preserves all analyses", {
+  for (test_type in 7:8) {
+    testthat::expect_no_warning(
+      x <- gsSurv(
+        test.type = test_type,
+        testHarm = c(TRUE, FALSE, FALSE),
+        testLower = c(FALSE, TRUE, TRUE),
+        method = "Schoenfeld",
+        sfharm = sfHSD,
+        sfharmparam = 10
+      )
+    )
+
+    testthat::expect_equal(x$k, 3)
+    testthat::expect_equal(x$testHarm, c(TRUE, FALSE, FALSE))
+    testthat::expect_equal(x$testLower, c(FALSE, TRUE, TRUE))
+    testthat::expect_equal(sum(x$upper$prob[, 2]), 1 - x$beta, tolerance = 2 * x$tol)
+    if (test_type == 7) {
+      testthat::expect_equal(sum(x$upper$prob[, 1]), x$alpha, tolerance = 2 * x$tol)
+    } else {
+      testthat::expect_equal(sum(x$falseposnb), x$alpha, tolerance = 2 * x$tol)
+    }
+    testthat::expect_equal(
+      colSums(x$upper$prob + x$lower$prob + x$harm$prob),
+      c(1, 1), tolerance = 5e-5
+    )
+
+    summary <- gsBoundSummary(toInteger(x), digits = 8)
+    final_crossing <- tail(which(grepl("^P\\(Cross\\)", summary$Value)), 2)
+    testthat::expect_false(anyNA(summary$Harm[final_crossing]))
+    testthat::expect_equal(
+      unname(rowSums(summary[final_crossing, c("Harm", "Futility", "Efficacy")])),
+      c(1, 1), tolerance = 1e-5
+    )
+  }
+})
+
 testthat::test_that("testLower = c(FALSE, TRUE, FALSE) with test.type 3", {
   x <- gsDesign(k = 3, test.type = 3, testLower = c(FALSE, TRUE, FALSE))
   testthat::expect_equal(x$lower$bound[1], -EXTREMEZ)

--- a/tests/testthat/test-sequentialPValue.R
+++ b/tests/testthat/test-sequentialPValue.R
@@ -31,3 +31,30 @@ testthat::test_that("default n.I not used",{
   seqp <- sequentialPValue(gsD=x,Z=c(.1,.1,1.5),interval=c(.001,.999))
   expect_equal(seqp,seqp1)
 })
+
+testthat::test_that("sequential p-value supports non-binding harm bounds", {
+  x8 <- gsDesign(k = 3, test.type = 8, alpha = 0.025, beta = 0.1, n.fix = 300)
+  x1 <- gsDesign(
+    k = x8$k,
+    test.type = 1,
+    alpha = x8$alpha,
+    beta = x8$beta,
+    n.I = x8$n.I,
+    maxn.IPlan = max(x8$n.I),
+    sfu = x8$upper$sf,
+    sfupar = x8$upper$param
+  )
+  Z <- c(0.1, 1, 2.2)
+
+  expect_equal(x8$upper$bound, x1$upper$bound)
+  expect_equal(
+    sequentialPValue(gsD = x8, n.I = x8$n.I, Z = Z),
+    sequentialPValue(gsD = x1, n.I = x1$n.I, Z = Z)
+  )
+
+  x7 <- gsDesign(k = 3, test.type = 7, alpha = 0.025, beta = 0.1, n.fix = 300)
+  expect_error(
+    sequentialPValue(gsD = x7, n.I = x7$n.I, Z = Z),
+    "no binding lower or harm bound allowed"
+  )
+})

--- a/vignettes/HarmBound.Rmd
+++ b/vignettes/HarmBound.Rmd
@@ -360,17 +360,11 @@ This ensures the ordering: harm bound $\leq$ futility bound $\leq$ efficacy boun
 
 In most regulatory settings, `test.type = 8` is the safer and more common choice.
 
-### Why a separate "binding harm / non-binding futility" option is unnecessary
+### Binding and non-binding harm monitoring
 
-One might consider a design where the futility bound is non-binding but the harm bound is binding.
-In practice, such a distinction has no computational effect.
-The harm bound is computed *after* the efficacy and futility bounds are set and does not feed back into those computations.
-When the futility bound is non-binding (as in `test.type = 8`), the efficacy bound is computed ignoring all lower-bound stopping.
-Since the harm bound lies below the futility bound, making the harm bound "binding" while the futility bound remains non-binding would not change the efficacy boundary, the required number of events, the final Z-values, or the p-values --- the results are identical.
+When futility and harm are both tested at an analysis, the harm boundary lies below the futility boundary and therefore does not add another stopping region. Crossing probabilities are nevertheless partitioned into mutually exclusive harm, futility, and efficacy outcomes.
 
-The only difference would be in *interpretation*: whether crossing the harm bound is treated as a firm commitment to stop or as advisory information for the DMC.
-This interpretive distinction does not require a separate `test.type`; it can be addressed in the protocol language and the DMC charter.
-The `test.type = 8` framework already provides full flexibility for the DMC to treat the harm bound as either advisory or mandatory.
+When harm is tested at an analysis where futility is skipped, the harm boundary is the active lower stopping boundary. This stopping probability is included in sample-size derivation and, for `test.type = 7`, in the binding efficacy-bound calculation. For `test.type = 8`, efficacy bounds continue to use the non-binding Type I error convention, while power and expected information account for actual harm and futility stopping.
 
 ### Adjusting the boundaries
 

--- a/vignettes/HarmBound.Rmd
+++ b/vignettes/HarmBound.Rmd
@@ -178,14 +178,15 @@ bounds <- data.frame(
 kable(bounds, caption = "Z-value boundaries at each analysis")
 ```
 
-**Decision rules at each analysis:**
+**Decision rules at an analysis where all three bounds are active:**
 
 - If $Z >$ efficacy bound: Stop for efficacy (reject $H_0$).
 - If futility bound $< Z \leq$ efficacy bound: Continue the trial.
 - If harm bound $< Z \leq$ futility bound: Stop for futility.
 - If $Z \leq$ harm bound: Stop for harm.
 
-Note that the harm bound is always at or below the futility bound.
+When both lower bounds are active, the harm bound is always at or below the futility bound.
+If futility is skipped but harm is tested, the harm bound is the sole active lower stopping boundary.
 At early analyses, the harm and futility bounds may coincide when the harm spending function has not yet allocated sufficient spending to differentiate them.
 
 ### Boundary crossing probabilities
@@ -225,7 +226,7 @@ plot(x8)
 
 The power plot (`plottype = 2`) shows cumulative boundary crossing probabilities as a function of the treatment effect.
 Three sets of lines appear: upper bound (cumulative efficacy crossing probability), 1-Futility bound, and 1-Harm bound.
-The harm lines are above the futility lines because the probability of crossing the harm bound is less than or equal to the probability of crossing the futility bound.
+Harm and futility are displayed as mutually exclusive stopping outcomes; neither curve should be interpreted as containing the other.
 We note that when the underlying treatment effect favors control, the high probability of crossing the harm bound indicates that the harm bound is sensitive and serves its intended purpose
 
 ```{r, fig.cap = "Boundary crossing probabilities for non-binding harm bound design"}
@@ -323,11 +324,17 @@ gsBoundSummary(x7)
 ### Efficacy bounds at alternate $\alpha$ levels
 
 The `gsBoundSummary()` function accepts an `alpha` argument to display efficacy bounds at one or more alternate $\alpha$ levels alongside the original design.
+Each alternate-alpha column retains the `testUpper` schedule from the design, so an efficacy analysis that was skipped remains inactive and every efficacy characteristic at that analysis, including cumulative crossing probability, is `NA`.
 Here we show the non-binding design (`x8`) with efficacy bounds for both $\alpha = 0.0125$ (the design level) and $\alpha = 0.025$:
 
 ```{r}
 gsBoundSummary(x8, alpha = 0.025)
 ```
+
+Alternate-alpha summaries are supported for `test.type = 8`, where both
+futility and harm bounds are non-binding. They are not supported for
+`test.type = 7`: a binding harm or futility bound is outside the non-binding
+sequential-p-value framework used for Maurer--Bretz graphical multiple testing.
 
 ## Practical considerations
 
@@ -350,8 +357,8 @@ This controls the probability of a false harm signal.
 
 ### Harm bound capping
 
-In the implementation, the harm bound is automatically **capped** so it never exceeds the futility bound.
-This ensures the ordering: harm bound $\leq$ futility bound $\leq$ efficacy bound at every analysis.
+In the implementation, the harm bound is automatically **capped** so it never exceeds the futility bound when both are active.
+This ensures the ordering harm bound $\leq$ futility bound $\leq$ efficacy bound at analyses where all three are tested, while allowing harm to be the active lower boundary when futility is skipped.
 
 ### When to use `test.type = 7` vs. `test.type = 8`
 

--- a/vignettes/HarmBound.Rmd
+++ b/vignettes/HarmBound.Rmd
@@ -233,9 +233,11 @@ plot(x8)
 #### Boundary crossing probabilities
 
 The power plot (`plottype = 2`) shows cumulative boundary crossing probabilities as a function of the treatment effect.
-Three sets of lines appear: upper bound (cumulative efficacy crossing probability), 1-Futility bound, and 1-Harm bound.
-Harm and futility are displayed as mutually exclusive stopping outcomes; the futility curve excludes harm crossings, so it should not be interpreted as containing the harm curve.
-We note that when the underlying treatment effect favors control, the high probability of crossing the harm bound indicates that the harm bound is sensitive and serves its intended purpose
+Three sets of lines appear: upper bound (cumulative efficacy crossing probability), `1-(Futility or harm)`, and `1-Harm`.
+Because the harm boundary is nested below the futility boundary when both are active, crossing the futility threshold includes both futility-only and harm stops.
+The `1-(Futility or harm)` curve therefore subtracts `x8$lower$prob + x8$harm$prob`, while the `1-Harm` curve subtracts harm crossings only.
+This aggregation is performed only for plotting: the probability arrays stored in `x8` remain mutually exclusive so that efficacy, futility-only, and harm outcomes add without double counting.
+When the underlying treatment effect favors control, the high probability of crossing the harm bound indicates that the harm bound is sensitive and serves its intended purpose.
 
 ```{r, fig.cap = "Boundary crossing probabilities for non-binding harm bound design"}
 plot(x8, plottype = 2)

--- a/vignettes/HarmBound.Rmd
+++ b/vignettes/HarmBound.Rmd
@@ -192,6 +192,9 @@ At early analyses, the harm and futility bounds may coincide when the harm spend
 ### Boundary crossing probabilities
 
 We examine the operating characteristics under two scenarios: no treatment effect (HR = 1, i.e., under $H_0$) and the design alternative (HR = 0.75).
+When harm and futility are both active, `x8$lower$prob` and `x8$harm$prob` are
+reported as mutually exclusive stopping outcomes. Thus, the probability of
+crossing the futility threshold is the sum of the two lower-tail components.
 
 ```{r}
 probs <- data.frame(
@@ -199,14 +202,19 @@ probs <- data.frame(
   Analysis = rep(1:x8$k, 2),
   Month = rep(x8$T, 2),
   `P(Efficacy)` = c(cumsum(x8$upper$prob[, 1]), cumsum(x8$upper$prob[, 2])),
-  `P(Futility)` = c(cumsum(x8$lower$prob[, 1]), cumsum(x8$lower$prob[, 2])),
+  `P(Futility only)` = c(cumsum(x8$lower$prob[, 1]), cumsum(x8$lower$prob[, 2])),
   `P(Harm)` = c(cumsum(x8$harm$prob[, 1]), cumsum(x8$harm$prob[, 2])),
+  `P(Futility or Harm)` = c(
+    cumsum(x8$lower$prob[, 1] + x8$harm$prob[, 1]),
+    cumsum(x8$lower$prob[, 2] + x8$harm$prob[, 2])
+  ),
   check.names = FALSE
 )
 kable(probs, digits = 4, caption = "Cumulative boundary crossing probabilities")
 ```
 
 Under $H_0$, the cumulative probability of crossing the harm bound across all analyses is approximately `r round(sum(x8$harm$prob[, 1]), 4)`, reflecting the spending allocated to the harm boundary.
+The cumulative probability of crossing the futility threshold, inclusive of harm, is approximately `r round(sum(x8$lower$prob[, 1] + x8$harm$prob[, 1]), 4)`.
 Under $H_1$ (HR = 0.75), crossing the harm bound is very unlikely (`r round(sum(x8$harm$prob[, 2]), 4)`), since the treatment is beneficial.
 
 ### Visualization
@@ -226,7 +234,7 @@ plot(x8)
 
 The power plot (`plottype = 2`) shows cumulative boundary crossing probabilities as a function of the treatment effect.
 Three sets of lines appear: upper bound (cumulative efficacy crossing probability), 1-Futility bound, and 1-Harm bound.
-Harm and futility are displayed as mutually exclusive stopping outcomes; neither curve should be interpreted as containing the other.
+Harm and futility are displayed as mutually exclusive stopping outcomes; the futility curve excludes harm crossings, so it should not be interpreted as containing the harm curve.
 We note that when the underlying treatment effect favors control, the high probability of crossing the harm bound indicates that the harm bound is sensitive and serves its intended purpose
 
 ```{r, fig.cap = "Boundary crossing probabilities for non-binding harm bound design"}

--- a/vignettes/SelectiveBoundTesting.Rmd
+++ b/vignettes/SelectiveBoundTesting.Rmd
@@ -40,7 +40,7 @@ For example:
 - **Selective harm monitoring**: For designs with harm bounds (`test.type = 7` or `8`), harm monitoring may be needed only at certain analyses.
 
 The `testUpper`, `testLower`, and `testHarm` parameters in `gsDesign()`, `gsSurv()`, and `gsSurvCalendar()` allow fine-grained control over which bounds are active at each analysis.
-When a bound is inactive at a given analysis, it is set to an extreme value ($\pm 20$ on the Z-scale) so that it cannot be crossed, and is displayed as `NA` in summaries.
+When a bound is inactive at a given analysis, it is set to an extreme value ($\pm 20$ on the Z-scale) so that it cannot be crossed. Every characteristic for that bound, including cumulative crossing probability, is displayed as `NA` at the inactive analysis. The underlying probability arrays retain the cumulative crossing information.
 
 ## Parameters
 
@@ -84,7 +84,7 @@ gsBoundSummary(x1)
 ```
 
 The probabilities under the null and alternative are recomputed accounting for the inactive bounds.
-Notice the cumulative futility crossing probability does not increase after IA1 since no further futility testing occurs.
+The underlying cumulative futility crossing probability does not increase after IA1 since no further futility testing occurs; the later inactive futility rows in `gsBoundSummary()` are displayed entirely as `NA`.
 
 We can also see the bounds in the `print()` output:
 
@@ -242,6 +242,7 @@ x1$testHarm
 ```
 
 These can be inspected programmatically for downstream analyses or reporting.
+For `gsSurv()` and `gsSurvCalendar()` objects, `x$call` records the original call and `x$inputs` retains evaluated survival-model inputs plus the applicable testing-schedule arguments. The normalized logical vectors above remain the authoritative schedule used in calculations and summaries.
 
 ## Type I Error Preservation
 
@@ -252,7 +253,7 @@ A key property of the selective bounds implementation is that **Type I error is 
 When bounds are selectively deactivated, the cumulative spending at each *performed* analysis remains at the spending function's planned value.
 At inactive analyses, the cumulative spending is frozen (no incremental spend), causing the C code to produce $\pm$EXTREMEZ bounds.
 At the next active analysis, the incremental spend absorbs the budget from any prior skipped analyses, so the cumulative spend catches up to the planned level.
-The efficacy bounds at active analyses are then recomputed using the modified spending with the sample size held fixed, ensuring the total alpha spent equals the nominal level.
+The efficacy bounds at active analyses are then recomputed using the modified spending, ensuring the total alpha spent equals the nominal level. If information was not fixed on input, the maximum information is subsequently solved again using the boundaries that will actually be tested so that power remains at its target.
 
 ### Non-binding futility (test.type 4 or 6)
 
@@ -288,8 +289,9 @@ cat("Non-binding alpha (skip IA1 efficacy):", nb_alpha_eff, "\n")
 ### Binding futility (test.type 3 or 5)
 
 For binding designs, the efficacy bounds depend on the futility bounds.
-When futility bounds are selectively removed, the bounds are recomputed with the modified spending while holding sample size fixed.
-This ensures the cumulative Type I error remains at the nominal level:
+When futility bounds are selectively removed, the bounds are recomputed with the modified spending.
+For a newly derived design, information is then adjusted to retain target power; when `n.I` is supplied, information remains fixed.
+This preserves cumulative Type I error at the nominal level while respecting the requested power calculation:
 
 ```{r}
 # Baseline binding design
@@ -300,13 +302,16 @@ cat("Baseline alpha:", sum(x_b$upper$prob[, 1]), "\n")
 x_b_sel <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
   testLower = c(TRUE, FALSE, FALSE))
 cat("Selective alpha:", sum(x_b_sel$upper$prob[, 1]), "\n")
+cat("Selective power:", sum(x_b_sel$upper$prob[, 2]), "\n")
 
 # Remove efficacy at IA1
 x_b_eff <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
   testUpper = c(FALSE, TRUE, TRUE))
 cat("Skip IA1 efficacy alpha:", sum(x_b_eff$upper$prob[, 1]), "\n")
+cat("Skip IA1 efficacy power:", sum(x_b_eff$upper$prob[, 2]), "\n")
 ```
 
 In all cases, the actual Type I error is exactly $\alpha = 0.025$ (within numerical tolerance).
-The sample size remains unchanged from the baseline design, and the bounds at active analyses adjust to properly allocate the spending budget.
+The bounds at active analyses adjust to allocate the spending budget, and derived information is recalibrated so that skipped efficacy or lower analyses do not leave the design over-powered.
 
+When `gsBoundSummary()` is used with alternate alpha levels, every efficacy column retains the original `testUpper` schedule. An efficacy look that was not planned is not reintroduced merely because another alpha level is displayed. Alternate-alpha summaries are available for the one-sided or non-binding test types 1, 4, 6, and 8. They are intentionally not offered for binding types 2, 3, 5, or 7, which are outside the Maurer--Bretz non-binding multiple-testing framework.

--- a/vignettes/VaccineEfficacy.Rmd
+++ b/vignettes/VaccineEfficacy.Rmd
@@ -195,14 +195,16 @@ cat(summary(xx, timeunit = "months"))
 ## Converting to an exact binomial design
 
 We now convert this to an exact binomial design.
-Full conversion with `toBinomialExact()` is available for `test.type = 1`,
-`4`, and `6`. For type 4, the upper event-count stopping boundary targets beta
-spending under the alternative; for type 6 it targets lower-bound spending
-under the null using `astar`. The current exact object has an efficacy bound
-and one upper stopping bound, so it cannot separately represent the futility
-and harm bounds from `test.type = 8`. Exact efficacy repeated and sequential
-p-values remain available for non-binding test types 1, 4, 6, and 8 because
-those calculations intentionally ignore non-binding lower and harm bounds.
+Full conversion with `toBinomialExact()` is available for non-binding
+`test.type = 1`, `4`, `6`, and `8`. For type 4, the upper event-count stopping
+boundary targets beta spending under the alternative; for type 6 it targets
+lower-bound spending under the null using `astar`. For type 8, `upper`
+contains all upper event-count stops and the additional `futility` and `harm`
+components partition those stops into mutually exclusive regions. The exact
+futility boundary targets beta spending under the alternative, while the harm
+boundary targets `astar` spending under the null. Exact efficacy repeated and
+sequential p-values remain available for all four non-binding test types and
+intentionally ignore their non-binding lower and harm bounds.
 The bound counts are described in this initial table displayed.
 `N` is the total event count, `a` the maximum number of events in the experimental group to cross the efficacy bound.
 For example, if 12 or fewer of 30 events at interim 1 are in the experimental group the efficacy bound has been crossed.

--- a/vignettes/VaccineEfficacy.Rmd
+++ b/vignettes/VaccineEfficacy.Rmd
@@ -195,6 +195,14 @@ cat(summary(xx, timeunit = "months"))
 ## Converting to an exact binomial design
 
 We now convert this to an exact binomial design.
+Full conversion with `toBinomialExact()` is available for `test.type = 1`,
+`4`, and `6`. For type 4, the upper event-count stopping boundary targets beta
+spending under the alternative; for type 6 it targets lower-bound spending
+under the null using `astar`. The current exact object has an efficacy bound
+and one upper stopping bound, so it cannot separately represent the futility
+and harm bounds from `test.type = 8`. Exact efficacy repeated and sequential
+p-values remain available for non-binding test types 1, 4, 6, and 8 because
+those calculations intentionally ignore non-binding lower and harm bounds.
 The bound counts are described in this initial table displayed.
 `N` is the total event count, `a` the maximum number of events in the experimental group to cross the efficacy bound.
 For example, if 12 or fewer of 30 events at interim 1 are in the experimental group the efficacy bound has been crossed.

--- a/vignettes/gsSurvPower.Rmd
+++ b/vignettes/gsSurvPower.Rmd
@@ -525,10 +525,16 @@ we can test at $\alpha = 0.025$?
 
 When `x` is provided and the information fractions (timing) match the
 original design, `gsSurvPower()` recalculates **efficacy bounds** at the
-new alpha using `gsDesign(test.type = 1)` (efficacy-only) while
-**preserving the original futility bounds** from `x`. This follows the
-same convention as `gsBoundSummary()`. Any futility bound that would
-exceed the new efficacy bound is clipped.
+new alpha using the non-binding efficacy convention while **preserving the
+original efficacy testing schedule and futility bounds** from `x`. This
+follows the same convention as `gsBoundSummary()`. Any futility bound that
+would exceed the new efficacy bound is clipped.
+
+For test types 1, 4, 6, and 8 this non-binding calculation is appropriate for
+evaluating alpha propagated by a Maurer--Bretz graphical multiple-testing
+procedure. For binding test types 2, 3, 5, and 7, the calculation below is a
+planning sensitivity analysis only and should not be interpreted as graphical
+alpha recycling or as a sequential p-value.
 
 When timing changes (e.g., different `targetEvents`), both bounds are
 recomputed from scratch using the full `test.type` and spending functions.
@@ -556,18 +562,20 @@ cat("Futility bounds:", round(pwr_a025$lower$bound, 4), "\n")
 cat("Power:          ", round(pwr_a025$power * 100, 1), "%\n\n")
 
 # Cross-check: gsBoundSummary at the same alternate alpha
-# (only test.type 1, 4, 6, 7, 8 are supported)
+# (only non-binding test.type 1, 4, 6, and 8 are supported)
 cat("=== gsBoundSummary (alpha = 0.025) ===\n")
 print(gsBoundSummary(design_a0125, alpha = 0.025))
 ```
 
 Note that `gsBoundSummary()` adds an $\alpha = 0.025$ column for
-`test.type` 1, 4, 6, 7, and 8. For binding types (3, 5),
-`gsBoundSummary()` does not support alternate alpha, but
-`gsSurvPower()` handles them using the same approach: recompute efficacy
-with `test.type = 1` at the new alpha and keep original futility bounds.
+non-binding `test.type` 1, 4, 6, and 8. It does not support alternate alpha
+for binding types 2, 3, 5, or 7. `gsSurvPower()` can still recompute efficacy
+with the non-binding convention for a binding input design, retain the original
+`testUpper` schedule, and keep the original futility bounds, but that result is
+a planning sensitivity analysis rather than a Maurer--Bretz multiplicity
+calculation.
 
-### Binding type example (test.type = 3)
+### Binding type planning sensitivity example (test.type = 3)
 
 ```{r alpha_binding}
 design3 <- gsSurv(


### PR DESCRIPTION
This PR fixes sample-size derivation when analyses skip efficacy, futility, or harm testing, so power no longer exceeds the requested target.\n\nIt also updates the related crossing-probability summaries and gsBoundSummary() handling for skipped bounds.\n\nValidation:\n- R CMD check --as-cran passed after installing missing suggested dependency kableExtra\n- Development version bumped to 3.10.1.9001