### PR TITLE
Fix gsSurvPower timing criteria

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.0.9004
+Version: 3.11.0.9005
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.0.9005
+Version: 3.11.0.9006
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.0.9003
+Version: 3.11.0.9004
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,12 @@
   exclusive futility and harm regions, targeting beta spending under the
   alternative and harm spending under the null, respectively (#287).
 
+## Documentation
+
+- Expanded the `gsSurvPower()` vignette with common timing pitfalls for
+  explicit `minfup`, `targetN`, `maxExtension`, and `minN + minFollowUp`
+  workflows (#291, #293, #295, #296).
+
 ## Bug fixes
 
 - `gsSurvPower()` now respects an explicitly supplied `minfup` as a final

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,20 @@
 
 ## Bug fixes
 
+- `gsSurvPower()` now respects an explicitly supplied `minfup` as a final
+  analysis timing floor for event-driven designs, so the final analysis is not
+  scheduled before the end of enrollment plus minimum follow-up (#291).
+- `gsSurvPower(targetN = ...)` now works when `R` is omitted by expanding and
+  rescaling enrollment-period durations to match the supplied `gamma` periods.
+  Documentation now clarifies that `targetN` changes enrollment duration; for
+  fixed-duration enrollment, specify `R` and scale `gamma` directly (#293).
+- `gsSurvPower()` now gives an informative error when `maxExtension` is used
+  without a floor timing criterion such as `plannedCalendarTime`, `minN`, or
+  `minTimeFromPreviousAnalysis` (#295).
+- `gsSurvPower()` can now use `minN` plus `minFollowUp` as the primary timing
+  criterion, solves for the earliest time at which enrollment reaches `minN`,
+  and reports a clear error if the criteria do not produce strictly increasing
+  analyses (#296).
 - `gsSurvPower()` now retains exact event totals when `targetEvents` determines
   an analysis, rather than exposing small root-finding residuals that could
   make `gsBoundSummary()` round an integer event target up by one (#294).

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
 
 ## Documentation
 
+- Clarified the two intended uses of `gsSurvPower()`, expanded guidance for
+  scenario and combined timing-rule analyses, added survival workflow routing,
+  and documented that expected-value calculations do not replace simulation
+  of stochastic trial execution (#303).
 - Expanded the `gsSurvPower()` vignette with common timing pitfalls for
   explicit `minfup`, `targetN`, `maxExtension`, and `minN + minFollowUp`
   workflows (#291, #293, #295, #296).

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -57,7 +57,9 @@
 #'   \item Compute floor times from applicable criteria:
 #'     \code{plannedCalendarTime[i]},
 #'     \code{T[i-1] + minTimeFromPreviousAnalysis[i]}, and
-#'     time when \code{minN[i]} enrolled + \code{minFollowUp[i]}.
+#'     time when \code{minN[i]} enrolled + \code{minFollowUp[i]}. When
+#'     \code{minfup} is explicitly supplied, the final analysis also has a
+#'     floor at the end of enrollment plus \code{minfup}.
 #'   \item \code{floor_time = max(all applicable floor times)}.
 #'   \item If \code{targetEvents[i]} is specified: find \code{t_events} when
 #'     expected events reach target. If \code{t_events <= floor_time}, analysis
@@ -70,7 +72,10 @@
 #'     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
 #'     \code{T[i-1] + maxExtension[i]} when no calendar time is specified),
 #'     even if other criteria such as \code{minTimeFromPreviousAnalysis}
-#'     or \code{minN + minFollowUp} would require a later time.
+#'     or \code{minN + minFollowUp} would require a later time. Each analysis
+#'     using \code{maxExtension} must have a floor timing criterion such as
+#'     \code{plannedCalendarTime}, \code{minTimeFromPreviousAnalysis},
+#'     \code{minN}, or explicit final-analysis \code{minfup}.
 #' }
 #'
 #' \strong{Normalization and consistency:}
@@ -185,14 +190,16 @@
 #' @param R Scalar or vector of enrollment period durations.
 #' @param targetN Target total sample size. When specified, \code{R} is
 #'   uniformly rescaled so that \code{sum(gamma * R) == targetN}, preserving
-#'   the relative duration of each enrollment period. This is a convenience
-#'   for "what-if" analyses where the enrollment rate changes but the
-#'   target sample size stays the same (or vice versa). Cannot be used
-#'   together with an explicit \code{R}.
+#'   the relative duration of each enrollment period. This changes enrollment
+#'   duration rather than the enrollment rates. Cannot be used together with
+#'   an explicit non-\code{NULL} \code{R}; to keep a fixed enrollment duration,
+#'   specify \code{R} and scale \code{gamma} directly.
 #' @param S Scalar or vector of piecewise failure period durations; \code{NULL}
 #'   for exponential failure.
 #' @param ratio Randomization ratio (experimental/control). Default 1.
-#' @param minfup Minimum follow-up time.
+#' @param minfup Minimum follow-up time. When explicitly supplied,
+#'   event-driven analyses cannot place the final analysis before the end of
+#'   enrollment plus \code{minfup}.
 #' @param method Sample-size variance formulation. One of
 #'   \code{"LachinFoulkes"} (default), \code{"Schoenfeld"},
 #'   \code{"Freedman"}, or \code{"BernsteinLagakos"}. Affects \code{n.fix}
@@ -212,14 +219,19 @@
 #'   supplied, row sums give the total event target used to solve each
 #'   analysis time.
 #' @param maxExtension Maximum time extension beyond the floor time to wait
-#'   for \code{targetEvents}. Scalar or vector of length \code{k}.
+#'   for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
+#'   floor timing criterion for the affected analysis, most commonly
+#'   \code{plannedCalendarTime}.
 #' @param minTimeFromPreviousAnalysis Minimum elapsed time since the previous
 #'   analysis. Scalar or vector of length \code{k}. Ignored for the first
 #'   analysis.
 #' @param minN Minimum total sample size enrolled before analysis can proceed.
-#'   Scalar or vector of length \code{k}.
+#'   Scalar or vector of length \code{k}. Can be used with
+#'   \code{minFollowUp} as the primary timing criterion; the resulting
+#'   analysis times and expected event totals must be strictly increasing.
 #' @param minFollowUp Minimum follow-up time after \code{minN} is reached.
-#'   Scalar or vector of length \code{k}. Must be >= 0.
+#'   Scalar or vector of length \code{k}. Must be >= 0 and requires
+#'   \code{minN}.
 #' @param informationRates Numeric vector of length \code{k} specifying
 #'   planned information fractions. When provided, spending fractions are
 #'   \code{pmin(informationRates, actual_timing)} at each analysis, where
@@ -289,6 +301,16 @@
 #'   plannedCalendarTime = c(24, 36)
 #' )$power
 #'
+#' # Use targetN without R to solve enrollment duration from relative rates
+#' pwr_target_n <- gsSurvPower(
+#'   k = 2, test.type = 1, alpha = 0.025, sided = 1,
+#'   lambdaC = log(2) / 15, hr = 0.7, eta = 0.001,
+#'   gamma = c(10, 20, 30, 40), targetN = 500,
+#'   ratio = 1.5, plannedCalendarTime = c(24, 36),
+#'   testLower = FALSE
+#' )
+#' sum(rowSums(pwr_target_n$gamma) * pwr_target_n$R)
+#'
 #' @seealso \code{vignette("gsSurvPower", package = "gsDesign")} for
 #'   worked examples including calendar spending, stratified event targets,
 #'   and biomarker subgroup analyses.
@@ -325,10 +347,14 @@ gsSurvPower <- function(
     fullSpendingAtFinal = FALSE,
     tol = .Machine$double.eps^0.25) {
   spending <- match.arg(spending)
+  call_object <- match.call()
+  call_args <- as.list(call_object)
 
   # Track whether user explicitly provided alpha; used below to decide
   # whether the gsSurv alpha/sided convention applies.
   alpha_provided_by_user <- !is.null(alpha)
+  minfup_provided_by_user <- "minfup" %in% names(call_args) &&
+    !is.null(call_args$minfup)
   if (!is.null(x)) {
     if (!inherits(x, "gsSurv")) stop("x must be a gsSurv object")
 
@@ -417,11 +443,24 @@ gsSurvPower <- function(
 
   # targetN: rescale R so that sum(gamma * R) == targetN
   if (!is.null(targetN)) {
-    if (!missing(R) && !is.null(match.call()$R)) {
+    if (length(targetN) != 1 || !is.numeric(targetN) ||
+        !is.finite(targetN) || targetN <= 0) {
+      stop("targetN must be a single positive finite numeric value")
+    }
+    if ("R" %in% names(call_args) && !is.null(call_args$R)) {
       stop("Cannot specify both R and targetN")
     }
     gamma_vec <- if (is.matrix(gamma)) rowSums(gamma) else as.numeric(gamma)
+    if (is.null(x) && length(R) == 1 && length(gamma_vec) > 1) {
+      R <- rep(R, length(gamma_vec))
+    }
+    if (length(R) != length(gamma_vec)) {
+      stop("R must have length 1 or match the number of enrollment periods in gamma")
+    }
     current_N <- sum(gamma_vec * R)
+    if (!is.finite(current_N) || current_N <= 0) {
+      stop("gamma and R must imply a positive total enrollment before targetN rescaling")
+    }
     R <- R * targetN / current_N
   }
 
@@ -433,6 +472,7 @@ gsSurvPower <- function(
     minTimeFromPreviousAnalysis = minTimeFromPreviousAnalysis,
     minFollowUp = minFollowUp,
     minN = minN,
+    finalMinFollowUp = if (minfup_provided_by_user) minfup else NULL,
     x = x
   )
   k <- timing_inputs$k
@@ -560,7 +600,7 @@ gsSurvPower <- function(
     bound_result = bound_result,
     normalized_rates = normalized_rates,
     settings = settings,
-    call_object = match.call()
+    call_object = call_object
   )
 }
 
@@ -628,15 +668,21 @@ gsSurvPower <- function(
     minTimeFromPreviousAnalysis,
     minFollowUp,
     minN,
+    finalMinFollowUp,
     x) {
   planned_time_input <- plannedCalendarTime
   target_event_input <- targetEvents
 
-  if (is.null(planned_time_input) && is.null(target_event_input)) {
+  if (!is.null(minFollowUp) && is.null(minN)) {
+    stop("minFollowUp requires minN")
+  }
+
+  if (is.null(planned_time_input) && is.null(target_event_input) &&
+      is.null(minN)) {
     if (!is.null(x)) {
       planned_time_input <- x$T
     } else {
-      stop("At least one of plannedCalendarTime or targetEvents must be specified")
+      stop("At least one of plannedCalendarTime, targetEvents, or minN must be specified")
     }
   }
 
@@ -648,6 +694,8 @@ gsSurvPower <- function(
       analysis_count <- nrow(target_event_input)
     } else if (!is.null(target_event_input)) {
       analysis_count <- length(target_event_input)
+    } else if (!is.null(minN)) {
+      analysis_count <- length(minN)
     }
   }
   if (is.null(analysis_count) || analysis_count < 1) {
@@ -669,6 +717,15 @@ gsSurvPower <- function(
     minFollowUp, "minFollowUp", analysis_count
   )
   min_enrolled <- .gsSurvPower_recycle_to_k(minN, "minN", analysis_count)
+  final_min_follow_up <- if (is.null(finalMinFollowUp)) {
+    NA_real_
+  } else {
+    if (length(finalMinFollowUp) != 1 || !is.numeric(finalMinFollowUp) ||
+        !is.finite(finalMinFollowUp) || finalMinFollowUp < 0) {
+      stop("minfup must be a single non-negative finite numeric value")
+    }
+    finalMinFollowUp
+  }
 
   if (is.null(target_event_input)) {
     total_event_targets <- rep(NA_real_, analysis_count)
@@ -683,6 +740,19 @@ gsSurvPower <- function(
     )
   }
 
+  for (analysis_index in seq_len(analysis_count)) {
+    has_floor_criterion <- !is.na(planned_time[analysis_index]) ||
+      (analysis_index > 1 && !is.na(min_time_from_previous[analysis_index])) ||
+      !is.na(min_enrolled[analysis_index]) ||
+      (analysis_index == analysis_count && !is.na(final_min_follow_up))
+    if (!is.na(max_extension[analysis_index]) && !has_floor_criterion) {
+      stop(
+        "maxExtension requires a floor timing criterion such as ",
+        "plannedCalendarTime, minTimeFromPreviousAnalysis, minN, or minfup"
+      )
+    }
+  }
+
   list(
     k = analysis_count,
     planned_time = planned_time,
@@ -690,6 +760,7 @@ gsSurvPower <- function(
     min_time_from_previous = min_time_from_previous,
     min_follow_up = min_follow_up,
     min_enrolled = min_enrolled,
+    final_min_follow_up = final_min_follow_up,
     total_event_targets = total_event_targets
   )
 }
@@ -743,9 +814,21 @@ gsSurvPower <- function(
   objective <- function(current_time) {
     expected_counts_at_time(current_time)$total_n - target
   }
-  if (objective(search_upper_bound) < 0) return(search_upper_bound)
-  if (objective(0.001) >= 0) return(0.001)
-  uniroot(objective, c(0.001, search_upper_bound), tol = tol)$root
+  lower <- 0.001
+  upper <- search_upper_bound
+  if (objective(upper) < 0) return(upper)
+  if (objective(lower) >= 0) return(lower)
+
+  for (iteration in seq_len(100)) {
+    midpoint <- (lower + upper) / 2
+    if (objective(midpoint) >= 0) {
+      upper <- midpoint
+    } else {
+      lower <- midpoint
+    }
+    if (upper - lower <= tol) break
+  }
+  upper
 }
 
 .gsSurvPower_solve_analysis_schedule <- function(
@@ -758,6 +841,7 @@ gsSurvPower <- function(
   min_time_from_previous <- timing_inputs$min_time_from_previous
   min_follow_up <- timing_inputs$min_follow_up
   min_enrolled <- timing_inputs$min_enrolled
+  final_min_follow_up <- timing_inputs$final_min_follow_up
   total_event_targets <- timing_inputs$total_event_targets
   analysis_count <- timing_inputs$k
 
@@ -814,6 +898,9 @@ gsSurvPower <- function(
         0
       }
       floor_times <- c(floor_times, enrollment_time + follow_up_time)
+    }
+    if (analysis_index == analysis_count && !is.na(final_min_follow_up)) {
+      floor_times <- c(floor_times, sum(R) + final_min_follow_up)
     }
     floor_time <- if (length(floor_times) > 0) max(floor_times) else 0.001
 
@@ -885,6 +972,21 @@ gsSurvPower <- function(
   experimental_enrollment <- gsRoundNearInteger(experimental_enrollment)
   total_events <- rowSums(control_events) + rowSums(experimental_events)
   total_events[target_rows] <- total_event_targets[target_rows]
+
+  if (analysis_count > 1) {
+    if (any(diff(analysis_time) <= tol)) {
+      stop(
+        "Analysis times must be strictly increasing; add targetEvents, ",
+        "plannedCalendarTime, minTimeFromPreviousAnalysis, or later ",
+        "minN/minFollowUp criteria"
+      )
+    }
+    if (any(diff(total_events) <= tol)) {
+      stop(
+        "Expected event totals must be strictly increasing across analyses"
+      )
+    }
+  }
 
   list(
     analysis_time = analysis_time,

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -353,8 +353,7 @@ gsSurvPower <- function(
   # Track whether user explicitly provided alpha; used below to decide
   # whether the gsSurv alpha/sided convention applies.
   alpha_provided_by_user <- !is.null(alpha)
-  minfup_provided_by_user <- "minfup" %in% names(call_args) &&
-    !is.null(call_args$minfup)
+  minfup_provided_by_user <- !is.null(minfup)
   if (!is.null(x)) {
     if (!inherits(x, "gsSurv")) stop("x must be a gsSurv object")
 

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -4,9 +4,11 @@
 #' with specified enrollment, dropout, treatment effect, and analysis timing.
 #' Unlike \code{gsSurv()} and \code{gsSurvCalendar()} which solve for sample
 #' size to achieve target power, \code{gsSurvPower()} takes fixed design
-#' assumptions and computes the resulting power. It is meant to compute for
-#' a single set of assumptions at a time; different scenarios are evaluated
-#' with separate calls.
+#' assumptions and computes the resulting power. Its two primary uses are
+#' computing achieved power when sample size is not being derived and
+#' evaluating alternative enrollment, failure, treatment-effect, and analysis
+#' timing scenarios. It computes one set of assumptions at a time; scenario
+#' grids are evaluated with separate calls.
 #' For \code{k = 1}, power is computed through the fixed-design
 #' \code{nSurv(beta = NULL)} path. The returned object is normalized as a
 #' single-analysis \code{gsSurv} object so it can be passed to
@@ -21,6 +23,16 @@
 #' evaluates power under HR = 0.8 using all other parameters from the design.
 #' When \code{x} is not provided, all design parameters must be specified
 #' directly.
+#'
+#' \strong{Interpretation and limitations:}
+#' Enrollment, dropout, event accumulation, and analysis timing are represented
+#' by their expected values under the supplied assumptions. Consequently,
+#' event- and enrollment-triggered analysis times are expected analysis times,
+#' not simulated realizations. The calculation does not represent
+#' trial-to-trial variation in enrollment, failure, dropout, or operational
+#' timing. Use simulation when that variation may materially affect operating
+#' characteristics or the probability that combined timing rules are met; see,
+#' for example, the \href{https://merck.github.io/simtrial/}{simtrial package}.
 #'
 #' \strong{Hazard ratio roles:}
 #' Two distinct hazard ratios serve different purposes. \code{hr} is the
@@ -41,10 +53,11 @@
 #' The choice between \code{plannedCalendarTime} and \code{targetEvents} has an
 #' important consequence for sensitivity analyses:
 #' \itemize{
-#'   \item \code{plannedCalendarTime} fixes calendar times; expected events are
-#'     recomputed under the assumed HR. A worse HR produces more events at the
-#'     same calendar time (the experimental arm fails faster). This gives an
-#'     "unconditional" power.
+#'   \item Used alone, \code{plannedCalendarTime} fixes calendar times;
+#'     when combined with other criteria, it supplies a timing floor. Expected
+#'     events are recomputed under the assumed HR. A worse HR produces more
+#'     events at the same calendar time (the experimental arm fails faster).
+#'     This gives an "unconditional" power.
 #'   \item \code{targetEvents} fixes event counts; calendar times adjust. Since
 #'     events are held constant, information fractions do not change with HR, and
 #'     results match the \code{gsDesign} power plot
@@ -68,7 +81,8 @@
 #'     \code{min(t_events, floor_time + maxExtension[i])}. Otherwise, analysis
 #'     at \code{t_events}.
 #'   \item If no \code{targetEvents}: analysis at \code{floor_time}.
-#'   \item \code{maxExtension} is a hard cap: the analysis time is never pushed
+#'   \item \code{maxExtension} defines a hard deadline: the analysis time
+#'     is never pushed
 #'     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
 #'     \code{T[i-1] + maxExtension[i]} when no calendar time is specified),
 #'     even if other criteria such as \code{minTimeFromPreviousAnalysis}

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -143,17 +143,19 @@ and strata (columns).}
 
 \item{targetN}{Target total sample size. When specified, \code{R} is
 uniformly rescaled so that \code{sum(gamma * R) == targetN}, preserving
-the relative duration of each enrollment period. This is a convenience
-for "what-if" analyses where the enrollment rate changes but the
-target sample size stays the same (or vice versa). Cannot be used
-together with an explicit \code{R}.}
+the relative duration of each enrollment period. This changes enrollment
+duration rather than the enrollment rates. Cannot be used together with
+an explicit non-\code{NULL} \code{R}; to keep a fixed enrollment duration,
+specify \code{R} and scale \code{gamma} directly.}
 
 \item{S}{Scalar or vector of piecewise failure period durations; \code{NULL}
 for exponential failure.}
 
 \item{ratio}{Randomization ratio (experimental/control). Default 1.}
 
-\item{minfup}{Minimum follow-up time.}
+\item{minfup}{Minimum follow-up time. When explicitly supplied,
+event-driven analyses cannot place the final analysis before the end of
+enrollment plus \code{minfup}.}
 
 \item{method}{Sample-size variance formulation. One of
 \code{"LachinFoulkes"} (default), \code{"Schoenfeld"},
@@ -178,17 +180,22 @@ supplied, row sums give the total event target used to solve each
 analysis time.}
 
 \item{maxExtension}{Maximum time extension beyond the floor time to wait
-for \code{targetEvents}. Scalar or vector of length \code{k}.}
+for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
+floor timing criterion for the affected analysis, most commonly
+\code{plannedCalendarTime}.}
 
 \item{minTimeFromPreviousAnalysis}{Minimum elapsed time since the previous
 analysis. Scalar or vector of length \code{k}. Ignored for the first
 analysis.}
 
 \item{minN}{Minimum total sample size enrolled before analysis can proceed.
-Scalar or vector of length \code{k}.}
+Scalar or vector of length \code{k}. Can be used with
+\code{minFollowUp} as the primary timing criterion; the resulting
+analysis times and expected event totals must be strictly increasing.}
 
 \item{minFollowUp}{Minimum follow-up time after \code{minN} is reached.
-Scalar or vector of length \code{k}. Must be >= 0.}
+Scalar or vector of length \code{k}. Must be >= 0 and requires
+\code{minN}.}
 
 \item{informationRates}{Numeric vector of length \code{k} specifying
 planned information fractions. When provided, spending fractions are
@@ -295,7 +302,9 @@ For analysis \code{i}, the analysis time \code{T[i]} is determined as:
   \item Compute floor times from applicable criteria:
     \code{plannedCalendarTime[i]},
     \code{T[i-1] + minTimeFromPreviousAnalysis[i]}, and
-    time when \code{minN[i]} enrolled + \code{minFollowUp[i]}.
+    time when \code{minN[i]} enrolled + \code{minFollowUp[i]}. When
+    \code{minfup} is explicitly supplied, the final analysis also has a
+    floor at the end of enrollment plus \code{minfup}.
   \item \code{floor_time = max(all applicable floor times)}.
   \item If \code{targetEvents[i]} is specified: find \code{t_events} when
     expected events reach target. If \code{t_events <= floor_time}, analysis
@@ -308,7 +317,10 @@ For analysis \code{i}, the analysis time \code{T[i]} is determined as:
     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
     \code{T[i-1] + maxExtension[i]} when no calendar time is specified),
     even if other criteria such as \code{minTimeFromPreviousAnalysis}
-    or \code{minN + minFollowUp} would require a later time.
+    or \code{minN + minFollowUp} would require a later time. Each analysis
+    using \code{maxExtension} must have a floor timing criterion such as
+    \code{plannedCalendarTime}, \code{minTimeFromPreviousAnalysis},
+    \code{minN}, or explicit final-analysis \code{minfup}.
 }
 
 \strong{Normalization and consistency:}
@@ -379,6 +391,16 @@ gsSurvPower(
   gamma = 8, R = 18, ratio = 1,
   plannedCalendarTime = c(24, 36)
 )$power
+
+# Use targetN without R to solve enrollment duration from relative rates
+pwr_target_n <- gsSurvPower(
+  k = 2, test.type = 1, alpha = 0.025, sided = 1,
+  lambdaC = log(2) / 15, hr = 0.7, eta = 0.001,
+  gamma = c(10, 20, 30, 40), targetN = 500,
+  ratio = 1.5, plannedCalendarTime = c(24, 36),
+  testLower = FALSE
+)
+sum(rowSums(pwr_target_n$gamma) * pwr_target_n$R)
 
 }
 \seealso{

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -249,9 +249,11 @@ An object of class \code{c("gsSurv", "gsDesign")} containing:
 with specified enrollment, dropout, treatment effect, and analysis timing.
 Unlike \code{gsSurv()} and \code{gsSurvCalendar()} which solve for sample
 size to achieve target power, \code{gsSurvPower()} takes fixed design
-assumptions and computes the resulting power. It is meant to compute for
-a single set of assumptions at a time; different scenarios are evaluated
-with separate calls.
+assumptions and computes the resulting power. Its two primary uses are
+computing achieved power when sample size is not being derived and
+evaluating alternative enrollment, failure, treatment-effect, and analysis
+timing scenarios. It computes one set of assumptions at a time; scenario
+grids are evaluated with separate calls.
 For \code{k = 1}, power is computed through the fixed-design
 \code{nSurv(beta = NULL)} path. The returned object is normalized as a
 single-analysis \code{gsSurv} object so it can be passed to
@@ -266,6 +268,16 @@ enabling "what-if" analyses: e.g., \code{gsSurvPower(x = design, hr = 0.8)}
 evaluates power under HR = 0.8 using all other parameters from the design.
 When \code{x} is not provided, all design parameters must be specified
 directly.
+
+\strong{Interpretation and limitations:}
+Enrollment, dropout, event accumulation, and analysis timing are represented
+by their expected values under the supplied assumptions. Consequently,
+event- and enrollment-triggered analysis times are expected analysis times,
+not simulated realizations. The calculation does not represent
+trial-to-trial variation in enrollment, failure, dropout, or operational
+timing. Use simulation when that variation may materially affect operating
+characteristics or the probability that combined timing rules are met; see,
+for example, the \href{https://merck.github.io/simtrial/}{simtrial package}.
 
 \strong{Hazard ratio roles:}
 Two distinct hazard ratios serve different purposes. \code{hr} is the
@@ -286,10 +298,11 @@ not apply to analysis \code{i}.
 The choice between \code{plannedCalendarTime} and \code{targetEvents} has an
 important consequence for sensitivity analyses:
 \itemize{
-  \item \code{plannedCalendarTime} fixes calendar times; expected events are
-    recomputed under the assumed HR. A worse HR produces more events at the
-    same calendar time (the experimental arm fails faster). This gives an
-    "unconditional" power.
+  \item Used alone, \code{plannedCalendarTime} fixes calendar times;
+    when combined with other criteria, it supplies a timing floor. Expected
+    events are recomputed under the assumed HR. A worse HR produces more
+    events at the same calendar time (the experimental arm fails faster).
+    This gives an "unconditional" power.
   \item \code{targetEvents} fixes event counts; calendar times adjust. Since
     events are held constant, information fractions do not change with HR, and
     results match the \code{gsDesign} power plot
@@ -313,7 +326,8 @@ For analysis \code{i}, the analysis time \code{T[i]} is determined as:
     \code{min(t_events, floor_time + maxExtension[i])}. Otherwise, analysis
     at \code{t_events}.
   \item If no \code{targetEvents}: analysis at \code{floor_time}.
-  \item \code{maxExtension} is a hard cap: the analysis time is never pushed
+  \item \code{maxExtension} defines a hard deadline: the analysis time
+    is never pushed
     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
     \code{T[i-1] + maxExtension[i]} when no calendar time is specified),
     even if other criteria such as \code{minTimeFromPreviousAnalysis}

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -95,6 +95,64 @@ test_that("gsSurvPower preserves integer sample size and event targets", {
   )
 })
 
+test_that("gsSurvPower applies explicit minfup as final analysis floor", {
+  target_events <- c(100, 200, 300)
+  pwr <- gsSurvPower(
+    k = 3,
+    test.type = 1,
+    alpha = 0.025,
+    sided = 1,
+    astar = 0,
+    sfu = sfLDOF,
+    sfupar = NULL,
+    spending = "information",
+    lambdaC = log(2) / 15,
+    hr = 0.7,
+    hr0 = 1,
+    eta = 0.001,
+    gamma = c(1, 2, 3, 4) * 500 /
+      sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+    R = c(2, 2, 2, 6),
+    targetEvents = target_events,
+    minfup = 25,
+    ratio = 1.5,
+    testUpper = TRUE,
+    testLower = FALSE,
+    testHarm = FALSE,
+    method = "LachinFoulkes"
+  )
+
+  expect_equal(tail(pwr$T, 1), sum(c(2, 2, 2, 6)) + 25, tolerance = 1e-6)
+  expect_equal(pwr$n.I[1:2], target_events[1:2], tolerance = 1e-6)
+  expect_true(pwr$n.I[3] > target_events[3])
+})
+
+test_that("gsSurvPower targetN works without explicit R", {
+  pwr <- gsSurvPower(
+    k = 2,
+    test.type = 1,
+    alpha = 0.025,
+    sided = 1,
+    lambdaC = log(2) / 15,
+    hr = 0.7,
+    hr0 = 1,
+    eta = 0.001,
+    gamma = c(10, 20, 30, 40),
+    targetN = 500,
+    plannedCalendarTime = c(24, 36),
+    ratio = 1.5,
+    testUpper = TRUE,
+    testLower = FALSE,
+    testHarm = FALSE,
+    method = "LachinFoulkes"
+  )
+
+  expect_length(pwr$R, 4)
+  expect_equal(sum(rowSums(pwr$gamma) * pwr$R), 500, tolerance = 1e-8)
+  expect_equal(pwr$R, rep(5, 4), tolerance = 1e-8)
+  expect_equal(pwr$T, c(24, 36))
+})
+
 test_that("gsSurvPower works without x (all parameters specified)", {
   pwr <- gsSurvPower(
     k = 2, test.type = 1, alpha = 0.025, sided = 1,
@@ -127,6 +185,19 @@ test_that("gsSurvPower respects maxExtension", {
     plannedCalendarTime = c(18)
   )
   expect_true(pwr_capped$T[1] <= pwr_uncapped$T[1])
+})
+
+test_that("gsSurvPower requires a floor criterion when maxExtension is supplied", {
+  expect_error(
+    gsSurvPower(
+      k = 2, test.type = 1, alpha = 0.025, sided = 1,
+      lambdaC = log(2) / 12, hr = 0.7, hr0 = 1,
+      gamma = 5, R = 12, ratio = 1,
+      targetEvents = c(20, 40),
+      maxExtension = c(0, 6)
+    ),
+    "maxExtension requires a floor timing criterion"
+  )
 })
 
 test_that("maxExtension is a hard cap even when other criteria push later", {
@@ -355,6 +426,56 @@ test_that("gsSurvPower minTimeFromPreviousAnalysis works", {
     minTimeFromPreviousAnalysis = c(NA, 6)
   )
   expect_true(pwr$T[2] - pwr$T[1] >= 6 - 1e-6)
+})
+
+test_that("gsSurvPower supports minN and minFollowUp timing", {
+  pwr <- gsSurvPower(
+    k = 3,
+    test.type = 1,
+    alpha = 0.025,
+    sided = 1,
+    lambdaC = log(2) / 15,
+    hr = 0.7,
+    hr0 = 1,
+    eta = 0.001,
+    gamma = c(1, 2, 3, 4) * 500 /
+      sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+    R = c(2, 2, 2, 6),
+    minN = c(100, 300, 500),
+    minFollowUp = c(6, 6, 6),
+    ratio = 1.5,
+    testUpper = TRUE,
+    testLower = FALSE,
+    testHarm = FALSE,
+    method = "LachinFoulkes"
+  )
+
+  expect_true(all(diff(pwr$T) > 0))
+  expect_true(all(pwr$N >= c(100, 300, 500)))
+
+  expect_error(
+    gsSurvPower(
+      k = 3,
+      test.type = 1,
+      alpha = 0.025,
+      sided = 1,
+      lambdaC = log(2) / 15,
+      hr = 0.7,
+      hr0 = 1,
+      eta = 0.001,
+      gamma = c(1, 2, 3, 4) * 500 /
+        sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+      R = c(2, 2, 2, 6),
+      minN = c(300, 500, 500),
+      minFollowUp = c(6, 6, 6),
+      ratio = 1.5,
+      testUpper = TRUE,
+      testLower = FALSE,
+      testHarm = FALSE,
+      method = "LachinFoulkes"
+    ),
+    "Analysis times must be strictly increasing"
+  )
 })
 
 test_that("gsSurvPower print method works for power output", {

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -127,6 +127,29 @@ test_that("gsSurvPower applies explicit minfup as final analysis floor", {
   expect_true(pwr$n.I[3] > target_events[3])
 })
 
+test_that("gsSurvPower only applies minfup floor when supplied directly", {
+  design <- gsSurv(
+    k = 3, test.type = 4, alpha = 0.025, sided = 1, beta = 0.1,
+    lambdaC = log(2) / 12, hr = 0.7, eta = 0.01,
+    gamma = 10, R = 16, minfup = 12, T = 28
+  )
+  target_events <- 0.8 * design$n.I
+
+  inherited <- gsSurvPower(x = design, targetEvents = target_events)
+  explicit <- gsSurvPower(
+    x = design,
+    targetEvents = target_events,
+    minfup = design$minfup
+  )
+
+  expect_lt(tail(inherited$T, 1), sum(design$R) + design$minfup)
+  expect_equal(
+    tail(explicit$T, 1),
+    sum(design$R) + design$minfup,
+    tolerance = 1e-6
+  )
+})
+
 test_that("gsSurvPower targetN works without explicit R", {
   pwr <- gsSurvPower(
     k = 2,

--- a/vignettes/SurvivalEnrollmentPlanning.Rmd
+++ b/vignettes/SurvivalEnrollmentPlanning.Rmd
@@ -38,6 +38,32 @@ given a fixed operational plan, what power will it achieve? Finally,
 `toInteger()` converts continuous expected events and enrollment to an
 integer-compatible plan.
 
+## Choose the workflow by the question
+
+The appropriate function depends first on whether the objective is to derive a
+powered design, evaluate a fixed plan, or quantify variation during trial
+execution.
+
+| Question | Workflow | What is fixed or solved |
+| --- | --- | --- |
+| What event-driven design achieves target power? | `gsSurv()` | Solves the required sample size, enrollment, or follow-up component |
+| What design achieves target power at specified calendar looks? | `gsSurvCalendar()` | Fixes calendar analysis times and solves the powered design |
+| What power does a specified plan achieve under a scenario? | `gsSurvPower()` | Keeps supplied enrollment, failure, treatment-effect, and timing assumptions fixed |
+| How variable are analysis dates and operating characteristics in execution? | Simulation, such as [**simtrial**](https://merck.github.io/simtrial/) | Generates trial realizations under stochastic enrollment, failure, dropout, and timing |
+
+`gsSurvPower()` is the bridge between initial design and simulation. It is
+well-suited to rapid deterministic scenario grids: vary enrollment rates,
+failure rates, dropout, hazard ratios, or operational timing rules and compare
+the resulting expected analysis times, events, and power. Its calculations use
+expected enrollment and event accumulation, however, so event- or
+enrollment-triggered analysis times are expected times. Use simulation when
+the distribution of those times—or the chance that competing operational
+rules determine an analysis—is important.
+
+For detailed combinations of calendar floors, event targets, minimum spacing,
+enrollment plus follow-up, and extension deadlines, see
+`vignette("gsSurvPower")`.
+
 ```{r setup}
 library(gsDesign)
 

--- a/vignettes/gsSurvPower.Rmd
+++ b/vignettes/gsSurvPower.Rmd
@@ -128,6 +128,118 @@ exceeds `plannedCalendarTime + maxExtension` (or `T[i-1] + maxExtension`
 when no calendar time is specified), even if other criteria such as
 `minTimeFromPreviousAnalysis` or `minN + minFollowUp` would push it later.
 
+### Common timing pitfalls
+
+The timing arguments in `gsSurvPower()` describe a fixed operational plan.
+They do not solve the study design to achieve power the way `gsSurv()` does.
+Several inputs are therefore easy to misread.
+
+**`minfup` is a final-analysis floor, not a target event rule.** If `minfup`
+is explicitly supplied, the final analysis cannot occur before enrollment has
+ended and the last enrolled subject has at least that much follow-up. For an
+event-driven design with enrollment durations `R`, the final analysis time is
+at least `sum(R) + minfup`. If the requested final `targetEvents` is expected
+earlier, the final analysis remains delayed to satisfy minimum follow-up, and
+the expected final event count may exceed the event target.
+
+```{r timing_pitfall_minfup}
+pwr_minfup <- gsSurvPower(
+  k = 3, test.type = 1, alpha = 0.025, sided = 1,
+  sfu = sfLDOF, sfupar = NULL,
+  lambdaC = log(2) / 15, hr = 0.7, hr0 = 1,
+  eta = 0.001,
+  gamma = c(1, 2, 3, 4) * 500 /
+    sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+  R = c(2, 2, 2, 6),
+  targetEvents = c(100, 200, 300),
+  minfup = 25,
+  ratio = 1.5,
+  testUpper = TRUE, testLower = FALSE
+)
+
+data.frame(
+  Analysis = 1:3,
+  Time = round(pwr_minfup$T, 1),
+  Events = round(pwr_minfup$n.I, 1)
+)
+```
+
+**`targetN` changes enrollment duration, not enrollment rates.** Use
+`targetN` when `gamma` gives relative or absolute enrollment rates and you
+want `gsSurvPower()` to rescale `R` so that `sum(gamma * R) == targetN`.
+Do not also specify a non-`NULL` `R`. If the protocol fixes enrollment
+duration, specify `R` and scale `gamma` yourself.
+
+```{r timing_pitfall_targetn}
+pwr_target_n <- gsSurvPower(
+  k = 2, test.type = 1, alpha = 0.025, sided = 1,
+  lambdaC = log(2) / 15, hr = 0.7, hr0 = 1,
+  eta = 0.001,
+  gamma = c(10, 20, 30, 40),
+  targetN = 500,
+  plannedCalendarTime = c(24, 36),
+  ratio = 1.5,
+  testUpper = TRUE, testLower = FALSE
+)
+
+pwr_target_n$R
+sum(rowSums(pwr_target_n$gamma) * pwr_target_n$R)
+```
+
+**`maxExtension` needs a floor time.** `maxExtension` is the amount of time
+the analysis may wait beyond a floor criterion while waiting for
+`targetEvents`. A floor can come from `plannedCalendarTime`,
+`minTimeFromPreviousAnalysis`, `minN`, or an explicitly supplied final
+`minfup`. Without a floor, `maxExtension` is not meaningful.
+
+```{r timing_pitfall_maxextension}
+pwr_extension <- gsSurvPower(
+  k = 3, test.type = 1, alpha = 0.025, sided = 1,
+  lambdaC = log(2) / 15, hr = 0.7, hr0 = 1,
+  eta = 0.001,
+  gamma = c(1, 2, 3, 4) * 500 /
+    sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+  R = c(2, 2, 2, 6),
+  plannedCalendarTime = c(24, 30, 36),
+  targetEvents = c(200, 300, 400),
+  maxExtension = c(0, 6, 6),
+  ratio = 1.5,
+  testUpper = TRUE, testLower = FALSE
+)
+
+round(pwr_extension$T, 1)
+```
+
+**`minN + minFollowUp` can define analysis timing, but analyses must remain
+strictly increasing.** This pair says: wait until at least `minN` subjects
+are enrolled, then wait `minFollowUp` additional time. It can be used as the
+primary timing rule, but the resulting analysis times and expected event
+totals must increase across analyses. If two analyses use the same enrollment
+threshold and follow-up rule, add `plannedCalendarTime`, `targetEvents`, or
+`minTimeFromPreviousAnalysis` to separate them.
+
+```{r timing_pitfall_minn}
+pwr_min_n <- gsSurvPower(
+  k = 3, test.type = 1, alpha = 0.025, sided = 1,
+  lambdaC = log(2) / 15, hr = 0.7, hr0 = 1,
+  eta = 0.001,
+  gamma = c(1, 2, 3, 4) * 500 /
+    sum(c(1, 2, 3, 4) * c(2, 2, 2, 6)),
+  R = c(2, 2, 2, 6),
+  minN = c(100, 300, 500),
+  minFollowUp = c(6, 6, 6),
+  ratio = 1.5,
+  testUpper = TRUE, testLower = FALSE
+)
+
+data.frame(
+  Analysis = 1:3,
+  Time = round(pwr_min_n$T, 1),
+  N = round(pwr_min_n$N, 1),
+  Events = round(pwr_min_n$n.I, 1)
+)
+```
+
 ### Spending and method
 
 - **`spending`**: One of `"information"` (default) or `"calendar"`.

--- a/vignettes/gsSurvPower.Rmd
+++ b/vignettes/gsSurvPower.Rmd
@@ -13,10 +13,17 @@ library(gsDesign)
 
 ## Motivation
 
-`gsSurv()` and `gsSurvCalendar()` derive sample sizes and enrollment rates
-to achieve a target power for a given hazard ratio. In practice, we often
-want to answer the reverse question: *given a specified hazard ratio, fixed enrollment, dropout, and
-analysis timing assumptions, what power does the design achieve?*
+`gsSurvPower()` has two primary uses:
+
+1. **Compute achieved power without deriving sample size.** Given enrollment,
+   failure, dropout, treatment-effect, and analysis-timing assumptions, what
+   power does the design achieve?
+2. **Evaluate scenarios for an existing design.** What happens when enrollment,
+   failure rates, the hazard ratio, or operational timing rules differ from
+   plan?
+
+This reverses the usual role of `gsSurv()` and `gsSurvCalendar()`, which derive
+sample sizes or enrollment rates to achieve target power.
 
 Common scenarios include:
 
@@ -25,6 +32,8 @@ Common scenarios include:
 - **Changing alpha**: What if the multiplicity scheme initially allocates
   $\alpha = 0.0125$ and later allows $\alpha = 0.025$?
 - **Modified enrollment**: What if enrollment is slower than planned?
+- **Modified failure or dropout rates**: What if events accumulate faster or
+  slower than planned?
 - **Different analysis times**: What if interim analyses occur at calendar
   times that differ from the original design?
 
@@ -61,6 +70,21 @@ with `variable = "Power"`. The most useful components to inspect first are:
 - `pwr_design$upper$bound` and `pwr_design$lower$bound` for the bounds being
   applied.
 
+### What this calculation does—and does not do
+
+`gsSurvPower()` applies asymptotic group sequential calculations to expected
+enrollment, dropout, event accumulation, and analysis timing under one set of
+assumptions. Thus, an event- or enrollment-triggered analysis time is the
+*expected* time at which its rule is met.
+
+It does not simulate trial-to-trial variation in enrollment, failure, dropout,
+or operational analysis timing. Use simulation when that variability may
+materially affect operating characteristics, such as the probability of
+meeting competing timing rules, the distribution of analysis dates, or power
+under realistic trial execution. Packages such as
+[**simtrial**](https://merck.github.io/simtrial/) can support that more
+comprehensive evaluation.
+
 ## How gsSurvPower uses your inputs
 
 `gsSurvPower()` accepts an optional `gsSurv`-class object `x`, including output
@@ -87,7 +111,8 @@ Analysis times can be specified by calendar time, by target event counts, or
 by a combination of criteria. The choice has an important consequence for
 sensitivity analyses:
 
-- **`plannedCalendarTime`** fixes the calendar time of each analysis.
+- **`plannedCalendarTime`** fixes the calendar time when used alone. When
+  combined with other timing rules, it supplies an earliest time or floor.
   Expected events are then recomputed under the assumed HR.
   A worse HR (closer to 1) produces *more* expected events at the same
   calendar time because the experimental arm fails faster.
@@ -107,10 +132,25 @@ specifies event targets.
 
 ### Quick decision guide
 
-| If the protocol fixes... | Use... | What changes in a sensitivity analysis |
+| Operational rule | Argument | Interpretation |
 | --- | --- | --- |
-| Analysis dates | `plannedCalendarTime` | Expected events and information fractions |
-| Event targets | `targetEvents` | Time until expected events reach those targets |
+| Analyze at a calendar time | `plannedCalendarTime` | Exact time alone; earliest time when combined |
+| Analyze after an event target | `targetEvents` | Expected time the target is reached |
+| Require spacing between looks | `minTimeFromPreviousAnalysis` | Earliest time relative to the previous analysis |
+| Require enrollment plus follow-up | `minN`, `minFollowUp` | Earliest time satisfying both criteria |
+| Require final minimum follow-up | explicit `minfup` | Final-analysis floor after enrollment ends |
+| Stop waiting after a deadline | `maxExtension` | Hard cap on extension beyond its timing anchor |
+
+For scenario analyses, override only the assumptions that change:
+
+| Scenario | Arguments commonly changed |
+| --- | --- |
+| Treatment effect | `hr` |
+| Control failure rates | `lambdaC`, `S` |
+| Dropout | `eta`, `etaE` |
+| Enrollment rate or shape | `gamma` |
+| Enrollment duration or target size | `R`, or `targetN` |
+| Operational analysis rules | Timing arguments in the table above |
 
 Additional criteria can be combined per-analysis, each specified as a scalar
 (recycled to all `k` analyses) or a vector of length `k` with `NA` for
@@ -123,7 +163,7 @@ Additional criteria can be combined per-analysis, each specified as a scalar
 
 When multiple criteria apply to a single analysis, the analysis time is the
 maximum of all floor criteria, with `targetEvents` potentially extending
-beyond the floor. `maxExtension` acts as a hard cap: the analysis time never
+beyond the floor. `maxExtension` defines a hard deadline: the analysis time never
 exceeds `plannedCalendarTime + maxExtension` (or `T[i-1] + maxExtension`
 when no calendar time is specified), even if other criteria such as
 `minTimeFromPreviousAnalysis` or `minN + minFollowUp` would push it later.
@@ -330,11 +370,8 @@ Real trials often use multiple criteria for analysis timing. In practice,
 a protocol may specify target event counts, planned calendar times,
 minimum follow-up after enrollment completes, and caps on how long
 analyses can be delayed. `gsSurvPower()` lets you combine all of these
-in a single call. Approximations are based on expected event accumulation under the assumed HR.
-Thus, computations do not take into account the stochastic variability in event accrual.
-While `gsSurvPower()` should be adequate for most purposes, verification
-for key scenarios should consider simulation using the **simtrial** R
-package.
+in a single call. As noted above, these are expected-value calculations;
+simulation is needed to characterize variability in when the rules are met.
 
 ### Setup
 
@@ -540,7 +577,13 @@ even though the capped planned-vs-actual fraction would otherwise be
 0.95. This produces slightly different final bounds compared to the
 same `informationRates` specification with `fullSpendingAtFinal = FALSE`.
 
-## Comparison with gsDesign power plots
+## Additional and advanced examples
+
+The remaining sections cover validation against standard power plots and more
+specialized changes to spending, alpha, and stratified assumptions. They are
+useful when the basic scenario-and-timing workflow above is not sufficient.
+
+### Comparison with gsDesign power plots
 
 The `gsDesign` package provides power plots via `plot(design, plottype = 2)`.
 These hold event counts fixed at the design values and vary only the drift
@@ -597,7 +640,7 @@ comparison
   producing an "unconditional" power that accounts for the interplay
   between treatment effect and event accrual.
 
-### Bounds stability
+#### Bounds stability
 
 When using `targetEvents`, the efficacy and futility bounds do not change
 with the assumed HR. The bounds are determined entirely by the design
@@ -625,7 +668,7 @@ With `plannedCalendarTime`, different assumed HRs produce different expected
 event counts and therefore different information fractions, so the bounds
 are appropriately recomputed via `gsDesign::gsDesign()`.
 
-## Changing alpha
+### Changing alpha
 
 A common use case is evaluating power at a different one-sided alpha level —
 for example, when a graphical multiplicity procedure initially allocates
@@ -687,7 +730,7 @@ with the non-binding convention for a binding input design, retain the original
 a planning sensitivity analysis rather than a Maurer--Bretz multiplicity
 calculation.
 
-### Binding type planning sensitivity example (test.type = 3)
+#### Binding type planning sensitivity example (test.type = 3)
 
 ```{r alpha_binding}
 design3 <- gsSurv(
@@ -719,7 +762,7 @@ cat("test.type:", pwr3_a025$test.type, "(same as input design)\n")
 cat("alpha:    ", pwr3_a025$alpha, "(updated to new value)\n")
 ```
 
-## Example: event-based timing
+### Event-based timing
 
 Instead of calendar times, analyses can be triggered by target event counts:
 
@@ -734,7 +777,7 @@ cat("Events at each analysis:",
 cat("Power:", round(pwr_events$power * 100, 1), "%\n")
 ```
 
-## Example: slower enrollment at fixed analysis times
+### Slower enrollment at fixed analysis times
 
 Another common sensitivity analysis is slower-than-planned enrollment. When
 calendar analysis times are fixed, slower enrollment reduces the expected number
@@ -753,7 +796,7 @@ cat("Original power:", round(pwr_design$power * 100, 1), "%\n")
 cat("Slower-enrollment power:", round(pwr_slow_enroll$power * 100, 1), "%\n")
 ```
 
-## Example: calendar-based spending
+### Calendar-based spending
 
 By default, alpha and beta spending track statistical **information fractions**
 (`n.I / max(n.I)`). Setting `spending = "calendar"` instead ties spending to
@@ -820,7 +863,7 @@ pwr_cal_override <- gsSurvPower(
 identical(pwr_cal$upper$bound, pwr_cal_override$upper$bound)
 ```
 
-## Example: stratified event targets
+### Stratified event targets
 
 When a trial enrolls patients from multiple strata with different event
 rates, you may want to specify per-stratum event targets rather than a
@@ -866,7 +909,7 @@ The matrix format is also used in the biomarker example below,
 where `lambdaC` and `gamma` vary by stratum but `plannedCalendarTime`
 drives the timing.
 
-## Example: biomarker subgroup to stratified design
+### Biomarker subgroup to stratified design
 
 A common scenario is designing a trial for a biomarker-defined subgroup,
 then assessing what power the same enrollment provides for the overall
@@ -875,7 +918,7 @@ Note that the `gsDesign2` package could be used to design with different
 hazard ratios in the biomarker-positive and biomarker-negative populations
 simultaneously; here we illustrate the simpler approach using `gsSurvPower()`.
 
-### Step 1: Design for the biomarker-positive subgroup
+#### Step 1: Design for the biomarker-positive subgroup
 
 Suppose 60% of the population is biomarker-positive (prevalence = 0.6),
 the control median survival in this subgroup is 12 months,
@@ -899,7 +942,7 @@ summary(bm_design)
 gsBoundSummary(bm_design)
 ```
 
-### Step 2: Power for the overall (stratified) population
+#### Step 2: Power for the overall (stratified) population
 
 Now consider enrolling the entire population using the same enrollment
 duration and analysis calendar times. The biomarker-positive enrollment


### PR DESCRIPTION
## Summary
- Fix gsSurvPower() timing resolution for explicit minfup, targetN, maxExtension, and minN/minFollowUp workflows.
- Add regression coverage for issues #291, #293, #295, and #296.
- Document common gsSurvPower() timing pitfalls in the vignette and refresh NEWS/Rd docs.

Closes #291.
Closes #293.
Closes #295.
Closes #296.

## Checks
- testthat::test_file("tests/testthat/test-gsSurvPower.R")
- testthat::test_dir("tests/testthat")
- git diff --check
- test-coverage GitHub Action: success
- R-CMD-check.yaml GitHub Action: success across macOS release, Windows release, Ubuntu devel, Ubuntu release, and Ubuntu oldrel-1
- pkgdown devel deploy: success