### PR TITLE
Document harm-bound recalibration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,10 @@
 - Expanded the `gsSurvPower()` vignette with common timing pitfalls for
   explicit `minfup`, `targetN`, `maxExtension`, and `minN + minFollowUp`
   workflows (#291, #293, #295, #296).
+- Explained why skipping futility while retaining harm monitoring can
+  recalibrate earlier harm bounds, and documented recommended final-analysis
+  testing schedules using common event-driven survival-design assumptions for
+  all selective-bound examples (#306).
 
 ## Bug fixes
 

--- a/vignettes/SelectiveBoundTesting.Rmd
+++ b/vignettes/SelectiveBoundTesting.Rmd
@@ -136,7 +136,7 @@ The lower bound is active only at IA1.
 At IA2 and the final analysis, the futility bound shows as `NA`:
 
 ```{r}
-gsBoundSummary(x1, exclude = NULL) |> gt()
+gsBoundSummary(x1, exclude = NULL) |> gt::gt()
 ```
 
 The probabilities under the null and alternative are recomputed accounting for the inactive bounds.
@@ -172,7 +172,7 @@ xs <- do.call(gsSurv, c(survival_args, list(
   testLower = c(TRUE, TRUE, FALSE)
 )))
 gsBoundSummary(xs, exclude = NULL) |>
-  gt()
+  gt::gt()
 ```
 
 ## Example 3: Selective harm monitoring (test.type 7/8)
@@ -199,7 +199,7 @@ xh <- do.call(gsSurv, c(survival_args, list(
   testUpper = c(FALSE, TRUE, TRUE),
   testHarm = c(TRUE, TRUE, FALSE)
 )))
-gsBoundSummary(xh, exclude = NULL) |> gt()
+gsBoundSummary(xh, exclude = NULL) |> gt::gt()
 ```
 
 The harm bound is `NA` at the final analysis.
@@ -295,7 +295,7 @@ x5 <- do.call(gsSurv, c(survival_args, list(
   testUpper = c(FALSE, TRUE, TRUE),
   testLower = c(TRUE, FALSE, FALSE)
 )))
-gsBoundSummary(x5, exclude = NULL) |> gt()
+gsBoundSummary(x5, exclude = NULL) |> gt::gt()
 ```
 
 Note the `NA` values: efficacy is `NA` at IA1, and futility is `NA` at IA2 and the final analysis.

--- a/vignettes/SelectiveBoundTesting.Rmd
+++ b/vignettes/SelectiveBoundTesting.Rmd
@@ -31,6 +31,58 @@ library(gsDesign)
 library(knitr)
 ```
 
+All examples use a common time-to-event design. Enrollment lasts 16 months,
+with the relative enrollment rate increasing over the first 6 months and then
+remaining constant. The trial lasts 36 months. Control-group survival is 50%,
+40%, and 35% at 1, 2, and 3 years, respectively. We convert each interval's
+change in log survival to a piecewise exponential failure rate. Dropout is
+exponential at an annual rate of 0.02, and the hazard ratio under the alternative
+is 0.7. Analyses occur after 40%, 70%, and 100% of planned events.
+
+```{r}
+survival_time <- c(0, 12, 24, 36)
+control_survival <- c(1, .50, .40, .35)
+control_failure_rate <- -diff(log(control_survival)) / diff(survival_time)
+enrollment_duration <- c(rep(1, 5), 11)
+relative_enrollment_rate <- 1:6
+
+survival_args <- list(
+  k = 3,
+  alpha = .025,
+  beta = .1,
+  hr = .7,
+  timing = c(.4, .7),
+  sfu = sfLDOF,
+  sfl = sfHSD,
+  sflpar = 1,
+  lambdaC = control_failure_rate,
+  S = c(12, 24),
+  eta = .02 / 12,
+  gamma = relative_enrollment_rate,
+  R = enrollment_duration,
+  T = 36,
+  minfup = 20
+)
+```
+
+Equivalently, `gsDesign2::s2pwe(times = c(12, 24, 36), survival =
+c(.50, .40, .35))$rate` performs this survival-to-rate conversion.
+
+Every example below inherits `timing = c(.4, .7)` and these survival and
+enrollment assumptions from `survival_args`. The `gamma` input changes from 1
+to 6 over the first 6 months; its sixth value then applies through month 16.
+Because total duration and minimum follow-up are fixed, `gsSurv()` scales this
+relative enrollment-rate pattern to attain 90% power. Designs with different
+stopping rules can therefore show different fitted enrollment rates while
+retaining the same timing, survival, dropout, and enrollment-ramp assumptions.
+
+The Lan--DeMets O'Brien--Fleming spending function, `sfLDOF`, sets a high bar
+for early efficacy stopping that is generally acceptable to regulators. The
+first interim is delayed until 40% of planned events to balance useful early
+futility stopping against power loss. We initially use `sfHSD` with
+`sflpar = 1`; this is a relatively aggressive starting point that should be
+examined in sensitivity analyses before adopting the design.
+
 In many clinical trial designs, it is desirable to test only certain boundaries at specific interim analyses.
 For example:
 
@@ -57,151 +109,193 @@ If all three are `FALSE` at any analysis, an error is raised.
 
 ## Example 1: Futility testing only at the first interim
 
-A common scenario is to test for futility only at the first interim analysis, with efficacy testing at all analyses.
+A common scenario is to test for futility only at the first interim analysis.
 This is useful when the trial's data monitoring committee wants an early "go/no-go" decision, but not ongoing futility monitoring.
+For this non-binding `test.type = 4` design, efficacy testing also begins at
+IA2 rather than IA1.
 
 ```{r}
-# 3-analysis design with non-binding futility (test.type = 4)
-# Futility testing only at IA1
-x1 <- gsDesign(
-  k = 3,
+# Non-binding futility only at IA1; efficacy starts at IA2
+x1 <- do.call(gsSurv, c(survival_args, list(
   test.type = 4,
-  alpha = 0.025,
-  beta = 0.1,
-  sfu = sfHSD,
-  sfupar = -4,
-  sfl = sfHSD,
-  sflpar = -2,
+  testUpper = c(FALSE, TRUE, TRUE),
   testLower = c(TRUE, FALSE, FALSE)
-)
+)))
 ```
+
+The active futility bound depends on the beta spending function as well as the
+testing schedule. Here, `sfl = sfHSD` and `sflpar = 1` specify the spending
+pattern. Changing `sfl` or `sflpar` changes how beta is allocated and therefore
+changes the futility bound at IA1. With `sflpar = 1`, the futility rule is
+relatively aggressive: the IA1 bound is approximately HR 0.912, and the
+probability of stopping there under the design alternative, HR 0.7, is 5.2%.
+Its impact on power, planned events, and expected trial duration should be
+compared with less aggressive choices.
 
 The lower bound is active only at IA1.
 At IA2 and the final analysis, the futility bound shows as `NA`:
 
 ```{r}
-gsBoundSummary(x1)
+gsBoundSummary(x1, exclude = NULL) |> gt()
 ```
 
 The probabilities under the null and alternative are recomputed accounting for the inactive bounds.
-The underlying cumulative futility crossing probability does not increase after IA1 since no further futility testing occurs; the later inactive futility rows in `gsBoundSummary()` are displayed entirely as `NA`.
+The underlying cumulative futility crossing probability does not increase after IA1 since no further
+futility testing occurs; the later inactive futility rows in `gsBoundSummary()` are displayed entirely as `NA`.
 
-We can also see the bounds in the `print()` output:
+Using `exclude = NULL` includes conditional power at the current trend (`CP`),
+conditional power under the design alternative (`CP H1`), and predictive power
+(`PP`). Predictive power averages conditional power over the posterior formed
+from the interim result and the `prior` argument; it is sometimes referred to as
+average conditional power. By default,
+`gsBoundSummary()` uses a normal prior centered halfway between the null and
+alternative, with standard deviation `10 / sqrt(x$n.fix)`. Its variance is
+equivalent to observing 1% of the fixed-design information, so it is intended
+to be relatively weak.
+This means that the posterior used to determine predictive power is dominated
+by the interim data and primarily reflects variability in the interim observed
+treatment effect.
 
-```{r}
-x1
-```
+## Example 2: Asymmetric lower testing
 
-### Plotting
-
-The standard plot shows the active bounds, with inactive bounds omitted:
-
-```{r, fig.cap="Power plot with futility only at IA1"}
-plot(x1, plottype = 1)
-```
-
-## Example 2: No efficacy testing at the first interim
-
-In some settings, particularly early-phase or adaptive designs, efficacy testing may be deferred until sufficient data have accrued.
-Here we skip the efficacy bound at the first interim:
-
-```{r}
-# 3-analysis design with binding futility (test.type = 3)
-# No efficacy testing at IA1
-x2 <- gsDesign(
-  k = 3,
-  test.type = 3,
-  alpha = 0.025,
-  beta = 0.1,
-  sfu = sfHSD,
-  sfupar = -4,
-  sfl = sfHSD,
-  sflpar = -2,
-  testUpper = c(FALSE, TRUE, TRUE)
-)
-```
+For `test.type = 6`, `astar` controls Type I error allocated to the lower
+bound.
+To be somewhat aggressive, we set `astar = 0.15`.
+As with the other non-binding designs considered here, we skip efficacy
+testing at IA1:
 
 ```{r}
-gsBoundSummary(x2)
+xs <- do.call(gsSurv, c(survival_args, list(
+  test.type = 6,
+  astar = .15,
+  testUpper = c(FALSE, TRUE, TRUE),
+  testLower = c(TRUE, TRUE, FALSE)
+)))
+gsBoundSummary(xs, exclude = NULL) |>
+  gt()
 ```
 
-At IA1, only the futility bound is active.
-The efficacy bound appears as `NA` for that analysis.
-
-## Example 3: Survival design with selective bounds via gsSurv
-
-The `testUpper`, `testLower`, and `testHarm` parameters pass through to `gsSurv()` and `gsSurvCalendar()`:
-
-```{r}
-# Survival design with futility only at IA1
-xs <- gsSurv(
-  k = 3,
-  test.type = 4,
-  alpha = 0.025,
-  beta = 0.1,
-  hr = 0.7,
-  timing = c(0.5, 0.75),
-  sfu = sfHSD,
-  sfupar = -4,
-  sfl = sfHSD,
-  sflpar = -2,
-  lambdaC = log(2) / 12,
-  eta = 0.01,
-  gamma = 10,
-  R = 12,
-  T = 36,
-  minfup = 24,
-  testLower = c(TRUE, FALSE, FALSE)
-)
-gsBoundSummary(xs)
-```
-
-## Example 4: Selective harm monitoring (test.type 7/8)
+## Example 3: Selective harm monitoring (test.type 7/8)
 
 For designs with a separate harm bound, the `testHarm` parameter controls which analyses include harm monitoring.
+This is the same concept as `testLower` for `test.type = 5` or `6`, in that the
+harm bound tests whether experimental treatment is worse than control.
+For `test.type = 7` or `8`, the futility bound instead examines differences
+from the hypothesized effect `hr`.
 This can be useful when harm monitoring is most critical during early enrollment, before longer-term safety data are available.
+Continuing with the common survival assumptions, we change the design type and
+add a harm spending function and testing schedule. We use the same
+Hwang--Shih--DeCani parameter, 1, for harm spending and skip efficacy testing
+at IA1:
+
 
 ```{r}
 # Harm bound design with harm monitoring only at IA1 and IA2
-xh <- gsDesign(
-  k = 3,
+xh <- do.call(gsSurv, c(survival_args, list(
   test.type = 8,
-  alpha = 0.025,
-  beta = 0.1,
-  astar = 0.05,
-  sfu = sfHSD,
-  sfupar = -4,
-  sfl = sfHSD,
-  sflpar = -2,
+  astar = .15,
   sfharm = sfHSD,
   sfharmparam = 1,
+  testUpper = c(FALSE, TRUE, TRUE),
   testHarm = c(TRUE, TRUE, FALSE)
-)
-gsBoundSummary(xh)
+)))
+gsBoundSummary(xh, exclude = NULL) |> gt()
 ```
 
 The harm bound is `NA` at the final analysis.
 
-## Example 5: Combining selective efficacy and futility
+### Why skipping final futility can change an earlier harm bound
+
+For `test.type = 7` and `8`, harm and futility are mutually exclusive
+lower-tail stopping outcomes. When both bounds are active, observations at or
+below the harm bound are classified as harm stops, while observations between
+the harm and futility bounds are classified as futility-only stops. If
+futility is inactive but harm remains active, harm becomes the only active
+lower stopping boundary at that analysis.
+
+This distinction applies even to `test.type = 8`. Non-binding means that
+futility and harm stopping are ignored when Type I error is protected; it does
+not mean that the reported harm and futility boundaries are derived
+independently. The boundaries are jointly calibrated to their spending targets
+and active testing schedules.
+
+The following three designs skip efficacy testing at IA1. They differ only in
+whether futility and harm are tested at the final analysis:
+
+```{r}
+common_harm_args <- c(survival_args, list(
+  test.type = 8,
+  astar = .15,
+  testUpper = c(FALSE, TRUE, TRUE),
+  sfharm = sfHSD,
+  sfharmparam = 1
+))
+
+x_all_lower <- do.call(gsSurv, c(
+  common_harm_args,
+  list(
+    testLower = c(TRUE, TRUE, TRUE),
+    testHarm = c(TRUE, TRUE, TRUE)
+  )
+))
+
+x_final_harm <- do.call(gsSurv, c(
+  common_harm_args,
+  list(
+    testLower = c(TRUE, TRUE, FALSE),
+    testHarm = c(TRUE, TRUE, TRUE)
+  )
+))
+
+x_matched_lower <- do.call(gsSurv, c(
+  common_harm_args,
+  list(
+    testLower = c(TRUE, TRUE, FALSE),
+    testHarm = c(TRUE, TRUE, FALSE)
+  )
+))
+
+harm_comparison <- data.frame(
+  Analysis = seq_len(x_all_lower$k),
+  `All lower bounds active` = x_all_lower$harm$bound,
+  `Final harm only` = x_final_harm$harm$bound,
+  `Both final lower bounds skipped` = x_matched_lower$harm$bound,
+  check.names = FALSE
+)
+kable(harm_comparison, digits = 3, caption = "Harm bounds by final-analysis testing schedule")
+```
+
+When final futility is skipped but final harm remains active, the lower-tail
+stopping partition changes. The joint calibration can therefore change an
+earlier harm bound even though `testHarm` itself was not changed. This is
+expected when harm monitoring is genuinely intended at the final analysis.
+
+If neither futility nor harm will be assessed at the final analysis, specify
+both schedules explicitly:
+
+```r
+testLower = c(TRUE, TRUE, FALSE)
+testHarm = c(TRUE, TRUE, FALSE)
+```
+
+Matching these schedules leaves the earlier harm bounds unchanged relative to
+the design with all lower bounds active. Conversely, retain
+`testHarm = c(TRUE, TRUE, TRUE)` when a final harm assessment is intended and
+interpret the recalibrated harm bounds as part of that testing strategy.
+
+## Example 4: Combining selective efficacy and futility
 
 Both `testUpper` and `testLower` can be specified simultaneously.
 For example, a design with futility-only at IA1 and efficacy-only at IA2:
 
 ```{r}
-# Futility only at IA1, efficacy only at IA2, both at Final
-x5 <- gsDesign(
-  k = 3,
+# Futility only at IA1; efficacy at IA2 and Final
+x5 <- do.call(gsSurv, c(survival_args, list(
   test.type = 4,
-  alpha = 0.025,
-  beta = 0.1,
-  sfu = sfHSD,
-  sfupar = -4,
-  sfl = sfHSD,
-  sflpar = -2,
   testUpper = c(FALSE, TRUE, TRUE),
   testLower = c(TRUE, FALSE, FALSE)
-)
-gsBoundSummary(x5)
+)))
+gsBoundSummary(x5, exclude = NULL) |> gt()
 ```
 
 Note the `NA` values: efficacy is `NA` at IA1, and futility is `NA` at IA2 and the final analysis.
@@ -220,15 +314,19 @@ The following rules are enforced:
 
 ```{r, error=TRUE}
 # This fails: testUpper must be TRUE at the final analysis
-try(gsDesign(k = 3, test.type = 3, testUpper = c(TRUE, TRUE, FALSE)))
+try(do.call(gsSurv, c(survival_args, list(
+  test.type = 3,
+  testUpper = c(TRUE, TRUE, FALSE)
+))))
 ```
 
 ```{r, error=TRUE}
 # This fails: no bound active at analysis 1
-try(gsDesign(k = 3, test.type = 4,
+try(do.call(gsSurv, c(survival_args, list(
+  test.type = 4,
   testUpper = c(FALSE, TRUE, TRUE),
   testLower = c(FALSE, TRUE, TRUE)
-))
+))))
 ```
 
 ## Accessing stored flags
@@ -257,32 +355,39 @@ The efficacy bounds at active analyses are then recomputed using the modified sp
 
 ### Non-binding futility (test.type 4 or 6)
 
-For non-binding designs, the efficacy bounds are computed under the assumption that the trial *may continue past the futility bound* (i.e., futility does not contribute to the upper alpha calculation).
+For non-binding designs, the efficacy bounds are computed under the assumption that the trial *may continue past the futility bound*
+(i.e., futility does not contribute to the upper alpha calculation).
 Since upper bounds are independent of lower bounds, removing futility has no effect on the upper (efficacy) bounds or the non-binding alpha:
 
 ```{r}
-# Baseline non-binding design
-x_nb <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1)
+# Baseline non-binding design; efficacy starts at IA2
+x_nb <- do.call(gsSurv, c(survival_args, list(
+  test.type = 4,
+  testUpper = c(FALSE, TRUE, TRUE)
+)))
 
 # Remove futility at IA2 and final
-x_nb_sel <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
+x_nb_sel <- do.call(gsSurv, c(survival_args, list(
+  test.type = 4,
+  testUpper = c(FALSE, TRUE, TRUE),
   testLower = c(TRUE, FALSE, FALSE))
+))
 
 # Non-binding alpha (computed ignoring lower bounds)
 nb_alpha_base <- sum(gsDesign:::gsprob(0, x_nb$n.I, rep(-20, 3), x_nb$upper$bound, r = x_nb$r)$probhi)
 nb_alpha_sel  <- sum(gsDesign:::gsprob(0, x_nb_sel$n.I, rep(-20, 3), x_nb_sel$upper$bound, r = x_nb_sel$r)$probhi)
 cat("Baseline non-binding alpha: ", nb_alpha_base, "\n")
-cat("Selective non-binding alpha:", nb_alpha_sel , "\n")
+cat("Selective non-binding alpha:", nb_alpha_sel, "\n")
 cat("Upper bounds identical:     ", all.equal(x_nb$upper$bound, x_nb_sel$upper$bound), "\n")
 ```
 
-When removing early efficacy bounds, the upper bounds at active analyses adjust to absorb the redistributed spending, still totalling exactly $\alpha = 0.025$:
+For the planned design, omitting efficacy at IA1 redistributes its alpha to the
+active analyses while still totalling exactly $\alpha = 0.025$:
 
 ```{r}
-# Remove efficacy at IA1
-x_nb_eff <- gsDesign(k = 3, test.type = 4, alpha = 0.025, beta = 0.1,
-  testUpper = c(FALSE, TRUE, TRUE))
-nb_alpha_eff <- sum(gsDesign:::gsprob(0, x_nb_eff$n.I, rep(-20, 3), x_nb_eff$upper$bound, r = x_nb_eff$r)$probhi)
+nb_alpha_eff <- sum(gsDesign:::gsprob(
+  0, x_nb$n.I, rep(-20, 3), x_nb$upper$bound, r = x_nb$r
+)$probhi)
 cat("Non-binding alpha (skip IA1 efficacy):", nb_alpha_eff, "\n")
 ```
 
@@ -295,18 +400,22 @@ This preserves cumulative Type I error at the nominal level while respecting the
 
 ```{r}
 # Baseline binding design
-x_b <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1)
+x_b <- do.call(gsSurv, c(survival_args, list(test.type = 3)))
 cat("Baseline alpha:", sum(x_b$upper$prob[, 1]), "\n")
 
 # Remove futility at IA2 and final
-x_b_sel <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
+x_b_sel <- do.call(gsSurv, c(survival_args, list(
+  test.type = 3,
   testLower = c(TRUE, FALSE, FALSE))
+))
 cat("Selective alpha:", sum(x_b_sel$upper$prob[, 1]), "\n")
 cat("Selective power:", sum(x_b_sel$upper$prob[, 2]), "\n")
 
 # Remove efficacy at IA1
-x_b_eff <- gsDesign(k = 3, test.type = 3, alpha = 0.025, beta = 0.1,
+x_b_eff <- do.call(gsSurv, c(survival_args, list(
+  test.type = 3,
   testUpper = c(FALSE, TRUE, TRUE))
+))
 cat("Skip IA1 efficacy alpha:", sum(x_b_eff$upper$prob[, 1]), "\n")
 cat("Skip IA1 efficacy power:", sum(x_b_eff$upper$prob[, 2]), "\n")
 ```


### PR DESCRIPTION
## Summary

- explain why skipping futility while retaining harm monitoring can recalibrate earlier harm bounds
- document matched `testLower` and `testHarm` schedules when neither lower bound is assessed at the final analysis
- use common event-driven survival assumptions across the selective-bound examples

Closes #306

## Validation

- `devtools::document()`
- rendered `vignettes/SelectiveBoundTesting.Rmd` successfully against the release branch code
- `git diff --check origin/GitHub/3.11.0-release...HEAD`