### PR TITLE
Align gsSurvPower timing with simtrial

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+- `gsSurvPower()` now aligns its expected analysis-cut grammar with
+  `simtrial::get_analysis_date()`: overall and per-stratum event and enrollment
+  requirements can be combined, `maxCalendarTime` provides an absolute cap,
+  and `spending = "min_planned_actual"` supports reference-design
+  planned-versus-actual spending. Existing unstratified `targetEvents`, `minN`,
+  and relative `maxExtension` behavior is retained (#303).
 - All `gsSurv` objects now include `N`, the cumulative total expected
   enrollment at each analysis. `nSurv` objects retain scalar `n` and also
   return identical scalar `N` as a non-breaking alias (#299).
@@ -47,6 +53,10 @@
 
 ## Bug fixes
 
+- A matrix supplied to `gsSurvPower(targetEvents = ...)` is now treated as a
+  deprecated alias for `targetEventsPerStratum` and its entries are enforced
+  as per-stratum requirements. Previously, the rows were reduced to overall
+  sums, which did not enforce the documented stratified cut (#303).
 - `gsSurvPower()` now respects an explicitly supplied `minfup` as a final
   analysis timing floor for event-driven designs, so the final analysis is not
   scheduled before the end of enrollment plus minimum follow-up (#291).

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,9 +37,10 @@
   non-binding futility plus harm monitoring for `test.type = 7` and `8`
   (#308).
 - Clarified the two intended uses of `gsSurvPower()`, expanded guidance for
-  scenario and combined timing-rule analyses, added survival workflow routing,
-  and documented that expected-value calculations do not replace simulation
-  of stochastic trial execution (#303).
+  scenario and combined timing-rule analyses, including mixed-`NA` rules by
+  analysis, added survival workflow routing, and documented that expected-value
+  calculations do not replace simulation of stochastic trial execution
+  (#303).
 - Clarified beta spending in `gsSurvPower()` scenario analyses, distinguishing
   design beta from achieved beta and defining `informationRates` as planned
   information-fraction caps used to derive effective spending time (#303).
@@ -53,6 +54,10 @@
 
 ## Bug fixes
 
+- `gsSurvPower()` now validates mixed-`NA` timing inputs consistently, rejects
+  missing testing indicators and spending times with informative messages,
+  and detects analyses without an active timing rule or follow-up values
+  without a corresponding enrollment requirement (#303).
 - A matrix supplied to `gsSurvPower(targetEvents = ...)` is now treated as a
   deprecated alias for `targetEventsPerStratum` and its entries are enforced
   as per-stratum requirements. Previously, the rows were reduced to overall

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+- `gsSurvPower()` results now have primary class `"gsSurvPower"` while
+  retaining inheritance from `"gsSurv"` and `"gsDesign"`. They also retain
+  evaluated, replayable arguments in `inputs`, enabling downstream packages to
+  identify and reproduce power calculations.
 - `gsSurvPower()` now aligns its expected analysis-cut grammar with
   `simtrial::get_analysis_date()`: overall and per-stratum event and enrollment
   requirements can be combined, `maxCalendarTime` provides an absolute cap,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 
 ## New features
 
-- `gsSurvPower()` results now have primary class `"gsSurvPower"` while
-  retaining inheritance from `"gsSurv"` and `"gsDesign"`. They also retain
+- `gsSurvPower()` results now have primary class "gsSurvPower" while
+  retaining inheritance from "gsSurv" and "gsDesign". They also retain
   evaluated, replayable arguments in `inputs`, enabling downstream packages to
-  identify and reproduce power calculations.
+  identify and reproduce power calculations (#313).
 - `gsSurvPower()` now aligns its expected analysis-cut grammar with
   `simtrial::get_analysis_date()`: overall and per-stratum event and enrollment
   requirements can be combined, `maxCalendarTime` provides an absolute cap,

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -65,10 +65,12 @@
 #' separate null-based calculation.
 #'
 #' \strong{Analysis timing:}
-#' Analysis times are determined by per-analysis criteria. Each timing parameter
-#' can be a scalar (recycled to all \code{k} analyses), a vector of length
-#' \code{k}, or \code{NA} at position \code{i} to indicate the criterion does
-#' not apply to analysis \code{i}.
+#' Analysis times are determined by per-analysis criteria. Except for the
+#' final-analysis-only scalar \code{minfup}, each timing-rule parameter can be
+#' a scalar (recycled to all \code{k} analyses), a vector of length \code{k},
+#' or \code{NA} at position \code{i} to indicate that the rule does not apply
+#' to analysis \code{i}. For the per-stratum matrix arguments, \code{NA}
+#' deactivates only that analysis-by-stratum requirement.
 #'
 #' The choice between \code{plannedCalendarTime} and overall
 #' \code{targetEvents} has an important consequence for sensitivity analyses:
@@ -207,21 +209,26 @@
 #'   bound spending function \code{sfharm}.
 #' @param testUpper Indicator of which analyses include an efficacy test.
 #'   \code{TRUE} (default) for all analyses. A logical vector of length
-#'   \code{k} may be specified.
+#'   \code{k} may be specified. Missing values are not allowed; use
+#'   \code{FALSE} to omit the test at an analysis.
 #' @param testLower Indicator of which analyses include a futility test.
 #'   \code{TRUE} (default) for all analyses. A logical vector of length
-#'   \code{k} may be specified.
+#'   \code{k} may be specified. Missing values are not allowed; use
+#'   \code{FALSE} to omit the test at an analysis.
 #' @param testHarm Indicator of which analyses include a harm bound.
 #'   \code{TRUE} (default) for all analyses. A logical vector of length
-#'   \code{k} may be specified. Only used for \code{test.type} 7 or 8.
+#'   \code{k} may be specified. Missing values are not allowed; use
+#'   \code{FALSE} to omit the test at an analysis. Only used for
+#'   \code{test.type} 7 or 8.
 #' @param r Integer grid parameter for numerical integration (default 18).
 #' @param usTime Upper spending time override; vector of length \code{k}
-#'   or \code{NULL} (default) to use information fractions. Ignored when
+#'   without missing values, or \code{NULL} (default) to use information
+#'   fractions. Ignored when
 #'   \code{spending = "calendar"}, because realized analysis times determine
 #'   the spending fractions.
 #' @param lsTime Lower spending time override; vector of length \code{k}
-#'   or \code{NULL} (default) to use information fractions. Ignored when
-#'   \code{spending = "calendar"}.
+#'   without missing values, or \code{NULL} (default) to use information
+#'   fractions. Ignored when \code{spending = "calendar"}.
 #' @param lambdaC Scalar, vector, or matrix of control event hazard rates.
 #'   Rows = time periods, columns = strata.
 #' @param hr Assumed hazard ratio (experimental/control) for power computation.
@@ -274,28 +281,32 @@
 #' @param maxExtension Maximum time extension beyond the floor time to wait
 #'   for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
 #'   floor timing criterion for the affected analysis, most commonly
-#'   \code{plannedCalendarTime}.
+#'   \code{plannedCalendarTime}. Use \code{NA} for analyses without a relative
+#'   extension cap.
 #' @param maxCalendarTime Absolute calendar-time cap for each analysis. Scalar
 #'   or vector of length \code{k}. When supplied with \code{maxExtension}, the
 #'   earlier cap applies. This corresponds to
-#'   \code{max_extension_for_target_event} in \pkg{simtrial}.
+#'   \code{max_extension_for_target_event} in \pkg{simtrial}. Use \code{NA}
+#'   for analyses without an absolute calendar-time cap.
 #' @param minTimeFromPreviousAnalysis Minimum elapsed time since the previous
 #'   analysis. Scalar or vector of length \code{k}. Ignored for the first
-#'   analysis.
+#'   analysis. Use \code{NA} for later analyses without a spacing requirement.
 #' @param minN Minimum total sample size enrolled before analysis can proceed.
 #'   Scalar or vector of length \code{k}. Can be used with
 #'   \code{minFollowUp} as the primary timing criterion; the resulting
-#'   analysis times and expected event totals must be strictly increasing.
+#'   analysis times and expected event totals must be strictly increasing. Use
+#'   \code{NA} for analyses without an overall enrollment requirement.
 #' @param minNPerStratum Per-stratum minimum enrollment requirements. Numeric
 #'   matrix with \code{k} rows and one column per stratum; \code{NA} omits a
 #'   stratum requirement at an analysis.
 #' @param minFollowUp Minimum follow-up time after all active \code{minN} and
 #'   \code{minNPerStratum} requirements are reached. Scalar or vector of
-#'   length \code{k}. Must be >= 0 and requires at least one enrollment
-#'   requirement.
+#'   length \code{k}. Must be >= 0. Use \code{NA} for no additional follow-up
+#'   at an analysis. Each non-missing value requires an active \code{minN} or
+#'   \code{minNPerStratum} requirement at the same analysis.
 #' @param informationRates Numeric vector of length \code{k} specifying
-#'   planned information-fraction caps. At each analysis, the effective upper
-#'   and lower spending time is
+#'   planned information-fraction caps, with no missing values. At each
+#'   analysis, the effective upper and lower spending time is
 #'   \code{pmin(informationRates, actual_timing)}, where
 #'   \code{actual_timing} is expected events divided by maximum expected
 #'   events. This prevents spending ahead of either the planned information
@@ -570,6 +581,10 @@ gsSurvPower <- function(
   )
   k <- timing_inputs$k
 
+  .gsSurvPower_validate_test_flag(testUpper, "testUpper", k)
+  .gsSurvPower_validate_test_flag(testLower, "testLower", k)
+  .gsSurvPower_validate_test_flag(testHarm, "testHarm", k)
+
   if (spending == "min_planned_actual" && is.null(informationRates)) {
     if (is.null(x)) {
       stop("spending = 'min_planned_actual' requires a reference design x")
@@ -581,12 +596,12 @@ gsSurvPower <- function(
 
   # Validate informationRates
   if (!is.null(informationRates)) {
-    if (length(informationRates) != k) {
-      stop("informationRates must have length k (", k, ")")
-    }
-    if (any(informationRates <= 0 | informationRates > 1)) {
-      stop("informationRates values must be in (0, 1]")
-    }
+    .gsSurvPower_validate_spending_time(
+      informationRates, "informationRates", k
+    )
+  } else if (spending == "information") {
+    .gsSurvPower_validate_spending_time(usTime, "usTime", k)
+    .gsSurvPower_validate_spending_time(lsTime, "lsTime", k)
   }
 
   expected_counts_at_time <- .gsSurvPower_build_expected_counts_at_time(
@@ -716,6 +731,38 @@ gsSurvPower <- function(
   stop(paste(name, "must have length 1 or", analysis_count))
 }
 
+.gsSurvPower_validate_timing_vector <- function(value, name) {
+  active <- !is.na(value)
+  if ((any(active) && !is.numeric(value)) ||
+      any(!is.finite(value[active])) || any(value[active] < 0)) {
+    stop(name, " values must be non-negative finite numbers or NA")
+  }
+  as.numeric(value)
+}
+
+.gsSurvPower_validate_test_flag <- function(value, name, analysis_count) {
+  if (!is.logical(value) || !(length(value) %in% c(1, analysis_count)) ||
+      anyNA(value)) {
+    stop(
+      name, " must be TRUE or FALSE, or a logical vector of length ",
+      analysis_count, " without NA"
+    )
+  }
+  invisible(value)
+}
+
+.gsSurvPower_validate_spending_time <- function(value, name, analysis_count) {
+  if (is.null(value)) return(invisible(value))
+  if (!is.numeric(value) || length(value) != analysis_count || anyNA(value) ||
+      any(!is.finite(value)) || any(value <= 0 | value > 1)) {
+    stop(
+      name, " must be a numeric vector of length ", analysis_count,
+      " with values in (0, 1] and without NA"
+    )
+  }
+  invisible(value)
+}
+
 .gsSurvPower_normalize_stratum_timing_matrix <- function(
     value,
     name,
@@ -724,9 +771,11 @@ gsSurvPower <- function(
   if (is.null(value)) {
     return(matrix(NA_real_, nrow = analysis_count, ncol = n_strata))
   }
-  if (!is.matrix(value) || !is.numeric(value)) {
+  all_missing_logical <- is.logical(value) && all(is.na(value))
+  if (!is.matrix(value) || (!is.numeric(value) && !all_missing_logical)) {
     stop(name, " must be a numeric matrix")
   }
+  if (all_missing_logical) storage.mode(value) <- "double"
   if (nrow(value) != analysis_count || ncol(value) != n_strata) {
     stop(
       name, " must have k rows (", analysis_count,
@@ -814,10 +863,6 @@ gsSurvPower <- function(
     target_event_input <- NULL
   }
 
-  if (!is.null(minFollowUp) && is.null(minN) && is.null(minNPerStratum)) {
-    stop("minFollowUp requires minN or minNPerStratum")
-  }
-
   if (is.null(planned_time_input) && is.null(target_event_input) &&
       is.null(targetEventsPerStratum) && is.null(minN) &&
       is.null(minNPerStratum)) {
@@ -850,29 +895,42 @@ gsSurvPower <- function(
     stop("Could not determine number of analyses (k)")
   }
 
-  planned_time <- .gsSurvPower_recycle_to_k(
-    planned_time_input, "plannedCalendarTime", analysis_count
+  planned_time <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(
+      planned_time_input, "plannedCalendarTime", analysis_count
+    ),
+    "plannedCalendarTime"
   )
-  max_extension <- .gsSurvPower_recycle_to_k(
-    maxExtension, "maxExtension", analysis_count
+  max_extension <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(
+      maxExtension, "maxExtension", analysis_count
+    ),
+    "maxExtension"
   )
-  max_calendar_time <- .gsSurvPower_recycle_to_k(
-    maxCalendarTime, "maxCalendarTime", analysis_count
+  max_calendar_time <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(
+      maxCalendarTime, "maxCalendarTime", analysis_count
+    ),
+    "maxCalendarTime"
   )
-  if (!is.numeric(max_calendar_time) ||
-      any(!is.finite(max_calendar_time[!is.na(max_calendar_time)])) ||
-      any(max_calendar_time[!is.na(max_calendar_time)] < 0)) {
-    stop("maxCalendarTime values must be non-negative finite numbers or NA")
-  }
-  min_time_from_previous <- .gsSurvPower_recycle_to_k(
-    minTimeFromPreviousAnalysis,
-    "minTimeFromPreviousAnalysis",
-    analysis_count
+  min_time_from_previous <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(
+      minTimeFromPreviousAnalysis,
+      "minTimeFromPreviousAnalysis",
+      analysis_count
+    ),
+    "minTimeFromPreviousAnalysis"
   )
-  min_follow_up <- .gsSurvPower_recycle_to_k(
-    minFollowUp, "minFollowUp", analysis_count
+  min_follow_up <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(
+      minFollowUp, "minFollowUp", analysis_count
+    ),
+    "minFollowUp"
   )
-  min_enrolled <- .gsSurvPower_recycle_to_k(minN, "minN", analysis_count)
+  min_enrolled <- .gsSurvPower_validate_timing_vector(
+    .gsSurvPower_recycle_to_k(minN, "minN", analysis_count),
+    "minN"
+  )
   target_events_per_stratum <- .gsSurvPower_normalize_stratum_timing_matrix(
     targetEventsPerStratum,
     "targetEventsPerStratum",
@@ -898,22 +956,45 @@ gsSurvPower <- function(
   if (is.null(target_event_input)) {
     total_event_targets <- rep(NA_real_, analysis_count)
   } else {
-    total_event_targets <- .gsSurvPower_recycle_to_k(
-      target_event_input, "targetEvents", analysis_count
+    total_event_targets <- .gsSurvPower_validate_timing_vector(
+      .gsSurvPower_recycle_to_k(
+        target_event_input, "targetEvents", analysis_count
+      ),
+      "targetEvents"
     )
   }
 
   for (analysis_index in seq_len(analysis_count)) {
+    has_enrollment_criterion <- !is.na(min_enrolled[analysis_index]) ||
+      any(!is.na(min_enrolled_per_stratum[analysis_index, ]))
+    if (!is.na(min_follow_up[analysis_index]) &&
+        !has_enrollment_criterion) {
+      stop(
+        "minFollowUp at analysis ", analysis_index,
+        " requires minN or minNPerStratum at the same analysis"
+      )
+    }
+
     has_floor_criterion <- !is.na(planned_time[analysis_index]) ||
       (analysis_index > 1 && !is.na(min_time_from_previous[analysis_index])) ||
-      !is.na(min_enrolled[analysis_index]) ||
-      any(!is.na(min_enrolled_per_stratum[analysis_index, ])) ||
+      has_enrollment_criterion ||
       (analysis_index == analysis_count && !is.na(final_min_follow_up))
     if (!is.na(max_extension[analysis_index]) && !has_floor_criterion) {
       stop(
         "maxExtension requires a floor timing criterion such as ",
         "plannedCalendarTime, minTimeFromPreviousAnalysis, minN, ",
         "minNPerStratum, or minfup"
+      )
+    }
+
+    has_event_criterion <- !is.na(total_event_targets[analysis_index]) ||
+      any(!is.na(target_events_per_stratum[analysis_index, ]))
+    if (!has_floor_criterion && !has_event_criterion) {
+      stop(
+        "Analysis ", analysis_index,
+        " has no active timing criterion; supply plannedCalendarTime, ",
+        "targetEvents, targetEventsPerStratum, minTimeFromPreviousAnalysis, ",
+        "minN, minNPerStratum, or final-analysis minfup"
       )
     }
   }

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -70,17 +70,17 @@
 #' \code{k}, or \code{NA} at position \code{i} to indicate the criterion does
 #' not apply to analysis \code{i}.
 #'
-#' The choice between \code{plannedCalendarTime} and \code{targetEvents} has an
-#' important consequence for sensitivity analyses:
+#' The choice between \code{plannedCalendarTime} and overall
+#' \code{targetEvents} has an important consequence for sensitivity analyses:
 #' \itemize{
 #'   \item Used alone, \code{plannedCalendarTime} fixes calendar times;
 #'     when combined with other criteria, it supplies a timing floor. Expected
 #'     events are recomputed under the assumed HR. A worse HR produces more
 #'     events at the same calendar time (the experimental arm fails faster).
 #'     This gives an "unconditional" power.
-#'   \item \code{targetEvents} fixes event counts; calendar times adjust. Since
-#'     events are held constant, information fractions do not change with HR, and
-#'     results match the \code{gsDesign} power plot
+#'   \item \code{targetEvents} fixes overall event counts; calendar times
+#'     adjust. Since events are held constant, information fractions do not
+#'     change with HR, and results match the \code{gsDesign} power plot
 #'     (\code{plot(x, plottype = 2)}) to numerical precision.
 #' }
 #'
@@ -90,17 +90,21 @@
 #'   \item Compute floor times from applicable criteria:
 #'     \code{plannedCalendarTime[i]},
 #'     \code{T[i-1] + minTimeFromPreviousAnalysis[i]}, and
-#'     time when \code{minN[i]} enrolled + \code{minFollowUp[i]}. When
-#'     \code{minfup} is explicitly supplied, the final analysis also has a
-#'     floor at the end of enrollment plus \code{minfup}.
+#'     time when \code{minN[i]} enrolled + \code{minFollowUp[i]}, and the
+#'     corresponding time for every active column of
+#'     \code{minNPerStratum[i, ]}. When \code{minfup} is explicitly supplied,
+#'     the final analysis also has a floor at the end of enrollment plus
+#'     \code{minfup}.
 #'   \item \code{floor_time = max(all applicable floor times)}.
-#'   \item If \code{targetEvents[i]} is specified: find \code{t_events} when
-#'     expected events reach target. If \code{t_events <= floor_time}, analysis
-#'     at \code{floor_time}. If \code{t_events > floor_time} and
+#'   \item Find the expected time for the overall \code{targetEvents[i]} and
+#'     for every active column of \code{targetEventsPerStratum[i, ]}. Their
+#'     maximum is \code{t_events}, so all active requirements use AND logic.
+#'     If \code{t_events <= floor_time}, analysis at \code{floor_time}. If
+#'     \code{t_events > floor_time} and
 #'     \code{maxExtension[i]} is set, analysis at
 #'     \code{min(t_events, floor_time + maxExtension[i])}. Otherwise, analysis
 #'     at \code{t_events}.
-#'   \item If no \code{targetEvents}: analysis at \code{floor_time}.
+#'   \item If no event requirement is active: analysis at \code{floor_time}.
 #'   \item \code{maxExtension} defines a hard deadline: the analysis time
 #'     is never pushed
 #'     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
@@ -109,7 +113,13 @@
 #'     or \code{minN + minFollowUp} would require a later time. Each analysis
 #'     using \code{maxExtension} must have a floor timing criterion such as
 #'     \code{plannedCalendarTime}, \code{minTimeFromPreviousAnalysis},
-#'     \code{minN}, or explicit final-analysis \code{minfup}.
+#'     \code{minN}, \code{minNPerStratum}, or explicit final-analysis
+#'     \code{minfup}.
+#'   \item Finally, \code{maxCalendarTime[i]} applies an absolute calendar-time
+#'     cap. If both cap types are supplied, the earlier cap applies. This
+#'     mirrors the realized-cut grammar in \pkg{simtrial}, where the argument
+#'     named \code{max_extension_for_target_event} is applied as an absolute
+#'     analysis date.
 #' }
 #'
 #' \strong{Normalization and consistency:}
@@ -123,12 +133,16 @@
 #' events as \code{n.I}. At the design HR, this reproduces the design power
 #' exactly.
 #'
-#' \strong{Stratified targetEvents:}
-#' \code{targetEvents} accepts a scalar (recycled), a vector of length \code{k}
-#' (overall targets per analysis), or a matrix with \code{k} rows and
-#' \code{nstrata} columns (per-stratum targets). A vector of length \code{k}
-#' is always interpreted as overall targets; use a matrix for per-stratum
-#' specification.
+#' \strong{Stratified timing requirements:}
+#' \code{targetEvents} accepts a scalar (recycled) or a vector of length
+#' \code{k} for overall event targets. Use \code{targetEventsPerStratum} for a
+#' \code{k}-by-\code{nstrata} matrix of per-stratum event requirements and
+#' \code{minNPerStratum} for per-stratum enrollment requirements. Overall and
+#' per-stratum requirements may be combined and all active requirements must
+#' be met unless a cap intervenes. \code{NA} omits a requirement. A matrix
+#' passed through \code{targetEvents} is a deprecated alias for
+#' \code{targetEventsPerStratum}; unlike the earlier row-sum interpretation,
+#' its entries are enforced by stratum.
 #'
 #' \strong{Bound recalculation when parameters change:}
 #' When \code{x} is provided, the handling of bounds depends on which
@@ -238,24 +252,33 @@
 #'   \code{"LachinFoulkes"} (default), \code{"Schoenfeld"},
 #'   \code{"Freedman"}, or \code{"BernsteinLagakos"}. Affects \code{n.fix}
 #'   computation when \code{x} is not provided.
-#' @param spending One of \code{"information"} (default) or \code{"calendar"}.
-#'   Controls whether alpha/beta spending tracks information fractions or
-#'   calendar time fractions (\code{T / max(T)}). With calendar spending,
-#'   \code{usTime} and \code{lsTime} are derived from the realized analysis
-#'   times and any user-supplied overrides are ignored.
+#' @param spending One of \code{"information"} (default), \code{"calendar"},
+#'   or \code{"min_planned_actual"}. Information spending tracks expected
+#'   event fractions within the scenario. Calendar spending uses
+#'   \code{T / max(T)}. With a reference design \code{x},
+#'   \code{"min_planned_actual"} uses
+#'   \code{pmin(x$n.I, actual events) / x$n.I[k]}, matching the planned-versus-
+#'   actual spending convention in \pkg{simtrial}. The latter two modes derive
+#'   \code{usTime} and \code{lsTime} and ignore user-supplied overrides.
 #' @param plannedCalendarTime Calendar times for analyses (time 0 = start of
 #'   randomization). Scalar (recycled) or vector of length \code{k}. Use
 #'   \code{NA} for analyses not determined by calendar time.
-#' @param targetEvents Target number of events at each analysis. Scalar
-#'   (recycled), vector of length \code{k} (overall targets), or matrix
-#'   with \code{k} rows and \code{nstrata} columns (per-stratum targets).
-#'   Use \code{NA} for analyses not determined by events. When a matrix is
-#'   supplied, row sums give the total event target used to solve each
-#'   analysis time.
+#' @param targetEvents Overall target number of events at each analysis.
+#'   Scalar (recycled) or vector of length \code{k}. Use \code{NA} for
+#'   analyses without an overall event requirement. A matrix is accepted as a
+#'   deprecated alias for \code{targetEventsPerStratum}.
+#' @param targetEventsPerStratum Per-stratum event requirements. Numeric matrix
+#'   with \code{k} rows and one column per stratum; \code{NA} omits a stratum
+#'   requirement at an analysis. The analysis waits until every active stratum
+#'   requirement and any overall \code{targetEvents} requirement are met.
 #' @param maxExtension Maximum time extension beyond the floor time to wait
 #'   for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
 #'   floor timing criterion for the affected analysis, most commonly
 #'   \code{plannedCalendarTime}.
+#' @param maxCalendarTime Absolute calendar-time cap for each analysis. Scalar
+#'   or vector of length \code{k}. When supplied with \code{maxExtension}, the
+#'   earlier cap applies. This corresponds to
+#'   \code{max_extension_for_target_event} in \pkg{simtrial}.
 #' @param minTimeFromPreviousAnalysis Minimum elapsed time since the previous
 #'   analysis. Scalar or vector of length \code{k}. Ignored for the first
 #'   analysis.
@@ -263,9 +286,13 @@
 #'   Scalar or vector of length \code{k}. Can be used with
 #'   \code{minFollowUp} as the primary timing criterion; the resulting
 #'   analysis times and expected event totals must be strictly increasing.
-#' @param minFollowUp Minimum follow-up time after \code{minN} is reached.
-#'   Scalar or vector of length \code{k}. Must be >= 0 and requires
-#'   \code{minN}.
+#' @param minNPerStratum Per-stratum minimum enrollment requirements. Numeric
+#'   matrix with \code{k} rows and one column per stratum; \code{NA} omits a
+#'   stratum requirement at an analysis.
+#' @param minFollowUp Minimum follow-up time after all active \code{minN} and
+#'   \code{minNPerStratum} requirements are reached. Scalar or vector of
+#'   length \code{k}. Must be >= 0 and requires at least one enrollment
+#'   requirement.
 #' @param informationRates Numeric vector of length \code{k} specifying
 #'   planned information-fraction caps. At each analysis, the effective upper
 #'   and lower spending time is
@@ -281,8 +308,9 @@
 #' @param fullSpendingAtFinal Logical. When \code{TRUE}, the final element of
 #'   the effective upper and lower spending-time vectors is forced to 1 after
 #'   applying
-#'   \code{informationRates}, calendar spending, or user-supplied
-#'   \code{usTime}/\code{lsTime}. This ensures full upper- and lower-bound
+#'   \code{informationRates}, calendar or planned-versus-actual spending, or
+#'   user-supplied \code{usTime}/\code{lsTime}. This ensures full upper- and
+#'   lower-bound
 #'   spending whenever a selected spending-time vector would otherwise end
 #'   below 1.
 #'   Default \code{FALSE}.
@@ -350,6 +378,18 @@
 #' )
 #' sum(rowSums(pwr_target_n$gamma) * pwr_target_n$R)
 #'
+#' # Require event counts within each stratum
+#' pwr_stratified <- gsSurvPower(
+#'   k = 2, test.type = 1, alpha = 0.025, sided = 1,
+#'   lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+#'   hr = 0.7, eta = 0.01,
+#'   gamma = matrix(c(5, 5), ncol = 2), R = 12, ratio = 1,
+#'   targetEventsPerStratum = matrix(
+#'     c(20, 10, 40, 20), nrow = 2, byrow = TRUE
+#'   )
+#' )
+#' pwr_stratified$eDC + pwr_stratified$eDE
+#'
 #' @seealso \code{vignette("gsSurvPower", package = "gsDesign")} for
 #'   worked examples including calendar spending, stratified event targets,
 #'   and biomarker subgroup analyses.
@@ -375,7 +415,7 @@ gsSurvPower <- function(
     gamma = NULL, R = NULL, targetN = NULL, S = NULL,
     ratio = NULL, minfup = NULL,
     method = NULL,
-    spending = c("information", "calendar"),
+    spending = c("information", "calendar", "min_planned_actual"),
     plannedCalendarTime = NULL,
     targetEvents = NULL,
     maxExtension = NULL,
@@ -384,7 +424,10 @@ gsSurvPower <- function(
     minFollowUp = NULL,
     informationRates = NULL,
     fullSpendingAtFinal = FALSE,
-    tol = .Machine$double.eps^0.25) {
+    tol = .Machine$double.eps^0.25,
+    targetEventsPerStratum = NULL,
+    maxCalendarTime = NULL,
+    minNPerStratum = NULL) {
   spending <- match.arg(spending)
   call_object <- match.call()
   call_args <- as.list(call_object)
@@ -502,18 +545,39 @@ gsSurvPower <- function(
     R <- R * targetN / current_N
   }
 
+  normalized_rates <- .gsSurvPower_normalize_rate_inputs(
+    control_hazard = lambdaC,
+    control_dropout = eta,
+    experimental_dropout = etaE,
+    enrollment_rate = gamma,
+    allocation_ratio = ratio
+  )
+
   timing_inputs <- .gsSurvPower_resolve_timing_inputs(
     default_k = k,
     plannedCalendarTime = plannedCalendarTime,
     targetEvents = targetEvents,
+    targetEventsPerStratum = targetEventsPerStratum,
     maxExtension = maxExtension,
+    maxCalendarTime = maxCalendarTime,
     minTimeFromPreviousAnalysis = minTimeFromPreviousAnalysis,
     minFollowUp = minFollowUp,
     minN = minN,
+    minNPerStratum = minNPerStratum,
     finalMinFollowUp = if (minfup_provided_by_user) minfup else NULL,
+    nStrata = ncol(normalized_rates$lambdaC),
     x = x
   )
   k <- timing_inputs$k
+
+  if (spending == "min_planned_actual" && is.null(informationRates)) {
+    if (is.null(x)) {
+      stop("spending = 'min_planned_actual' requires a reference design x")
+    }
+    if (length(x$n.I) != k || any(!is.finite(x$n.I)) || any(x$n.I <= 0)) {
+      stop("x must provide k positive finite planned event totals in n.I")
+    }
+  }
 
   # Validate informationRates
   if (!is.null(informationRates)) {
@@ -525,13 +589,6 @@ gsSurvPower <- function(
     }
   }
 
-  normalized_rates <- .gsSurvPower_normalize_rate_inputs(
-    control_hazard = lambdaC,
-    control_dropout = eta,
-    experimental_dropout = etaE,
-    enrollment_rate = gamma,
-    allocation_ratio = ratio
-  )
   expected_counts_at_time <- .gsSurvPower_build_expected_counts_at_time(
     control_hazard = normalized_rates$lambdaC,
     control_dropout = normalized_rates$etaC,
@@ -593,6 +650,7 @@ gsSurvPower <- function(
   spending_times <- .gsSurvPower_resolve_spending_times(
     analysis_time = analysis_schedule$analysis_time,
     actual_timing = analysis_schedule$timing,
+    actual_events = analysis_schedule$total_events,
     settings = settings
   )
 
@@ -658,6 +716,30 @@ gsSurvPower <- function(
   stop(paste(name, "must have length 1 or", analysis_count))
 }
 
+.gsSurvPower_normalize_stratum_timing_matrix <- function(
+    value,
+    name,
+    analysis_count,
+    n_strata) {
+  if (is.null(value)) {
+    return(matrix(NA_real_, nrow = analysis_count, ncol = n_strata))
+  }
+  if (!is.matrix(value) || !is.numeric(value)) {
+    stop(name, " must be a numeric matrix")
+  }
+  if (nrow(value) != analysis_count || ncol(value) != n_strata) {
+    stop(
+      name, " must have k rows (", analysis_count,
+      ") and one column per stratum (", n_strata, ")"
+    )
+  }
+  active <- !is.na(value)
+  if (any(!is.finite(value[active])) || any(value[active] < 0)) {
+    stop(name, " values must be non-negative finite numbers or NA")
+  }
+  value
+}
+
 .gsSurvPower_normalize_rate_inputs <- function(
     control_hazard,
     control_dropout,
@@ -702,25 +784,51 @@ gsSurvPower <- function(
     default_k,
     plannedCalendarTime,
     targetEvents,
+    targetEventsPerStratum,
     maxExtension,
+    maxCalendarTime,
     minTimeFromPreviousAnalysis,
     minFollowUp,
     minN,
+    minNPerStratum,
     finalMinFollowUp,
+    nStrata,
     x) {
   planned_time_input <- plannedCalendarTime
   target_event_input <- targetEvents
 
-  if (!is.null(minFollowUp) && is.null(minN)) {
-    stop("minFollowUp requires minN")
+  if (is.matrix(target_event_input)) {
+    if (!is.null(targetEventsPerStratum)) {
+      stop(
+        "Supply per-stratum event requirements through only one of ",
+        "targetEvents or targetEventsPerStratum"
+      )
+    }
+    if (nStrata > 1) {
+      warning(
+        "A matrix targetEvents is deprecated; use targetEventsPerStratum. ",
+        "Matrix values are now enforced as per-stratum requirements."
+      )
+    }
+    targetEventsPerStratum <- target_event_input
+    target_event_input <- NULL
+  }
+
+  if (!is.null(minFollowUp) && is.null(minN) && is.null(minNPerStratum)) {
+    stop("minFollowUp requires minN or minNPerStratum")
   }
 
   if (is.null(planned_time_input) && is.null(target_event_input) &&
-      is.null(minN)) {
+      is.null(targetEventsPerStratum) && is.null(minN) &&
+      is.null(minNPerStratum)) {
     if (!is.null(x)) {
       planned_time_input <- x$T
     } else {
-      stop("At least one of plannedCalendarTime, targetEvents, or minN must be specified")
+      stop(
+        "At least one timing criterion must be specified: ",
+        "plannedCalendarTime, targetEvents, targetEventsPerStratum, ",
+        "minN, or minNPerStratum"
+      )
     }
   }
 
@@ -728,12 +836,14 @@ gsSurvPower <- function(
   if (is.null(analysis_count)) {
     if (!is.null(planned_time_input)) {
       analysis_count <- length(planned_time_input)
-    } else if (is.matrix(target_event_input)) {
-      analysis_count <- nrow(target_event_input)
     } else if (!is.null(target_event_input)) {
       analysis_count <- length(target_event_input)
+    } else if (!is.null(targetEventsPerStratum)) {
+      analysis_count <- nrow(targetEventsPerStratum)
     } else if (!is.null(minN)) {
       analysis_count <- length(minN)
+    } else if (!is.null(minNPerStratum)) {
+      analysis_count <- nrow(minNPerStratum)
     }
   }
   if (is.null(analysis_count) || analysis_count < 1) {
@@ -746,6 +856,14 @@ gsSurvPower <- function(
   max_extension <- .gsSurvPower_recycle_to_k(
     maxExtension, "maxExtension", analysis_count
   )
+  max_calendar_time <- .gsSurvPower_recycle_to_k(
+    maxCalendarTime, "maxCalendarTime", analysis_count
+  )
+  if (!is.numeric(max_calendar_time) ||
+      any(!is.finite(max_calendar_time[!is.na(max_calendar_time)])) ||
+      any(max_calendar_time[!is.na(max_calendar_time)] < 0)) {
+    stop("maxCalendarTime values must be non-negative finite numbers or NA")
+  }
   min_time_from_previous <- .gsSurvPower_recycle_to_k(
     minTimeFromPreviousAnalysis,
     "minTimeFromPreviousAnalysis",
@@ -755,6 +873,18 @@ gsSurvPower <- function(
     minFollowUp, "minFollowUp", analysis_count
   )
   min_enrolled <- .gsSurvPower_recycle_to_k(minN, "minN", analysis_count)
+  target_events_per_stratum <- .gsSurvPower_normalize_stratum_timing_matrix(
+    targetEventsPerStratum,
+    "targetEventsPerStratum",
+    analysis_count,
+    nStrata
+  )
+  min_enrolled_per_stratum <- .gsSurvPower_normalize_stratum_timing_matrix(
+    minNPerStratum,
+    "minNPerStratum",
+    analysis_count,
+    nStrata
+  )
   final_min_follow_up <- if (is.null(finalMinFollowUp)) {
     NA_real_
   } else {
@@ -767,11 +897,6 @@ gsSurvPower <- function(
 
   if (is.null(target_event_input)) {
     total_event_targets <- rep(NA_real_, analysis_count)
-  } else if (is.matrix(target_event_input)) {
-    if (nrow(target_event_input) != analysis_count) {
-      stop("targetEvents matrix must have k rows")
-    }
-    total_event_targets <- rowSums(target_event_input)
   } else {
     total_event_targets <- .gsSurvPower_recycle_to_k(
       target_event_input, "targetEvents", analysis_count
@@ -782,11 +907,13 @@ gsSurvPower <- function(
     has_floor_criterion <- !is.na(planned_time[analysis_index]) ||
       (analysis_index > 1 && !is.na(min_time_from_previous[analysis_index])) ||
       !is.na(min_enrolled[analysis_index]) ||
+      any(!is.na(min_enrolled_per_stratum[analysis_index, ])) ||
       (analysis_index == analysis_count && !is.na(final_min_follow_up))
     if (!is.na(max_extension[analysis_index]) && !has_floor_criterion) {
       stop(
         "maxExtension requires a floor timing criterion such as ",
-        "plannedCalendarTime, minTimeFromPreviousAnalysis, minN, or minfup"
+        "plannedCalendarTime, minTimeFromPreviousAnalysis, minN, ",
+        "minNPerStratum, or minfup"
       )
     }
   }
@@ -795,11 +922,14 @@ gsSurvPower <- function(
     k = analysis_count,
     planned_time = planned_time,
     max_extension = max_extension,
+    max_calendar_time = max_calendar_time,
     min_time_from_previous = min_time_from_previous,
     min_follow_up = min_follow_up,
     min_enrolled = min_enrolled,
+    min_enrolled_per_stratum = min_enrolled_per_stratum,
     final_min_follow_up = final_min_follow_up,
-    total_event_targets = total_event_targets
+    total_event_targets = total_event_targets,
+    target_events_per_stratum = target_events_per_stratum
   )
 }
 
@@ -848,9 +978,16 @@ gsSurvPower <- function(
     target,
     expected_counts_at_time,
     search_upper_bound,
-    tol) {
+    tol,
+    stratum_index = NULL) {
   objective <- function(current_time) {
-    expected_counts_at_time(current_time)$total_n - target
+    counts <- expected_counts_at_time(current_time)
+    enrolled <- if (is.null(stratum_index)) {
+      counts$total_n
+    } else {
+      counts$eNC[stratum_index] + counts$eNE[stratum_index]
+    }
+    enrolled - target
   }
   lower <- 0.001
   upper <- search_upper_bound
@@ -876,11 +1013,14 @@ gsSurvPower <- function(
     tol) {
   planned_time <- timing_inputs$planned_time
   max_extension <- timing_inputs$max_extension
+  max_calendar_time <- timing_inputs$max_calendar_time
   min_time_from_previous <- timing_inputs$min_time_from_previous
   min_follow_up <- timing_inputs$min_follow_up
   min_enrolled <- timing_inputs$min_enrolled
+  min_enrolled_per_stratum <- timing_inputs$min_enrolled_per_stratum
   final_min_follow_up <- timing_inputs$final_min_follow_up
   total_event_targets <- timing_inputs$total_event_targets
+  target_events_per_stratum <- timing_inputs$target_events_per_stratum
   analysis_count <- timing_inputs$k
 
   planned_time_max <- if (any(!is.na(planned_time))) {
@@ -890,12 +1030,23 @@ gsSurvPower <- function(
   }
   search_upper_bound <- max(sum(R) * 5, planned_time_max * 2, 200)
 
-  find_time_for_events <- function(target) {
+  find_time_for_events <- function(target, stratum_index = NULL) {
     objective <- function(current_time) {
-      expected_counts_at_time(current_time)$total_d - target
+      counts <- expected_counts_at_time(current_time)
+      events <- if (is.null(stratum_index)) {
+        counts$total_d
+      } else {
+        counts$eDC[stratum_index] + counts$eDE[stratum_index]
+      }
+      events - target
     }
     if (objective(search_upper_bound) < 0) {
-      warning("Target ", round(target), " events may not be achievable")
+      target_label <- if (is.null(stratum_index)) {
+        " events"
+      } else {
+        paste0(" events in stratum ", stratum_index)
+      }
+      warning("Target ", round(target), target_label, " may not be achievable")
       return(list(time = search_upper_bound, achievable = FALSE))
     }
     if (objective(0.001) >= 0) {
@@ -923,6 +1074,11 @@ gsSurvPower <- function(
         analysis_time[analysis_index - 1] + min_time_from_previous[analysis_index]
       )
     }
+    follow_up_time <- if (!is.na(min_follow_up[analysis_index])) {
+      min_follow_up[analysis_index]
+    } else {
+      0
+    }
     if (!is.na(min_enrolled[analysis_index])) {
       enrollment_time <- .gsSurvPower_find_time_for_enrollment(
         target = min_enrolled[analysis_index],
@@ -930,11 +1086,19 @@ gsSurvPower <- function(
         search_upper_bound = search_upper_bound,
         tol = tol
       )
-      follow_up_time <- if (!is.na(min_follow_up[analysis_index])) {
-        min_follow_up[analysis_index]
-      } else {
-        0
-      }
+      floor_times <- c(floor_times, enrollment_time + follow_up_time)
+    }
+    active_enrollment_strata <- which(
+      !is.na(min_enrolled_per_stratum[analysis_index, ])
+    )
+    for (stratum_index in active_enrollment_strata) {
+      enrollment_time <- .gsSurvPower_find_time_for_enrollment(
+        target = min_enrolled_per_stratum[analysis_index, stratum_index],
+        expected_counts_at_time = expected_counts_at_time,
+        search_upper_bound = search_upper_bound,
+        tol = tol,
+        stratum_index = stratum_index
+      )
       floor_times <- c(floor_times, enrollment_time + follow_up_time)
     }
     if (analysis_index == analysis_count && !is.na(final_min_follow_up)) {
@@ -942,11 +1106,27 @@ gsSurvPower <- function(
     }
     floor_time <- if (length(floor_times) > 0) max(floor_times) else 0.001
 
+    overall_event_solution <- NULL
+    event_times <- numeric(0)
     if (!is.na(total_event_targets[analysis_index])) {
-      event_solution <- find_time_for_events(
+      overall_event_solution <- find_time_for_events(
         total_event_targets[analysis_index]
       )
-      event_time <- event_solution$time
+      event_times <- c(event_times, overall_event_solution$time)
+    }
+    active_event_strata <- which(
+      !is.na(target_events_per_stratum[analysis_index, ])
+    )
+    for (stratum_index in active_event_strata) {
+      stratum_solution <- find_time_for_events(
+        target_events_per_stratum[analysis_index, stratum_index],
+        stratum_index = stratum_index
+      )
+      event_times <- c(event_times, stratum_solution$time)
+    }
+
+    if (length(event_times) > 0) {
+      event_time <- max(event_times)
       if (event_time <= floor_time) {
         analysis_time[analysis_index] <- floor_time
       } else if (!is.na(max_extension[analysis_index])) {
@@ -958,7 +1138,7 @@ gsSurvPower <- function(
         analysis_time[analysis_index] <- event_time
       }
     } else {
-      event_solution <- NULL
+      event_time <- NA_real_
       analysis_time[analysis_index] <- floor_time
     }
 
@@ -975,10 +1155,16 @@ gsSurvPower <- function(
         analysis_time[analysis_index - 1] + max_extension[analysis_index]
       )
     }
+    if (!is.na(max_calendar_time[analysis_index])) {
+      analysis_time[analysis_index] <- min(
+        analysis_time[analysis_index],
+        max_calendar_time[analysis_index]
+      )
+    }
     target_determines_analysis[analysis_index] <-
-      !is.null(event_solution) &&
-      event_solution$achievable &&
-      analysis_time[analysis_index] == event_solution$time
+      !is.null(overall_event_solution) &&
+      overall_event_solution$achievable &&
+      abs(analysis_time[analysis_index] - overall_event_solution$time) <= tol
   }
 
   control_events <- experimental_events <- NULL
@@ -1014,9 +1200,9 @@ gsSurvPower <- function(
   if (analysis_count > 1) {
     if (any(diff(analysis_time) <= tol)) {
       stop(
-        "Analysis times must be strictly increasing; add targetEvents, ",
-        "plannedCalendarTime, minTimeFromPreviousAnalysis, or later ",
-        "minN/minFollowUp criteria"
+        "Analysis times must be strictly increasing; add later overall or ",
+        "per-stratum event targets, plannedCalendarTime, ",
+        "minTimeFromPreviousAnalysis, or later enrollment/follow-up criteria"
       )
     }
     if (any(diff(total_events) <= tol)) {
@@ -1081,6 +1267,7 @@ gsSurvPower <- function(
 .gsSurvPower_resolve_spending_times <- function(
     analysis_time,
     actual_timing,
+    actual_events,
     settings) {
   if (!is.null(settings$informationRates)) {
     effective_spending_time <- pmin(settings$informationRates, actual_timing)
@@ -1093,7 +1280,17 @@ gsSurvPower <- function(
     ))
   }
 
-  if (settings$spending == "calendar") {
+  if (settings$spending == "min_planned_actual") {
+    effective_spending_time <- pmin(settings$x$n.I, actual_events) /
+      settings$x$n.I[settings$k]
+    if (isTRUE(settings$fullSpendingAtFinal)) {
+      effective_spending_time[length(effective_spending_time)] <- 1
+    }
+    return(list(
+      usTime = effective_spending_time,
+      lsTime = effective_spending_time
+    ))
+  } else if (settings$spending == "calendar") {
     upper_spending_time <- analysis_time / max(analysis_time)
     lower_spending_time <- upper_spending_time
   } else {

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -328,7 +328,8 @@
 #' @param tol Tolerance for \code{\link[stats]{uniroot}} when solving for
 #'   analysis times.
 #'
-#' @return An object of class \code{c("gsSurv", "gsDesign")} containing:
+#' @return An object of class
+#'   \code{c("gsSurvPower", "gsSurv", "gsDesign")} containing:
 #' \item{k}{Number of analyses.}
 #' \item{n.I}{Total expected events at each analysis.}
 #' \item{timing}{Information fractions at each analysis.}
@@ -345,8 +346,13 @@
 #'   under the assumed HR).}
 #' \item{beta}{Type II error (\code{1 - power}).}
 #' \item{variable}{Always \code{"Power"}.}
-#' \item{test.type, alpha, sided, method, spending, call}{Design settings used
-#'   for the power calculation.}
+#' \item{test.type, alpha, sided, method, spending, call}{Design settings and
+#'   the original call used for the power calculation.}
+#' \item{inputs}{Evaluated arguments supplied to \code{gsSurvPower()}. The
+#'   calculation can be reproduced under the same package version with
+#'   \code{do.call(gsSurvPower, inputs)}. When \code{x} is supplied, the
+#'   evaluated reference design is retained so that inherited design settings
+#'   and planned-versus-actual spending can be reproduced.}
 #' \item{informationRates, fullSpendingAtFinal}{Planned information-fraction
 #'   caps and final effective-spending-time setting used for bound spending.}
 #' \item{testUpper, testLower, testHarm}{Logical indicators of which analyses
@@ -442,6 +448,11 @@ gsSurvPower <- function(
   spending <- match.arg(spending)
   call_object <- match.call()
   call_args <- as.list(call_object)
+  input_arguments <- mget(
+    names(call_object)[-1],
+    envir = environment(),
+    inherits = FALSE
+  )
 
   # Track whether user explicitly provided alpha; used below to decide
   # whether the gsSurv alpha/sided convention applies.
@@ -711,7 +722,8 @@ gsSurvPower <- function(
     bound_result = bound_result,
     normalized_rates = normalized_rates,
     settings = settings,
-    call_object = call_object
+    call_object = call_object,
+    input_arguments = input_arguments
   )
 }
 
@@ -1598,7 +1610,8 @@ gsSurvPower <- function(
     bound_result,
     normalized_rates,
     settings,
-    call_object) {
+    call_object,
+    input_arguments) {
   result <- design_result
   result$n.I <- analysis_schedule$total_events
   result$T <- analysis_schedule$analysis_time
@@ -1627,6 +1640,7 @@ gsSurvPower <- function(
   result$informationRates <- settings$informationRates
   result$fullSpendingAtFinal <- settings$fullSpendingAtFinal
   result$call <- call_object
+  result$inputs <- input_arguments
   result$timing <- analysis_schedule$timing
   result$testUpper <- .gsSurvPower_format_test_flag(settings$testUpper, settings$k)
   result$testLower <- if (settings$k == 1) {
@@ -1657,6 +1671,6 @@ gsSurvPower <- function(
   result$power <- sum(bound_result$probabilities$upper$prob[, 2])
   result$beta <- 1 - result$power
 
-  class(result) <- c("gsSurv", "gsDesign")
+  class(result) <- c("gsSurvPower", "gsSurv", "gsDesign")
   gsSurvAddN(.gsSurvPower_label_output_matrices(result))
 }

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -36,7 +36,7 @@ gsSurvPower(
   ratio = NULL,
   minfup = NULL,
   method = NULL,
-  spending = c("information", "calendar"),
+  spending = c("information", "calendar", "min_planned_actual"),
   plannedCalendarTime = NULL,
   targetEvents = NULL,
   maxExtension = NULL,
@@ -45,7 +45,10 @@ gsSurvPower(
   minFollowUp = NULL,
   informationRates = NULL,
   fullSpendingAtFinal = FALSE,
-  tol = .Machine$double.eps^0.25
+  tol = .Machine$double.eps^0.25,
+  targetEventsPerStratum = NULL,
+  maxCalendarTime = NULL,
+  minNPerStratum = NULL
 )
 }
 \arguments{
@@ -162,22 +165,23 @@ enrollment plus \code{minfup}.}
 \code{"Freedman"}, or \code{"BernsteinLagakos"}. Affects \code{n.fix}
 computation when \code{x} is not provided.}
 
-\item{spending}{One of \code{"information"} (default) or \code{"calendar"}.
-Controls whether alpha/beta spending tracks information fractions or
-calendar time fractions (\code{T / max(T)}). With calendar spending,
-\code{usTime} and \code{lsTime} are derived from the realized analysis
-times and any user-supplied overrides are ignored.}
+\item{spending}{One of \code{"information"} (default), \code{"calendar"},
+or \code{"min_planned_actual"}. Information spending tracks expected
+event fractions within the scenario. Calendar spending uses
+\code{T / max(T)}. With a reference design \code{x},
+\code{"min_planned_actual"} uses
+\code{pmin(x$n.I, actual events) / x$n.I[k]}, matching the planned-versus-
+actual spending convention in \pkg{simtrial}. The latter two modes derive
+\code{usTime} and \code{lsTime} and ignore user-supplied overrides.}
 
 \item{plannedCalendarTime}{Calendar times for analyses (time 0 = start of
 randomization). Scalar (recycled) or vector of length \code{k}. Use
 \code{NA} for analyses not determined by calendar time.}
 
-\item{targetEvents}{Target number of events at each analysis. Scalar
-(recycled), vector of length \code{k} (overall targets), or matrix
-with \code{k} rows and \code{nstrata} columns (per-stratum targets).
-Use \code{NA} for analyses not determined by events. When a matrix is
-supplied, row sums give the total event target used to solve each
-analysis time.}
+\item{targetEvents}{Overall target number of events at each analysis.
+Scalar (recycled) or vector of length \code{k}. Use \code{NA} for
+analyses without an overall event requirement. A matrix is accepted as a
+deprecated alias for \code{targetEventsPerStratum}.}
 
 \item{maxExtension}{Maximum time extension beyond the floor time to wait
 for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
@@ -193,9 +197,10 @@ Scalar or vector of length \code{k}. Can be used with
 \code{minFollowUp} as the primary timing criterion; the resulting
 analysis times and expected event totals must be strictly increasing.}
 
-\item{minFollowUp}{Minimum follow-up time after \code{minN} is reached.
-Scalar or vector of length \code{k}. Must be >= 0 and requires
-\code{minN}.}
+\item{minFollowUp}{Minimum follow-up time after all active \code{minN} and
+\code{minNPerStratum} requirements are reached. Scalar or vector of
+length \code{k}. Must be >= 0 and requires at least one enrollment
+requirement.}
 
 \item{informationRates}{Numeric vector of length \code{k} specifying
 planned information-fraction caps. At each analysis, the effective upper
@@ -213,14 +218,29 @@ information fractions (or calendar fractions when
 \item{fullSpendingAtFinal}{Logical. When \code{TRUE}, the final element of
 the effective upper and lower spending-time vectors is forced to 1 after
 applying
-\code{informationRates}, calendar spending, or user-supplied
-\code{usTime}/\code{lsTime}. This ensures full upper- and lower-bound
+\code{informationRates}, calendar or planned-versus-actual spending, or
+user-supplied \code{usTime}/\code{lsTime}. This ensures full upper- and
+lower-bound
 spending whenever a selected spending-time vector would otherwise end
 below 1.
 Default \code{FALSE}.}
 
 \item{tol}{Tolerance for \code{\link[stats]{uniroot}} when solving for
 analysis times.}
+
+\item{targetEventsPerStratum}{Per-stratum event requirements. Numeric matrix
+with \code{k} rows and one column per stratum; \code{NA} omits a stratum
+requirement at an analysis. The analysis waits until every active stratum
+requirement and any overall \code{targetEvents} requirement are met.}
+
+\item{maxCalendarTime}{Absolute calendar-time cap for each analysis. Scalar
+or vector of length \code{k}. When supplied with \code{maxExtension}, the
+earlier cap applies. This corresponds to
+\code{max_extension_for_target_event} in \pkg{simtrial}.}
+
+\item{minNPerStratum}{Per-stratum minimum enrollment requirements. Numeric
+matrix with \code{k} rows and one column per stratum; \code{NA} omits a
+stratum requirement at an analysis.}
 }
 \value{
 An object of class \code{c("gsSurv", "gsDesign")} containing:
@@ -320,17 +340,17 @@ can be a scalar (recycled to all \code{k} analyses), a vector of length
 \code{k}, or \code{NA} at position \code{i} to indicate the criterion does
 not apply to analysis \code{i}.
 
-The choice between \code{plannedCalendarTime} and \code{targetEvents} has an
-important consequence for sensitivity analyses:
+The choice between \code{plannedCalendarTime} and overall
+\code{targetEvents} has an important consequence for sensitivity analyses:
 \itemize{
   \item Used alone, \code{plannedCalendarTime} fixes calendar times;
     when combined with other criteria, it supplies a timing floor. Expected
     events are recomputed under the assumed HR. A worse HR produces more
     events at the same calendar time (the experimental arm fails faster).
     This gives an "unconditional" power.
-  \item \code{targetEvents} fixes event counts; calendar times adjust. Since
-    events are held constant, information fractions do not change with HR, and
-    results match the \code{gsDesign} power plot
+  \item \code{targetEvents} fixes overall event counts; calendar times
+    adjust. Since events are held constant, information fractions do not
+    change with HR, and results match the \code{gsDesign} power plot
     (\code{plot(x, plottype = 2)}) to numerical precision.
 }
 
@@ -340,17 +360,21 @@ For analysis \code{i}, the analysis time \code{T[i]} is determined as:
   \item Compute floor times from applicable criteria:
     \code{plannedCalendarTime[i]},
     \code{T[i-1] + minTimeFromPreviousAnalysis[i]}, and
-    time when \code{minN[i]} enrolled + \code{minFollowUp[i]}. When
-    \code{minfup} is explicitly supplied, the final analysis also has a
-    floor at the end of enrollment plus \code{minfup}.
+    time when \code{minN[i]} enrolled + \code{minFollowUp[i]}, and the
+    corresponding time for every active column of
+    \code{minNPerStratum[i, ]}. When \code{minfup} is explicitly supplied,
+    the final analysis also has a floor at the end of enrollment plus
+    \code{minfup}.
   \item \code{floor_time = max(all applicable floor times)}.
-  \item If \code{targetEvents[i]} is specified: find \code{t_events} when
-    expected events reach target. If \code{t_events <= floor_time}, analysis
-    at \code{floor_time}. If \code{t_events > floor_time} and
+  \item Find the expected time for the overall \code{targetEvents[i]} and
+    for every active column of \code{targetEventsPerStratum[i, ]}. Their
+    maximum is \code{t_events}, so all active requirements use AND logic.
+    If \code{t_events <= floor_time}, analysis at \code{floor_time}. If
+    \code{t_events > floor_time} and
     \code{maxExtension[i]} is set, analysis at
     \code{min(t_events, floor_time + maxExtension[i])}. Otherwise, analysis
     at \code{t_events}.
-  \item If no \code{targetEvents}: analysis at \code{floor_time}.
+  \item If no event requirement is active: analysis at \code{floor_time}.
   \item \code{maxExtension} defines a hard deadline: the analysis time
     is never pushed
     beyond \code{plannedCalendarTime[i] + maxExtension[i]} (or
@@ -359,7 +383,13 @@ For analysis \code{i}, the analysis time \code{T[i]} is determined as:
     or \code{minN + minFollowUp} would require a later time. Each analysis
     using \code{maxExtension} must have a floor timing criterion such as
     \code{plannedCalendarTime}, \code{minTimeFromPreviousAnalysis},
-    \code{minN}, or explicit final-analysis \code{minfup}.
+    \code{minN}, \code{minNPerStratum}, or explicit final-analysis
+    \code{minfup}.
+  \item Finally, \code{maxCalendarTime[i]} applies an absolute calendar-time
+    cap. If both cap types are supplied, the earlier cap applies. This
+    mirrors the realized-cut grammar in \pkg{simtrial}, where the argument
+    named \code{max_extension_for_target_event} is applied as an absolute
+    analysis date.
 }
 
 \strong{Normalization and consistency:}
@@ -373,12 +403,16 @@ Power is computed via \code{gsDesign::gsProbability()} with actual expected
 events as \code{n.I}. At the design HR, this reproduces the design power
 exactly.
 
-\strong{Stratified targetEvents:}
-\code{targetEvents} accepts a scalar (recycled), a vector of length \code{k}
-(overall targets per analysis), or a matrix with \code{k} rows and
-\code{nstrata} columns (per-stratum targets). A vector of length \code{k}
-is always interpreted as overall targets; use a matrix for per-stratum
-specification.
+\strong{Stratified timing requirements:}
+\code{targetEvents} accepts a scalar (recycled) or a vector of length
+\code{k} for overall event targets. Use \code{targetEventsPerStratum} for a
+\code{k}-by-\code{nstrata} matrix of per-stratum event requirements and
+\code{minNPerStratum} for per-stratum enrollment requirements. Overall and
+per-stratum requirements may be combined and all active requirements must
+be met unless a cap intervenes. \code{NA} omits a requirement. A matrix
+passed through \code{targetEvents} is a deprecated alias for
+\code{targetEventsPerStratum}; unlike the earlier row-sum interpretation,
+its entries are enforced by stratum.
 
 \strong{Bound recalculation when parameters change:}
 When \code{x} is provided, the handling of bounds depends on which
@@ -440,6 +474,18 @@ pwr_target_n <- gsSurvPower(
   testLower = FALSE
 )
 sum(rowSums(pwr_target_n$gamma) * pwr_target_n$R)
+
+# Require event counts within each stratum
+pwr_stratified <- gsSurvPower(
+  k = 2, test.type = 1, alpha = 0.025, sided = 1,
+  lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+  hr = 0.7, eta = 0.01,
+  gamma = matrix(c(5, 5), ncol = 2), R = 12, ratio = 1,
+  targetEventsPerStratum = matrix(
+    c(20, 10, 40, 20), nrow = 2, byrow = TRUE
+  )
+)
+pwr_stratified$eDC + pwr_stratified$eDE
 
 }
 \seealso{

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -102,25 +102,30 @@ bound spending function \code{sfharm}.}
 \item{r}{Integer grid parameter for numerical integration (default 18).}
 
 \item{usTime}{Upper spending time override; vector of length \code{k}
-or \code{NULL} (default) to use information fractions. Ignored when
+without missing values, or \code{NULL} (default) to use information
+fractions. Ignored when
 \code{spending = "calendar"}, because realized analysis times determine
 the spending fractions.}
 
 \item{lsTime}{Lower spending time override; vector of length \code{k}
-or \code{NULL} (default) to use information fractions. Ignored when
-\code{spending = "calendar"}.}
+without missing values, or \code{NULL} (default) to use information
+fractions. Ignored when \code{spending = "calendar"}.}
 
 \item{testUpper}{Indicator of which analyses include an efficacy test.
 \code{TRUE} (default) for all analyses. A logical vector of length
-\code{k} may be specified.}
+\code{k} may be specified. Missing values are not allowed; use
+\code{FALSE} to omit the test at an analysis.}
 
 \item{testLower}{Indicator of which analyses include a futility test.
 \code{TRUE} (default) for all analyses. A logical vector of length
-\code{k} may be specified.}
+\code{k} may be specified. Missing values are not allowed; use
+\code{FALSE} to omit the test at an analysis.}
 
 \item{testHarm}{Indicator of which analyses include a harm bound.
 \code{TRUE} (default) for all analyses. A logical vector of length
-\code{k} may be specified. Only used for \code{test.type} 7 or 8.}
+\code{k} may be specified. Missing values are not allowed; use
+\code{FALSE} to omit the test at an analysis. Only used for
+\code{test.type} 7 or 8.}
 
 \item{lambdaC}{Scalar, vector, or matrix of control event hazard rates.
 Rows = time periods, columns = strata.}
@@ -186,25 +191,28 @@ deprecated alias for \code{targetEventsPerStratum}.}
 \item{maxExtension}{Maximum time extension beyond the floor time to wait
 for \code{targetEvents}. Scalar or vector of length \code{k}. Requires a
 floor timing criterion for the affected analysis, most commonly
-\code{plannedCalendarTime}.}
+\code{plannedCalendarTime}. Use \code{NA} for analyses without a relative
+extension cap.}
 
 \item{minTimeFromPreviousAnalysis}{Minimum elapsed time since the previous
 analysis. Scalar or vector of length \code{k}. Ignored for the first
-analysis.}
+analysis. Use \code{NA} for later analyses without a spacing requirement.}
 
 \item{minN}{Minimum total sample size enrolled before analysis can proceed.
 Scalar or vector of length \code{k}. Can be used with
 \code{minFollowUp} as the primary timing criterion; the resulting
-analysis times and expected event totals must be strictly increasing.}
+analysis times and expected event totals must be strictly increasing. Use
+\code{NA} for analyses without an overall enrollment requirement.}
 
 \item{minFollowUp}{Minimum follow-up time after all active \code{minN} and
 \code{minNPerStratum} requirements are reached. Scalar or vector of
-length \code{k}. Must be >= 0 and requires at least one enrollment
-requirement.}
+length \code{k}. Must be >= 0. Use \code{NA} for no additional follow-up
+at an analysis. Each non-missing value requires an active \code{minN} or
+\code{minNPerStratum} requirement at the same analysis.}
 
 \item{informationRates}{Numeric vector of length \code{k} specifying
-planned information-fraction caps. At each analysis, the effective upper
-and lower spending time is
+planned information-fraction caps, with no missing values. At each
+analysis, the effective upper and lower spending time is
 \code{pmin(informationRates, actual_timing)}, where
 \code{actual_timing} is expected events divided by maximum expected
 events. This prevents spending ahead of either the planned information
@@ -236,7 +244,8 @@ requirement and any overall \code{targetEvents} requirement are met.}
 \item{maxCalendarTime}{Absolute calendar-time cap for each analysis. Scalar
 or vector of length \code{k}. When supplied with \code{maxExtension}, the
 earlier cap applies. This corresponds to
-\code{max_extension_for_target_event} in \pkg{simtrial}.}
+\code{max_extension_for_target_event} in \pkg{simtrial}. Use \code{NA}
+for analyses without an absolute calendar-time cap.}
 
 \item{minNPerStratum}{Per-stratum minimum enrollment requirements. Numeric
 matrix with \code{k} rows and one column per stratum; \code{NA} omits a
@@ -335,10 +344,12 @@ beta under the alternative. Harm spending for test types 7 and 8 is also a
 separate null-based calculation.
 
 \strong{Analysis timing:}
-Analysis times are determined by per-analysis criteria. Each timing parameter
-can be a scalar (recycled to all \code{k} analyses), a vector of length
-\code{k}, or \code{NA} at position \code{i} to indicate the criterion does
-not apply to analysis \code{i}.
+Analysis times are determined by per-analysis criteria. Except for the
+final-analysis-only scalar \code{minfup}, each timing-rule parameter can be
+a scalar (recycled to all \code{k} analyses), a vector of length \code{k},
+or \code{NA} at position \code{i} to indicate that the rule does not apply
+to analysis \code{i}. For the per-stratum matrix arguments, \code{NA}
+deactivates only that analysis-by-stratum requirement.
 
 The choice between \code{plannedCalendarTime} and overall
 \code{targetEvents} has an important consequence for sensitivity analyses:

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -252,7 +252,8 @@ matrix with \code{k} rows and one column per stratum; \code{NA} omits a
 stratum requirement at an analysis.}
 }
 \value{
-An object of class \code{c("gsSurv", "gsDesign")} containing:
+An object of class
+  \code{c("gsSurvPower", "gsSurv", "gsDesign")} containing:
 \item{k}{Number of analyses.}
 \item{n.I}{Total expected events at each analysis.}
 \item{timing}{Information fractions at each analysis.}
@@ -269,8 +270,13 @@ An object of class \code{c("gsSurv", "gsDesign")} containing:
   under the assumed HR).}
 \item{beta}{Type II error (\code{1 - power}).}
 \item{variable}{Always \code{"Power"}.}
-\item{test.type, alpha, sided, method, spending, call}{Design settings used
-  for the power calculation.}
+\item{test.type, alpha, sided, method, spending, call}{Design settings and
+  the original call used for the power calculation.}
+\item{inputs}{Evaluated arguments supplied to \code{gsSurvPower()}. The
+  calculation can be reproduced under the same package version with
+  \code{do.call(gsSurvPower, inputs)}. When \code{x} is supplied, the
+  evaluated reference design is retained so that inherited design settings
+  and planned-versus-actual spending can be reproduced.}
 \item{informationRates, fullSpendingAtFinal}{Planned information-fraction
   caps and final effective-spending-time setting used for bound spending.}
 \item{testUpper, testLower, testHarm}{Logical indicators of which analyses

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -653,6 +653,34 @@ test_that("gsSurvPower supports per-stratum enrollment and follow-up gates", {
   expect_true(all(pwr$eNC + pwr$eNE >= enrollment_targets))
 })
 
+test_that("gsSurvPower supports mixed NA across analysis timing rules", {
+  pwr <- gsSurvPower(
+    k = 3,
+    test.type = 1,
+    alpha = 0.025,
+    sided = 1,
+    lambdaC = log(2) / 6,
+    hr = 0.7,
+    hr0 = 1,
+    gamma = 10,
+    R = 12,
+    ratio = 1,
+    plannedCalendarTime = c(12, NA, 36),
+    targetEvents = c(NA, 80, NA),
+    targetEventsPerStratum = matrix(c(NA, 50, NA), ncol = 1),
+    maxExtension = c(NA, 6, NA),
+    maxCalendarTime = c(NA, 24, NA),
+    minTimeFromPreviousAnalysis = c(NA, 6, NA),
+    minN = c(100, NA, NA),
+    minNPerStratum = matrix(c(40, NA, NA), ncol = 1),
+    minFollowUp = c(2, NA, NA)
+  )
+
+  expect_equal(pwr$T, c(12, 18, 36), tolerance = 1e-3)
+  expect_true(pwr$N[1] >= 100)
+  expect_true(all(diff(pwr$n.I) > 0))
+})
+
 test_that("gsSurvPower print method works for power output", {
   design <- gsSurv(
     k = 2, test.type = 4, alpha = 0.025, sided = 1, beta = 0.1,
@@ -695,6 +723,59 @@ test_that("gsSurvPower validates inputs", {
       plannedCalendarTime = c(12, 24, 36)
     ),
     "must have length 1 or"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 3, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, 24, 36),
+      minN = c(100, NA, NA),
+      minFollowUp = c(2, 5, NA)
+    ),
+    "minFollowUp at analysis 2 requires minN or minNPerStratum"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 3, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, 24, 36),
+      informationRates = c(0.3, NA, 1)
+    ),
+    "informationRates.*without NA"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 3, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, 24, 36),
+      testUpper = c(FALSE, NA, TRUE)
+    ),
+    "testUpper.*without NA"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 3, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, 24, 36),
+      usTime = c(0.3, NA, 1)
+    ),
+    "usTime.*without NA"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 2, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, Inf)
+    ),
+    "plannedCalendarTime values must be non-negative finite numbers or NA"
+  )
+
+  expect_error(
+    gsSurvPower(
+      k = 3, lambdaC = log(2) / 6, gamma = 10, R = 12,
+      plannedCalendarTime = c(12, NA, 36)
+    ),
+    "Analysis 2 has no active timing criterion"
   )
 })
 

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -51,6 +51,13 @@ test_that("gsSurvPower works with targetEvents", {
   events <- rowSums(pwr$eDC) + rowSums(pwr$eDE)
   expect_equal(events, c(50, 100), tolerance = 1e-6)
   expect_equal(pwr$n.I, events)
+
+  pwr_matrix <- expect_no_warning(gsSurvPower(
+    x = design,
+    targetEvents = matrix(c(50, 100), ncol = 1)
+  ))
+  expect_equal(pwr_matrix$T, pwr$T, tolerance = 1e-6)
+  expect_equal(pwr_matrix$n.I, pwr$n.I, tolerance = 1e-6)
 })
 
 test_that("gsSurvPower preserves integer sample size and event targets", {
@@ -210,6 +217,37 @@ test_that("gsSurvPower respects maxExtension", {
   expect_true(pwr_capped$T[1] <= pwr_uncapped$T[1])
 })
 
+test_that("maxCalendarTime is an absolute analysis-time cap", {
+  base_args <- list(
+    k = 1, test.type = 1, alpha = 0.025, sided = 1,
+    lambdaC = log(2) / 6, hr = 0.7, hr0 = 1,
+    gamma = 10, R = 12, ratio = 1,
+    targetEvents = 100
+  )
+
+  pwr_capped <- do.call(gsSurvPower, c(base_args, list(
+    maxCalendarTime = 18
+  )))
+  pwr_uncapped <- do.call(gsSurvPower, base_args)
+
+  expect_equal(pwr_capped$T, 18, tolerance = 1e-6)
+  expect_lt(pwr_capped$n.I, 100)
+  expect_gt(pwr_uncapped$T, pwr_capped$T)
+
+  pwr_relative_first <- do.call(gsSurvPower, c(base_args, list(
+    plannedCalendarTime = 18,
+    maxExtension = 2,
+    maxCalendarTime = 22
+  )))
+  pwr_absolute_first <- do.call(gsSurvPower, c(base_args, list(
+    plannedCalendarTime = 18,
+    maxExtension = 10,
+    maxCalendarTime = 22
+  )))
+  expect_equal(pwr_relative_first$T, 20, tolerance = 1e-6)
+  expect_equal(pwr_absolute_first$T, 22, tolerance = 1e-6)
+})
+
 test_that("gsSurvPower requires a floor criterion when maxExtension is supplied", {
   expect_error(
     gsSurvPower(
@@ -317,9 +355,17 @@ test_that("gsSurvPower informationRates take precedence over calendar spending",
     usTime = c(0.3, 0.7, 1),
     lsTime = c(0.4, 0.8, 1)
   )
+  pwr_min_planned_actual <- gsSurvPower(
+    x = design,
+    plannedCalendarTime = design$T,
+    informationRates = info_rates,
+    spending = "min_planned_actual"
+  )
 
   expect_equal(pwr_info$upper$bound, pwr_calendar$upper$bound)
   expect_equal(pwr_info$lower$bound, pwr_calendar$lower$bound)
+  expect_equal(pwr_info$upper$bound, pwr_min_planned_actual$upper$bound)
+  expect_equal(pwr_info$lower$bound, pwr_min_planned_actual$lower$bound)
   expect_equal(pwr_info$informationRates, info_rates)
 })
 
@@ -373,7 +419,49 @@ test_that("gsSurvPower fullSpendingAtFinal forces final spending fraction to one
   expect_true(isTRUE(pwr_full$fullSpendingAtFinal))
 })
 
-test_that("gsSurvPower uses row sums of matrix targetEvents for timing", {
+test_that("gsSurvPower supports planned-versus-actual spending", {
+  design <- gsSurv(
+    k = 3, test.type = 4, alpha = 0.025, sided = 1, beta = 0.1,
+    sfu = sfHSD, sfupar = -4, sfl = sfHSD, sflpar = -2,
+    lambdaC = log(2) / 12, hr = 0.7, hr0 = 1,
+    eta = 0.01, gamma = 10, R = 16, minfup = 12, T = 28
+  )
+
+  pwr <- gsSurvPower(
+    x = design,
+    lambdaC = log(2) / 24,
+    plannedCalendarTime = design$T,
+    spending = "min_planned_actual"
+  )
+  expected_spending_time <- pmin(design$n.I, pwr$n.I) /
+    design$n.I[design$k]
+
+  expect_equal(pwr$upper$sTime, expected_spending_time, tolerance = 1e-8)
+  expect_equal(pwr$lower$sTime, expected_spending_time, tolerance = 1e-8)
+  expect_lt(tail(expected_spending_time, 1), 1)
+
+  pwr_full <- gsSurvPower(
+    x = design,
+    lambdaC = log(2) / 24,
+    plannedCalendarTime = design$T,
+    spending = "min_planned_actual",
+    fullSpendingAtFinal = TRUE
+  )
+  expect_equal(tail(pwr_full$upper$sTime, 1), 1)
+
+  expect_error(
+    gsSurvPower(
+      k = 2, test.type = 1, alpha = 0.025, sided = 1,
+      lambdaC = log(2) / 6, hr = 0.7, hr0 = 1,
+      gamma = 10, R = 12, ratio = 1,
+      plannedCalendarTime = c(18, 24),
+      spending = "min_planned_actual"
+    ),
+    "requires a reference design x"
+  )
+})
+
+test_that("gsSurvPower enforces per-stratum event requirements", {
   target_matrix <- matrix(c(20, 10, 40, 20), nrow = 2, byrow = TRUE)
   base_args <- list(
     k = 2, test.type = 1, alpha = 0.025, sided = 1,
@@ -384,13 +472,51 @@ test_that("gsSurvPower uses row sums of matrix targetEvents for timing", {
     R = 12, ratio = 1
   )
 
-  pwr_matrix <- do.call(gsSurvPower, c(base_args, list(targetEvents = target_matrix)))
-  pwr_vector <- do.call(gsSurvPower, c(base_args, list(
-    targetEvents = rowSums(target_matrix)
+  pwr_per_stratum <- do.call(gsSurvPower, c(base_args, list(
+    targetEventsPerStratum = target_matrix
+  )))
+  events_per_stratum <- pwr_per_stratum$eDC + pwr_per_stratum$eDE
+
+  expect_true(all(events_per_stratum >= target_matrix - 1e-4))
+  expect_true(all(apply(
+    abs(events_per_stratum - target_matrix) < 1e-4,
+    1,
+    any
+  )))
+  expect_false(isTRUE(all.equal(
+    pwr_per_stratum$n.I,
+    rowSums(target_matrix),
+    tolerance = 1e-4
   )))
 
-  expect_equal(pwr_matrix$T, pwr_vector$T, tolerance = 1e-6)
-  expect_equal(pwr_matrix$n.I, pwr_vector$n.I, tolerance = 1e-6)
+  expect_warning(
+    pwr_alias <- do.call(gsSurvPower, c(base_args, list(
+      targetEvents = target_matrix
+    ))),
+    "matrix targetEvents is deprecated"
+  )
+  expect_equal(pwr_alias$T, pwr_per_stratum$T, tolerance = 1e-6)
+  expect_equal(pwr_alias$n.I, pwr_per_stratum$n.I, tolerance = 1e-6)
+})
+
+test_that("gsSurvPower combines overall and per-stratum event requirements", {
+  target_matrix <- matrix(c(20, 10, 40, 20), nrow = 2, byrow = TRUE)
+  overall_targets <- c(35, 70)
+
+  pwr <- gsSurvPower(
+    k = 2, test.type = 1, alpha = 0.025, sided = 1,
+    lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+    hr = 0.7, hr0 = 1,
+    eta = matrix(c(0.01, 0.02), ncol = 2),
+    gamma = matrix(c(5, 5), ncol = 2),
+    R = 12, ratio = 1,
+    targetEvents = overall_targets,
+    targetEventsPerStratum = target_matrix
+  )
+
+  events_per_stratum <- pwr$eDC + pwr$eDE
+  expect_true(all(events_per_stratum >= target_matrix - 1e-4))
+  expect_equal(pwr$n.I, overall_targets, tolerance = 1e-4)
 })
 
 test_that("gsSurvPower uses etaE separately from eta", {
@@ -501,6 +627,32 @@ test_that("gsSurvPower supports minN and minFollowUp timing", {
   )
 })
 
+test_that("gsSurvPower supports per-stratum enrollment and follow-up gates", {
+  enrollment_targets <- matrix(
+    c(20, 30, 40, 60),
+    nrow = 2,
+    byrow = TRUE
+  )
+  pwr <- gsSurvPower(
+    k = 2,
+    test.type = 1,
+    alpha = 0.025,
+    sided = 1,
+    lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+    hr = 0.7,
+    hr0 = 1,
+    eta = 0,
+    gamma = matrix(c(4, 6), ncol = 2),
+    R = 12,
+    minNPerStratum = enrollment_targets,
+    minFollowUp = c(2, 2),
+    ratio = 1
+  )
+
+  expect_equal(pwr$T, c(7, 12), tolerance = 1e-3)
+  expect_true(all(pwr$eNC + pwr$eNE >= enrollment_targets))
+})
+
 test_that("gsSurvPower print method works for power output", {
   design <- gsSurv(
     k = 2, test.type = 4, alpha = 0.025, sided = 1, beta = 0.1,
@@ -543,6 +695,24 @@ test_that("gsSurvPower validates inputs", {
       plannedCalendarTime = c(12, 24, 36)
     ),
     "must have length 1 or"
+  )
+})
+
+test_that("gsSurvPower preserves the legacy positional argument order", {
+  legacy_formals <- c(
+    "x", "k", "test.type", "alpha", "sided", "astar",
+    "sfu", "sfupar", "sfl", "sflpar", "sfharm", "sfharmparam",
+    "r", "usTime", "lsTime", "testUpper", "testLower", "testHarm",
+    "lambdaC", "hr", "hr0", "hr1", "eta", "etaE", "gamma", "R",
+    "targetN", "S", "ratio", "minfup", "method", "spending",
+    "plannedCalendarTime", "targetEvents", "maxExtension",
+    "minTimeFromPreviousAnalysis", "minN", "minFollowUp",
+    "informationRates", "fullSpendingAtFinal", "tol"
+  )
+
+  expect_identical(
+    names(formals(gsSurvPower))[seq_along(legacy_formals)],
+    legacy_formals
   )
 })
 

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -8,6 +8,7 @@ test_that("gsSurvPower works with plannedCalendarTime from gsSurv design", {
   )
 
   pwr <- gsSurvPower(x = design, plannedCalendarTime = design$T)
+  expect_s3_class(pwr, "gsSurvPower")
   expect_s3_class(pwr, "gsSurv")
   expect_s3_class(pwr, "gsDesign")
   expect_equal(pwr$k, 3)
@@ -18,6 +19,67 @@ test_that("gsSurvPower works with plannedCalendarTime from gsSurv design", {
   expect_equal(pwr$hr, design$hr)
   expect_equal(pwr$hr1, design$hr)
   expect_equal(pwr$variable, "Power")
+})
+
+test_that("gsSurvPower retains evaluated inputs for direct reconstruction", {
+  pwr <- gsSurvPower(
+    k = 3,
+    test.type = 1,
+    lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+    hr = 0.7,
+    gamma = matrix(c(4, 6), ncol = 2),
+    R = 12,
+    plannedCalendarTime = c(12, NA, 36),
+    targetEvents = c(NA, 80, NA),
+    targetEventsPerStratum = matrix(
+      c(NA, NA, 20, 30, NA, NA), nrow = 3, byrow = TRUE
+    ),
+    maxExtension = c(NA, 6, NA),
+    maxCalendarTime = c(NA, 24, NA),
+    minTimeFromPreviousAnalysis = c(NA, 6, NA),
+    minN = c(100, NA, NA),
+    minNPerStratum = matrix(
+      c(40, 60, NA, NA, NA, NA), nrow = 3, byrow = TRUE
+    ),
+    minFollowUp = c(2, NA, NA)
+  )
+  saved_inputs <- unserialize(serialize(pwr$inputs, NULL))
+  rebuilt <- do.call(gsSurvPower, saved_inputs)
+
+  expect_s3_class(rebuilt, "gsSurvPower")
+  expect_identical(pwr$inputs$plannedCalendarTime, c(12, NA, 36))
+  expect_identical(
+    pwr$inputs$targetEventsPerStratum,
+    matrix(c(NA, NA, 20, 30, NA, NA), nrow = 3, byrow = TRUE)
+  )
+  expect_equal(rebuilt$T, pwr$T)
+  expect_equal(rebuilt$n.I, pwr$n.I)
+  expect_equal(rebuilt$upper$bound, pwr$upper$bound)
+  expect_equal(rebuilt$power, pwr$power)
+})
+
+test_that("gsSurvPower reconstruction retains its reference design", {
+  design <- gsSurv(
+    k = 3, test.type = 4, beta = 0.15,
+    lambdaC = log(2) / 12, hr = 0.7, eta = 0.01,
+    gamma = 10, R = 16, minfup = 12, T = 28
+  )
+  pwr <- gsSurvPower(
+    x = design,
+    hr = 0.8,
+    targetEvents = 0.9 * design$n.I,
+    spending = "min_planned_actual"
+  )
+  saved_inputs <- unserialize(serialize(pwr$inputs, NULL))
+  rebuilt <- do.call(gsSurvPower, saved_inputs)
+
+  expect_identical(pwr$inputs$x, design)
+  expect_identical(pwr$inputs$targetEvents, 0.9 * design$n.I)
+  expect_equal(rebuilt$T, pwr$T)
+  expect_equal(rebuilt$n.I, pwr$n.I)
+  expect_equal(rebuilt$upper$bound, pwr$upper$bound)
+  expect_equal(rebuilt$lower$bound, pwr$lower$bound)
+  expect_equal(rebuilt$power, pwr$power)
 })
 
 test_that("gsSurvPower power decreases with worse HR", {

--- a/vignettes/gsSurvPower.Rmd
+++ b/vignettes/gsSurvPower.Rmd
@@ -246,18 +246,30 @@ For scenario analyses, override only the assumptions that change:
 | Enrollment duration or target size | `R`, or `targetN` |
 | Operational analysis rules | Timing arguments in the table above |
 
-Additional criteria can be combined per-analysis, each specified as a scalar
+Per-analysis timing rules can be combined, each specified as a scalar
 (recycled to all `k` analyses) or a vector of length `k` with `NA` for
 "not applicable":
 
+- `plannedCalendarTime`: Calendar-time floor for the analysis.
+- `targetEvents`: Overall event requirement for the analysis.
 - `maxExtension`: Maximum time beyond the floor to wait for target events.
 - `maxCalendarTime`: Absolute calendar-time deadline for an analysis.
 - `minTimeFromPreviousAnalysis`: Minimum elapsed time since the previous analysis.
 - `minN`: Minimum sample size enrolled before analysis.
-- `minNPerStratum`: Matrix of minimum enrollment by analysis and stratum.
-- `minFollowUp`: Minimum follow-up after `minN` is reached.
+- `minNPerStratum`: Matrix of minimum enrollment by analysis and stratum;
+  `NA` deactivates only the corresponding stratum requirement.
+- `minFollowUp`: Additional follow-up after active `minN` or
+  `minNPerStratum` requirements are reached. `NA` means no additional
+  follow-up, while a non-missing value requires an enrollment threshold at
+  the same analysis.
 - `targetEventsPerStratum`: Matrix of event requirements by analysis and
-  stratum.
+  stratum; `NA` deactivates only the corresponding stratum requirement.
+
+Each analysis must retain at least one active floor or event requirement.
+The mixed-`NA` convention is specific to timing rules. For selective bounds,
+use `FALSE` rather than `NA` in `testUpper`, `testLower`, or `testHarm`.
+Spending-time inputs (`informationRates`, `usTime`, and `lsTime`) describe a
+complete spending schedule and therefore must not contain `NA`.
 
 When multiple criteria apply to a single analysis, the analysis time is the
 maximum of all floor criteria and all overall or per-stratum event-target
@@ -433,8 +445,9 @@ data.frame(
   Custom spending times can also be passed via `usTime` and `lsTime`, but they
   are ignored for the latter two modes.
 
-- **`informationRates`**: Planned information-fraction caps (vector of
-  length `k`). At each analysis, the effective spending time is
+- **`informationRates`**: Planned information-fraction caps (complete vector
+  of length `k`, without missing values). At each analysis, the effective
+  spending time is
   `pmin(informationRates, actual_timing)`. Thus, spending cannot run ahead of
   either the planned information schedule or the information actually
   accumulated. `informationRates` takes precedence over `spending`, `usTime`,

--- a/vignettes/gsSurvPower.Rmd
+++ b/vignettes/gsSurvPower.Rmd
@@ -134,7 +134,7 @@ rules:
 | Information fractions and spending inputs unchanged | Reuse the bounds from `x` |
 | Only alpha or the upper spending function changes, with timing unchanged | Preserve the bounds from `x`, clipping only if a lower bound exceeds the new efficacy bound |
 | Information fractions or spending times change | Recompute the bounds on the new schedule using design beta, `hr1`, `sfl`, and `sflpar` |
-| `informationRates`, calendar spending, or `lsTime` is supplied | Derive the selected lower effective spending-time vector and recompute the bounds |
+| `informationRates`, calendar or planned-versus-actual spending, or `lsTime` is supplied | Derive the selected lower effective spending-time vector and recompute the bounds |
 
 Thus, changing `hr` with fixed event targets generally preserves the original
 information fractions and futility bounds. Changing `hr` at fixed calendar
@@ -191,8 +191,8 @@ sensitivity analyses:
   This gives an "unconditional" power that reflects how the assumed
   treatment effect influences event accrual.
 
-- **`targetEvents`** fixes the event count at each analysis. The calendar
-  time is the time until expected events reach the target under the
+- **`targetEvents`** fixes the overall event count at each analysis. The
+  calendar time is the time until expected events reach the target under the
   assumed HR. Since the event counts are held
   constant, the information fractions do not change with HR, and the
   resulting power matches the `gsDesign` power plot (`plot(x, plottype = 2)`)
@@ -213,16 +213,27 @@ analysis proceeds with fewer expected events than targeted. Other applicable
 floor criteria can require an even later analysis, subject to the same hard
 extension cap.
 
+`maxCalendarTime` supplies a different kind of deadline: it is an absolute
+calendar-time cap rather than an extension measured from a timing anchor.
+After combining all floor and event requirements, the expected analysis time
+is capped at `maxCalendarTime`. If both `maxExtension` and `maxCalendarTime`
+are supplied, the earlier deadline applies. This distinction preserves the
+existing meaning of `maxExtension` while matching the absolute-cap behavior of
+simtrial's `max_extension_for_target_event`.
+
 ### Quick decision guide
 
 | Operational rule | Argument | Interpretation |
 | --- | --- | --- |
 | Analyze at a calendar time | `plannedCalendarTime` | Exact time alone; earliest time when combined |
-| Analyze after an event target | `targetEvents` | Expected time the target is reached |
+| Analyze after an overall event target | `targetEvents` | Expected time the overall target is reached |
+| Require event targets by stratum | `targetEventsPerStratum` | Earliest time every active stratum target is reached |
 | Require spacing between looks | `minTimeFromPreviousAnalysis` | Earliest time relative to the previous analysis |
 | Require enrollment plus follow-up | `minN`, `minFollowUp` | Earliest time satisfying both criteria |
+| Require enrollment by stratum plus follow-up | `minNPerStratum`, `minFollowUp` | Earliest time every active stratum requirement plus follow-up is met |
 | Require final minimum follow-up | explicit `minfup` | Final-analysis floor after enrollment ends |
-| Stop waiting after a deadline | `maxExtension` | Hard cap on extension beyond its timing anchor |
+| Cap delay relative to a timing anchor | `maxExtension` | Relative hard cap preserving the existing gsDesign convention |
+| Stop at an absolute calendar deadline | `maxCalendarTime` | Absolute hard cap, corresponding to simtrial cut behavior |
 
 For scenario analyses, override only the assumptions that change:
 
@@ -240,16 +251,49 @@ Additional criteria can be combined per-analysis, each specified as a scalar
 "not applicable":
 
 - `maxExtension`: Maximum time beyond the floor to wait for target events.
+- `maxCalendarTime`: Absolute calendar-time deadline for an analysis.
 - `minTimeFromPreviousAnalysis`: Minimum elapsed time since the previous analysis.
 - `minN`: Minimum sample size enrolled before analysis.
+- `minNPerStratum`: Matrix of minimum enrollment by analysis and stratum.
 - `minFollowUp`: Minimum follow-up after `minN` is reached.
+- `targetEventsPerStratum`: Matrix of event requirements by analysis and
+  stratum.
 
 When multiple criteria apply to a single analysis, the analysis time is the
-maximum of all floor criteria, with `targetEvents` potentially extending
-beyond the floor. `maxExtension` defines a hard deadline: the analysis time never
+maximum of all floor criteria and all overall or per-stratum event-target
+times. Thus, active requirements use AND logic. `maxExtension` defines a hard
+deadline: the analysis time never
 exceeds `plannedCalendarTime + maxExtension` (or `T[i-1] + maxExtension`
 when no calendar time is specified), even if other criteria such as
-`minTimeFromPreviousAnalysis` or `minN + minFollowUp` would push it later.
+`minTimeFromPreviousAnalysis` or enrollment plus follow-up would push it
+later. `maxCalendarTime` is then applied as an absolute cap.
+
+### Relationship to simtrial analysis cuts
+
+The timing grammar intentionally parallels
+[`simtrial::get_analysis_date()`](https://merck.github.io/simtrial/reference/get_analysis_date.html),
+with camel-case names and one value per planned analysis. The main distinction
+is conceptual: `gsSurvPower()` applies the rules to expected event and
+enrollment counts, whereas simtrial applies them to a realized simulated data
+set. Consequently, matching rules do not imply identical analysis dates in any
+one simulated trial.
+
+| simtrial cut argument | `gsSurvPower()` argument | Relationship |
+| --- | --- | --- |
+| `planned_calendar_time` | `plannedCalendarTime` | Calendar-time floor when combined |
+| `target_event_overall` | `targetEvents` | Overall event requirement |
+| `target_event_per_stratum` | `targetEventsPerStratum` | Per-stratum requirement; rows index analyses and columns index strata |
+| `min_time_after_previous_analysis` | `minTimeFromPreviousAnalysis` | Minimum gap from the preceding analysis |
+| `min_n_overall` | `minN` | Overall enrollment requirement |
+| `min_n_per_stratum` | `minNPerStratum` | Per-stratum enrollment requirement; rows index analyses and columns index strata |
+| `min_followup` | `minFollowUp` | Follow-up after all active enrollment requirements |
+| `max_extension_for_target_event` | `maxCalendarTime` | Absolute calendar cap, despite the simtrial argument's name |
+
+simtrial specifies one cut at a time and therefore uses a named vector for its
+per-stratum requirements. `gsSurvPower()` specifies all `k` analyses in one
+call and uses a `k`-by-`nstrata` matrix; use `NA` for an inactive stratum at a
+look. `maxExtension` remains available for the older gsDesign relative-cap
+convention and has no exact simtrial counterpart.
 
 ### Common timing pitfalls
 
@@ -333,6 +377,15 @@ pwr_extension <- gsSurvPower(
 round(pwr_extension$T, 1)
 ```
 
+**`maxCalendarTime` is an absolute date, not a duration.** Use it when the
+operational rule is "analyze no later than month 30," including when there is
+an event requirement but no natural floor from which to measure an extension.
+If a target or floor is not reached by that date, the analysis proceeds at the
+cap under the expected-value calculation. This matches how simtrial applies
+`max_extension_for_target_event`, despite the latter argument's name. When a
+relative extension and an absolute deadline are both part of the plan, supply
+both cap arguments; the earlier one controls.
+
 **`minN + minFollowUp` can define analysis timing, but analyses must remain
 strictly increasing.** This pair says: wait until at least `minN` subjects
 are enrolled, then wait `minFollowUp` additional time. It can be used as the
@@ -340,6 +393,10 @@ primary timing rule, but the resulting analysis times and expected event
 totals must increase across analyses. If two analyses use the same enrollment
 threshold and follow-up rule, add `plannedCalendarTime`, `targetEvents`, or
 `minTimeFromPreviousAnalysis` to separate them.
+
+For a stratified plan, replace or supplement `minN` with a
+`minNPerStratum` matrix. The follow-up clock starts after the last active
+overall or per-stratum enrollment threshold is reached.
 
 ```{r timing_pitfall_minn}
 pwr_min_n <- gsSurvPower(
@@ -365,11 +422,16 @@ data.frame(
 
 ### Spending and method
 
-- **`spending`**: One of `"information"` (default) or `"calendar"`.
+- **`spending`**: One of `"information"` (default), `"calendar"`, or
+  `"min_planned_actual"`.
   Information-based spending tracks the fraction of statistical information
   accumulated; calendar-based spending sets `usTime = lsTime = T / max(T)`.
+  With a reference design `x`, planned-versus-actual spending sets both
+  spending-time vectors to
+  `pmin(x$n.I, actual events) / x$n.I[k]`, matching simtrial's
+  `ia_alpha_spending = "min_planned_actual"` convention.
   Custom spending times can also be passed via `usTime` and `lsTime`, but they
-  are ignored when `spending = "calendar"`.
+  are ignored for the latter two modes.
 
 - **`informationRates`**: Planned information-fraction caps (vector of
   length `k`). At each analysis, the effective spending time is
@@ -391,13 +453,21 @@ data.frame(
   When `x` is provided, `x$n.fix` and, implicitly, $\theta$ are used directly for
   exact consistency with the design.
 
-### Stratified targetEvents
+### Stratified timing arguments
 
 `targetEvents` accepts a scalar (recycled), a vector of length `k`
-(one overall target per analysis), or a matrix with `k` rows and
-`nstrata` columns (per-stratum targets). A vector of length `k` is
-always interpreted as overall targets; to specify per-stratum targets
-for a single analysis, use a 1-row matrix.
+(one overall target per analysis). Use `targetEventsPerStratum` for a matrix
+with `k` rows and `nstrata` columns. A vector of length `k` is always
+interpreted as overall targets; to specify per-stratum targets for a single
+analysis, use a 1-row matrix. Overall and per-stratum event requirements can
+be supplied together, and the analysis waits for all active requirements
+unless a cap intervenes. A matrix passed to `targetEvents` remains accepted as
+a deprecated alias, but its entries are now enforced per stratum rather than
+being reduced to row sums.
+
+`minNPerStratum` uses the same matrix layout for enrollment requirements. When
+it is supplied with `minFollowUp`, the follow-up interval begins only after
+every active overall and per-stratum enrollment requirement has been reached.
 
 ## Power under alternative assumptions
 
@@ -613,12 +683,50 @@ The final analysis collects `r round(pwr_fast$n.I[design$k], 0)` events
 vs. the target of `r round(design$n.I[design$k], 0)`, and power rises to
 `r round(pwr_fast$power * 100, 1)`%.
 
-### Controlling effective spending time with informationRates
+### Controlling effective spending time
 
 When events fall short of the target (as in Scenario 1), the actual
-information fraction at each analysis may be lower than planned.
-By default, bounds are computed at the actual information fractions.
-The `informationRates` parameter supplies planned information-fraction caps.
+event count at each analysis may be lower than planned. By default, bounds are
+computed at the scenario's information fractions, `n.I / max(n.I)`, which
+always end at 1. With a reference design `x`,
+`spending = "min_planned_actual"` instead uses
+`pmin(x$n.I, scenario n.I) / x$n.I[k]`. This is the expected-value analogue of
+simtrial's planned-versus-actual spending option: spending cannot run ahead of
+the planned event count at a look or the events expected under the scenario.
+
+```{r min_planned_actual_spending}
+pwr_slow_min_spending <- gsSurvPower(
+  x = design,
+  gamma = design$gamma / 2,
+  targetEvents = design$n.I,
+  plannedCalendarTime = design$T,
+  minN = c(NA, total_N, total_N),
+  minFollowUp = c(NA, 2, 12),
+  maxExtension = c(3, 12, 20),
+  spending = "min_planned_actual"
+)
+
+data.frame(
+  Analysis = 1:design$k,
+  Planned_Events = round(design$n.I, 1),
+  Scenario_Events = round(pwr_slow_min_spending$n.I, 1),
+  Effective_Spending_Time = round(
+    pmin(design$n.I, pwr_slow_min_spending$n.I) / design$n.I[design$k],
+    3
+  )
+)
+```
+
+The same effective spending-time vector is used for the upper and lower
+bounds. Set `fullSpendingAtFinal = TRUE` to spend fully at the final analysis,
+corresponding to simtrial's `fa_alpha_spending = "full_alpha"`; leave it
+`FALSE` for information-fraction final spending.
+
+#### User-specified spending-time caps with `informationRates`
+
+For a spending schedule specified directly rather than through the reference
+design's planned event counts, `informationRates` supplies planned
+information-fraction caps.
 The effective spending time is
 `pmin(informationRates, actual_timing)` at each analysis. This prevents
 spending ahead of the planned information schedule when events arrive faster
@@ -971,13 +1079,15 @@ identical(pwr_cal$upper$bound, pwr_cal_override$upper$bound)
 
 When a trial enrolls patients from multiple strata with different event
 rates, you may want to specify per-stratum event targets rather than a
-single overall number. `targetEvents` accepts a matrix with `k` rows
-(analyses) and `nstrata` columns (strata). Row sums give the overall
-target used to solve each analysis time.
+single overall number. `targetEventsPerStratum` accepts a matrix with `k` rows
+(analyses) and `nstrata` columns (strata). The analysis waits until each
+non-`NA` entry in its row is reached. Because event rates can differ across
+strata, events in one stratum can exceed its requirement while the other
+stratum catches up; the overall count therefore need not equal the row sum.
 
 Consider a two-stratum design where stratum 1 has median survival of
-6 months and stratum 2 has 12 months. We target 30 events (20 + 10) at
-the interim and 60 events (40 + 20) at the final analysis:
+6 months and stratum 2 has 12 months. We require at least 20 and 10 events by
+stratum at the interim, and 40 and 20 events by stratum at the final analysis:
 
 ```{r stratified_events}
 # Per-stratum event targets: rows = analyses, columns = strata
@@ -992,26 +1102,27 @@ pwr_strat <- gsSurvPower(
   lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
   hr = 0.7, eta = 0.01,
   gamma = matrix(c(5, 5), ncol = 2), R = 12, ratio = 1,
-  targetEvents = event_matrix
+  targetEventsPerStratum = event_matrix
 )
 
-# The analysis times are solved so that total expected events
-# match the row sums of the target matrix
+# Every stratum requirement is met; one can be exceeded while another catches up.
+actual_events_by_stratum <- pwr_strat$eDC + pwr_strat$eDE
 data.frame(
   Analysis = 1:2,
   Target_Stratum1 = event_matrix[, 1],
+  Expected_Stratum1 = round(actual_events_by_stratum[, 1], 1),
   Target_Stratum2 = event_matrix[, 2],
-  Target_Total = rowSums(event_matrix),
-  Expected_Events = round(pwr_strat$n.I, 1),
+  Expected_Stratum2 = round(actual_events_by_stratum[, 2], 1),
+  Expected_Total = round(pwr_strat$n.I, 1),
   Calendar_Time = round(pwr_strat$T, 1)
 )
 
 cat("Power:", round(pwr_strat$power * 100, 1), "%\n")
 ```
 
-The matrix format is also used in the biomarker example below,
-where `lambdaC` and `gamma` vary by stratum but `plannedCalendarTime`
-drives the timing.
+The biomarker example below also uses matrix-valued `lambdaC` and `gamma` to
+represent strata, but its timing is driven by `plannedCalendarTime` rather
+than per-stratum targets.
 
 ### Biomarker subgroup to stratified design
 


### PR DESCRIPTION
## Summary

- add explicit overall and per-stratum event and enrollment timing requirements
- add an absolute calendar-time cap while retaining existing relative maxExtension behavior
- add planned-versus-actual spending aligned with simtrial
- correct multi-stratum matrix targetEvents semantics through a deprecated alias
- document the simtrial crosswalk and expected-versus-realized distinction

## Compatibility

- preserves the complete legacy positional argument order
- preserves scalar/vector targetEvents, minN, and maxExtension behavior
- preserves one-column matrix targetEvents behavior without a warning
- intentionally changes only multi-stratum matrix targetEvents handling so entries are enforced by stratum instead of reduced to row sums

## Validation

- focused gsSurvPower tests: 214 assertions passed
- full package suite: 3,209 passed, 116 expected skips, 0 failures, 0 warnings
- R CMD check --as-cran --no-manual: Status OK
- clean source build and vignette rebuild passed
