### PR TITLE
Type and retain gsSurvPower inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+- `gsSurvPower()` results now have primary class `"gsSurvPower"` while
+  retaining inheritance from `"gsSurv"` and `"gsDesign"`. They also retain
+  evaluated, replayable arguments in `inputs`, enabling downstream packages to
+  identify and reproduce power calculations.
 - `gsSurvPower()` now aligns its expected analysis-cut grammar with
   `simtrial::get_analysis_date()`: overall and per-stratum event and enrollment
   requirements can be combined, `maxCalendarTime` provides an absolute cap,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 
 ## New features
 
-- `gsSurvPower()` results now have primary class `"gsSurvPower"` while
-  retaining inheritance from `"gsSurv"` and `"gsDesign"`. They also retain
+- `gsSurvPower()` results now have primary class "gsSurvPower" while
+  retaining inheritance from "gsSurv" and "gsDesign". They also retain
   evaluated, replayable arguments in `inputs`, enabling downstream packages to
-  identify and reproduce power calculations.
+  identify and reproduce power calculations (#313).
 - `gsSurvPower()` now aligns its expected analysis-cut grammar with
   `simtrial::get_analysis_date()`: overall and per-stratum event and enrollment
   requirements can be combined, `maxCalendarTime` provides an absolute cap,

--- a/R/gsSurvPower.R
+++ b/R/gsSurvPower.R
@@ -328,7 +328,8 @@
 #' @param tol Tolerance for \code{\link[stats]{uniroot}} when solving for
 #'   analysis times.
 #'
-#' @return An object of class \code{c("gsSurv", "gsDesign")} containing:
+#' @return An object of class
+#'   \code{c("gsSurvPower", "gsSurv", "gsDesign")} containing:
 #' \item{k}{Number of analyses.}
 #' \item{n.I}{Total expected events at each analysis.}
 #' \item{timing}{Information fractions at each analysis.}
@@ -345,8 +346,13 @@
 #'   under the assumed HR).}
 #' \item{beta}{Type II error (\code{1 - power}).}
 #' \item{variable}{Always \code{"Power"}.}
-#' \item{test.type, alpha, sided, method, spending, call}{Design settings used
-#'   for the power calculation.}
+#' \item{test.type, alpha, sided, method, spending, call}{Design settings and
+#'   the original call used for the power calculation.}
+#' \item{inputs}{Evaluated arguments supplied to \code{gsSurvPower()}. The
+#'   calculation can be reproduced under the same package version with
+#'   \code{do.call(gsSurvPower, inputs)}. When \code{x} is supplied, the
+#'   evaluated reference design is retained so that inherited design settings
+#'   and planned-versus-actual spending can be reproduced.}
 #' \item{informationRates, fullSpendingAtFinal}{Planned information-fraction
 #'   caps and final effective-spending-time setting used for bound spending.}
 #' \item{testUpper, testLower, testHarm}{Logical indicators of which analyses
@@ -442,6 +448,11 @@ gsSurvPower <- function(
   spending <- match.arg(spending)
   call_object <- match.call()
   call_args <- as.list(call_object)
+  input_arguments <- mget(
+    names(call_object)[-1],
+    envir = environment(),
+    inherits = FALSE
+  )
 
   # Track whether user explicitly provided alpha; used below to decide
   # whether the gsSurv alpha/sided convention applies.
@@ -711,7 +722,8 @@ gsSurvPower <- function(
     bound_result = bound_result,
     normalized_rates = normalized_rates,
     settings = settings,
-    call_object = call_object
+    call_object = call_object,
+    input_arguments = input_arguments
   )
 }
 
@@ -1598,7 +1610,8 @@ gsSurvPower <- function(
     bound_result,
     normalized_rates,
     settings,
-    call_object) {
+    call_object,
+    input_arguments) {
   result <- design_result
   result$n.I <- analysis_schedule$total_events
   result$T <- analysis_schedule$analysis_time
@@ -1627,6 +1640,7 @@ gsSurvPower <- function(
   result$informationRates <- settings$informationRates
   result$fullSpendingAtFinal <- settings$fullSpendingAtFinal
   result$call <- call_object
+  result$inputs <- input_arguments
   result$timing <- analysis_schedule$timing
   result$testUpper <- .gsSurvPower_format_test_flag(settings$testUpper, settings$k)
   result$testLower <- if (settings$k == 1) {
@@ -1657,6 +1671,6 @@ gsSurvPower <- function(
   result$power <- sum(bound_result$probabilities$upper$prob[, 2])
   result$beta <- 1 - result$power
 
-  class(result) <- c("gsSurv", "gsDesign")
+  class(result) <- c("gsSurvPower", "gsSurv", "gsDesign")
   gsSurvAddN(.gsSurvPower_label_output_matrices(result))
 }

--- a/man/gsSurvPower.Rd
+++ b/man/gsSurvPower.Rd
@@ -252,7 +252,8 @@ matrix with \code{k} rows and one column per stratum; \code{NA} omits a
 stratum requirement at an analysis.}
 }
 \value{
-An object of class \code{c("gsSurv", "gsDesign")} containing:
+An object of class
+  \code{c("gsSurvPower", "gsSurv", "gsDesign")} containing:
 \item{k}{Number of analyses.}
 \item{n.I}{Total expected events at each analysis.}
 \item{timing}{Information fractions at each analysis.}
@@ -269,8 +270,13 @@ An object of class \code{c("gsSurv", "gsDesign")} containing:
   under the assumed HR).}
 \item{beta}{Type II error (\code{1 - power}).}
 \item{variable}{Always \code{"Power"}.}
-\item{test.type, alpha, sided, method, spending, call}{Design settings used
-  for the power calculation.}
+\item{test.type, alpha, sided, method, spending, call}{Design settings and
+  the original call used for the power calculation.}
+\item{inputs}{Evaluated arguments supplied to \code{gsSurvPower()}. The
+  calculation can be reproduced under the same package version with
+  \code{do.call(gsSurvPower, inputs)}. When \code{x} is supplied, the
+  evaluated reference design is retained so that inherited design settings
+  and planned-versus-actual spending can be reproduced.}
 \item{informationRates, fullSpendingAtFinal}{Planned information-fraction
   caps and final effective-spending-time setting used for bound spending.}
 \item{testUpper, testLower, testHarm}{Logical indicators of which analyses

--- a/tests/testthat/test-gsSurvPower.R
+++ b/tests/testthat/test-gsSurvPower.R
@@ -8,6 +8,7 @@ test_that("gsSurvPower works with plannedCalendarTime from gsSurv design", {
   )
 
   pwr <- gsSurvPower(x = design, plannedCalendarTime = design$T)
+  expect_s3_class(pwr, "gsSurvPower")
   expect_s3_class(pwr, "gsSurv")
   expect_s3_class(pwr, "gsDesign")
   expect_equal(pwr$k, 3)
@@ -18,6 +19,67 @@ test_that("gsSurvPower works with plannedCalendarTime from gsSurv design", {
   expect_equal(pwr$hr, design$hr)
   expect_equal(pwr$hr1, design$hr)
   expect_equal(pwr$variable, "Power")
+})
+
+test_that("gsSurvPower retains evaluated inputs for direct reconstruction", {
+  pwr <- gsSurvPower(
+    k = 3,
+    test.type = 1,
+    lambdaC = matrix(log(2) / c(6, 12), ncol = 2),
+    hr = 0.7,
+    gamma = matrix(c(4, 6), ncol = 2),
+    R = 12,
+    plannedCalendarTime = c(12, NA, 36),
+    targetEvents = c(NA, 80, NA),
+    targetEventsPerStratum = matrix(
+      c(NA, NA, 20, 30, NA, NA), nrow = 3, byrow = TRUE
+    ),
+    maxExtension = c(NA, 6, NA),
+    maxCalendarTime = c(NA, 24, NA),
+    minTimeFromPreviousAnalysis = c(NA, 6, NA),
+    minN = c(100, NA, NA),
+    minNPerStratum = matrix(
+      c(40, 60, NA, NA, NA, NA), nrow = 3, byrow = TRUE
+    ),
+    minFollowUp = c(2, NA, NA)
+  )
+  saved_inputs <- unserialize(serialize(pwr$inputs, NULL))
+  rebuilt <- do.call(gsSurvPower, saved_inputs)
+
+  expect_s3_class(rebuilt, "gsSurvPower")
+  expect_identical(pwr$inputs$plannedCalendarTime, c(12, NA, 36))
+  expect_identical(
+    pwr$inputs$targetEventsPerStratum,
+    matrix(c(NA, NA, 20, 30, NA, NA), nrow = 3, byrow = TRUE)
+  )
+  expect_equal(rebuilt$T, pwr$T)
+  expect_equal(rebuilt$n.I, pwr$n.I)
+  expect_equal(rebuilt$upper$bound, pwr$upper$bound)
+  expect_equal(rebuilt$power, pwr$power)
+})
+
+test_that("gsSurvPower reconstruction retains its reference design", {
+  design <- gsSurv(
+    k = 3, test.type = 4, beta = 0.15,
+    lambdaC = log(2) / 12, hr = 0.7, eta = 0.01,
+    gamma = 10, R = 16, minfup = 12, T = 28
+  )
+  pwr <- gsSurvPower(
+    x = design,
+    hr = 0.8,
+    targetEvents = 0.9 * design$n.I,
+    spending = "min_planned_actual"
+  )
+  saved_inputs <- unserialize(serialize(pwr$inputs, NULL))
+  rebuilt <- do.call(gsSurvPower, saved_inputs)
+
+  expect_identical(pwr$inputs$x, design)
+  expect_identical(pwr$inputs$targetEvents, 0.9 * design$n.I)
+  expect_equal(rebuilt$T, pwr$T)
+  expect_equal(rebuilt$n.I, pwr$n.I)
+  expect_equal(rebuilt$upper$bound, pwr$upper$bound)
+  expect_equal(rebuilt$lower$bound, pwr$lower$bound)
+  expect_equal(rebuilt$power, pwr$power)
 })
 
 test_that("gsSurvPower power decreases with worse HR", {


### PR DESCRIPTION
## Summary

- give `gsSurvPower()` results primary class `"gsSurvPower"` while retaining
  `"gsSurv"` and `"gsDesign"` inheritance
- retain evaluated, serializable call arguments in `inputs`, including a
  reference design when supplied
- document the replay contract and add a NEWS entry
- test serialized round trips for direct stratified/mixed-`NA` timing and
  reference-design planned-versus-actual spending

The calculation can be replayed under the same gsDesign version with:

```r
do.call(gsSurvPower, result$inputs)
```

This PR is stacked on #311 because one acceptance test exercises the timing
grammar added there. After #311 merges, this PR can be retargeted to
`GitHub/3.11.0-release`.

## Verification

- `devtools::document()`
- focused `tests/testthat/test-gsSurvPower.R`: 238 expectations, no failures
- full `testthat::test_dir("tests/testthat")`: no failures; expected CRAN and
  graphical tests skipped
- `git diff --check`

Downstream gsDesignBroom reconstruction support is tracked in
https://github.com/keaven/gsDesignBroom/issues/4.

Closes #313
