### PR TITLE
Reduce repeated work in the numerical integration recursion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,14 @@
   and skipped analyses. Use `is.finite()` to identify active bounds.
   `gsBoundCP()` returns `NA` at an absent bound (#242, #321).
 
+## Performance
+
+- Reduced repeated work in the C density update and boundary searches while
+  retaining the Jennison and Turnbull grid and numerical results. Research
+  benchmarks measured roughly 20% to 35% faster core routines. R's normal
+  tail calculations remain the default; `-DGS_USE_ERFC` enables an optional
+  C-library alternative.
+
 ## Bug fixes
 
 - Guarded the Newton boundary search against `0/0` updates and separated its

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
   retaining the Jennison and Turnbull grid and numerical results. Research
   benchmarks measured roughly 20% to 35% faster core routines. R's normal
   tail calculations remain the default; `-DGS_USE_ERFC` enables an optional
-  C-library alternative.
+  C-library alternative (#322).
 
 ## Bug fixes
 

--- a/src/gsDesign.h
+++ b/src/gsDesign.h
@@ -4,6 +4,19 @@
 /* 1 / sqrt(2 * pi): shared scale factor for standard normal density. */
 static const double gs_inv_sqrt_2pi = 0.3989422804014327;
 
+/* Standard normal lower/upper tail probability used in the boundary search
+   and the crossing probabilities. R's pnorm() is the reference; erfc() from
+   the C library is a faster alternative with equivalent accuracy on
+   platforms with a high quality libm (opt in with -DGS_USE_ERFC). */
+#ifdef GS_USE_ERFC
+#include <math.h>
+#define GS_PNORM_LOWER(x) (0.5 * erfc(-(x) * M_SQRT1_2))
+#define GS_PNORM_UPPER(x) (0.5 * erfc((x) * M_SQRT1_2))
+#else
+#define GS_PNORM_LOWER(x) pnorm((x), 0., 1., 1, 0)
+#define GS_PNORM_UPPER(x) pnorm((x), 0., 1., 0, 0)
+#endif
+
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
              double *probhi, double *xtol, int *xr, int *retval, int *printerr);
 void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
@@ -14,5 +27,13 @@ void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
                double *a, double *b, double *xz, int *zlen, int *xr);
 void stdnorpts(int *r, double *bounds, double *z, double *w);
+int gridpts(int r, double mu, double a, double b, double *z, double *w);
+void h1(double theta, int m, double *wgt, double I, double *z, double *h);
+void hupdate(double theta, double *wgt, int m1, double Ikm1, double *zkm1,
+             double *hkm1, int m2, double Ik, double *zk, double *hk);
+double probneg(double theta, int m, double ak, double *z, double *h,
+               double Ikm1, double Ik);
+double probpos(double theta, int m, double bk, double *z, double *h,
+               double Ikm1, double Ik);
 
 #endif

--- a/src/gsbound.c
+++ b/src/gsbound.c
@@ -14,32 +14,28 @@
 
 /**
  * @brief Compute group sequential Z-boundaries from target crossing
- * probabilities.
+ * probabilities under the null hypothesis.
  *
- * Uses the Jennison & Turnbull numerical integration grid (p. 349) and a
- * Newton-Raphson iteration to find lower and upper Z cutoffs for each analysis.
- * An analysis with a non-positive target probability has no bound on that
- * side: the corresponding cutoff is returned as `-Inf` (lower) or `+Inf`
- * (upper) and the Newton iteration is skipped for that side.
- * This routine is written with pointer arguments to support calling via R's
- * `.C()` interface; callers must pass `NAOK = TRUE` so that infinite values
- * can be exchanged with R.
+ * Newton-Raphson iteration for lower and upper Z cutoffs at each analysis
+ * (Jennison & Turnbull, 2000, Section 19.4.1). An analysis with a
+ * non-positive target probability has no bound on that side: the cutoff is
+ * returned as `-Inf` (lower) or `+Inf` (upper) and the iteration is skipped
+ * for that side. Written with pointer arguments for R's `.C()` interface
+ * (call with `NAOK = TRUE`).
  *
  * @param[in] xnanal Number of analyses (`nanal = xnanal[0]`).
  * @param[in] I Statistical information at each analysis (length `nanal`).
  * @param[out] a Lower Z cutoffs at each analysis (length `nanal`).
  * @param[out] b Upper Z cutoffs at each analysis (length `nanal`).
- * @param[in] problo Target probability of crossing the lower boundary at each
- *   analysis (length `nanal`); a value `<= 0` means no lower bound.
- * @param[in] probhi Target probability of crossing the upper boundary at each
- *   analysis (length `nanal`); a value `<= 0` means no upper bound.
- * @param[in] xtol Relative convergence tolerance (`tol = xtol[0]`).
- * @param[in] xr Grid parameter controlling the number of integration points
- *   (`r = xr[0]`).
- * @param[out] retval Error flag (`retval[0]`): 0 on success, 1 on illegal
- *   arguments or failure to converge.
- * @param[in] printerr If non-zero (`printerr[0] != 0`), print diagnostics via
- *   `Rprintf()`.
+ * @param[in] problo Target lower crossing probabilities; `<= 0` means no
+ *   lower bound at that analysis.
+ * @param[in] probhi Target upper crossing probabilities; `<= 0` means no
+ *   upper bound at that analysis.
+ * @param[in] xtol Convergence tolerance on the bounds (`tol = xtol[0]`).
+ * @param[in] xr Grid parameter (`r = xr[0]`).
+ * @param[out] retval Error flag: 0 on success, 1 on illegal arguments or
+ *   failure to converge.
+ * @param[in] printerr If non-zero, print diagnostics via `Rprintf()`.
  * @return Nothing.
  */
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
@@ -47,15 +43,11 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
              int *printerr) {
   int i, ii, j, m1, m2, r, nanal, lo_active, hi_active;
   double plo, phi, dplo, dphi, btem = 0., atem = 0., atem2, btem2, rtdeltak,
-                               rtIk, rtIkm1, xlo, xhi;
+                               rtIk, rtIkm1, xlo, xhi, scale;
   double adelta, bdelta, tol;
   /* note: should allocate zwk & wwk dynamically...*/
   double zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000], hwk2[1000],
       *z1, *z2, *w1, *w2, *h, *h2, *tem;
-  void h1(double, int, double *, double, double *, double *);
-  void hupdate(double, double *, int, double, double *, double *, int, double,
-               double *, double *);
-  int gridpts(int, double, double, double, double *, double *);
   r = xr[0];
   nanal = xnanal[0];
   tol = xtol[0];
@@ -80,6 +72,10 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
     b[0] = R_PosInf;
   else
     b[0] = qnorm(probhi[0], 0., 1., 0, 0);
+  if (nanal == 1) {
+    retval[0] = 0;
+    return;
+  }
   /* set up work vectors */
   z1 = zwk;
   w1 = wwk;
@@ -95,6 +91,7 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
     rtIkm1 = rtIk;
     rtIk = sqrt(I[i]);
     rtdeltak = sqrt(I[i] - I[i - 1]);
+    scale = gs_inv_sqrt_2pi * rtIk / rtdeltak;
     lo_active = problo[i] > 0.;
     hi_active = probhi[i] > 0.;
     atem2 = lo_active ? qnorm(problo[i], 0., 1., 1, 0) : R_NegInf;
@@ -115,16 +112,18 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
       if (lo_active) {
         for (ii = 0; ii <= m1; ii++) {
           xlo = (z1[ii] * rtIkm1 - atem * rtIk) / rtdeltak;
-          plo += h[ii] * pnorm(xlo, 0., 1., 0, 0);
-          dplo += h[ii] * exp(-xlo * xlo / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
+          plo += h[ii] * GS_PNORM_UPPER(xlo);
+          dplo += h[ii] * exp(-xlo * xlo / 2);
         }
+        dplo *= scale;
       }
       if (hi_active) {
         for (ii = 0; ii <= m1; ii++) {
           xhi = (z1[ii] * rtIkm1 - btem * rtIk) / rtdeltak;
-          phi += h[ii] * pnorm(xhi, 0., 1., 1, 0);
-          dphi -= h[ii] * exp(-xhi * xhi / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
+          phi += h[ii] * GS_PNORM_LOWER(xhi);
+          dphi -= h[ii] * exp(-xhi * xhi / 2);
         }
+        dphi *= scale;
       }
       /* use 1st order Taylor's series to update boundaries */
       /* maximum allowed change is 1 */

--- a/src/gsbound1.c
+++ b/src/gsbound1.c
@@ -13,44 +13,38 @@
  *
  * For a given drift parameter @p xtheta and fixed lower cutoffs @p a, finds the
  * upper cutoffs @p b that match the target upper-tail crossing probabilities
- * @p probhi. The implied lower-tail crossing probabilities are returned in
- * @p problo. An analysis with a non-positive target has no upper bound: `+Inf`
- * is returned and the Newton iteration is skipped. Lower cutoffs may be
- * `-Inf` (no lower bound). This routine is written with pointer arguments to
- * support calling via R's `.C()` interface; callers must pass `NAOK = TRUE`
- * so that infinite values can be exchanged with R.
+ * @p probhi by Newton-Raphson iteration (Jennison & Turnbull, 2000, Section
+ * 19.4.1). The implied lower-tail crossing probabilities are returned in
+ * @p problo; they do not depend on the iterate and are evaluated once per
+ * analysis. An analysis with a non-positive target has no upper bound: `+Inf`
+ * is returned and the iteration is skipped. Lower cutoffs may be `-Inf`.
+ * Written with pointer arguments for R's `.C()` interface (call with
+ * `NAOK = TRUE`).
  *
  * @param[in] xnanal Number of analyses (`nanal = xnanal[0]`).
  * @param[in] xtheta Drift parameter (`theta = xtheta[0]`).
  * @param[in] I Statistical information at each analysis (length `nanal`).
  * @param[in] a Fixed lower Z cutoffs at each analysis (length `nanal`).
  * @param[out] b Upper Z cutoffs at each analysis (length `nanal`).
- * @param[out] problo Output vector of lower-tail crossing probabilities (length
- *   `nanal`).
+ * @param[out] problo Lower-tail crossing probabilities (length `nanal`).
  * @param[in] probhi Target upper-tail crossing probabilities (length `nanal`);
  *   a value `<= 0` means no upper bound.
- * @param[in] xtol Relative convergence tolerance (`tol = xtol[0]`).
- * @param[in] xr Grid parameter controlling the number of integration points
- *   (`r = xr[0]`).
- * @param[out] retval Error flag (`retval[0]`): 0 on success, 1 on illegal
- *   arguments or failure to converge.
- * @param[in] printerr If non-zero (`printerr[0] != 0`), print diagnostics via
- *   `Rprintf()`.
+ * @param[in] xtol Convergence tolerance on the bound (`tol = xtol[0]`).
+ * @param[in] xr Grid parameter (`r = xr[0]`).
+ * @param[out] retval Error flag: 0 on success, 1 on illegal arguments or
+ *   failure to converge.
+ * @param[in] printerr If non-zero, print diagnostics via `Rprintf()`.
  * @return Nothing.
  */
 void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
               double *problo, double *probhi, double *xtol, int *xr,
               int *retval, int *printerr) {
   int i, ii, j, m1, m2, r, nanal, hi_active;
-  double plo = 0., phi, dphi, btem = 0., btem2, rtdeltak, rtIk, rtIkm1, xlo,
-         xhi, theta, mu, tol, bdelta;
+  double plo, phi, dphi, btem = 0., btem2, rtdeltak, rtIk, rtIkm1, xlo, xhi,
+                             theta, mu, tol, bdelta, drift, scale;
   /* note: should allocate zwk & wwk dynamically...*/
   double zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000], hwk2[1000],
       *z1, *z2, *w1, *w2, *h, *h2, *tem;
-  void h1(double, int, double *, double, double *, double *);
-  void hupdate(double, double *, int, double, double *, double *, int, double,
-               double *, double *);
-  int gridpts(int, double, double, double, double *, double *);
   r = xr[0];
   nanal = xnanal[0];
   theta = xtheta[0];
@@ -69,8 +63,7 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
   }
   rtIk = sqrt(I[0]);
   mu = rtIk * theta; /* mean of normalized statistic at 1st interim */
-  problo[0] = pnorm(mu - a[0], 0., 1., 0,
-                    0); /* probability of crossing lower bound at 1st interim */
+  problo[0] = GS_PNORM_UPPER(mu - a[0]); /* crossing lower bound at 1st interim */
   if (probhi[0] <= 0.)
     b[0] = R_PosInf;
   else
@@ -86,8 +79,6 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
   z2 = zwk2;
   w2 = wwk2;
   h2 = hwk2;
-  if (DEBUG)
-    Rprintf("r=%d mu=%lf a[0]=%lf b[0]=%lf\n", r, mu, a[0], b[0]);
   m1 = gridpts(r, mu, a[0], b[0], z1, w1);
   h1(theta, m1, w1, I[0], z1, h);
   /* use Newton-Raphson to find subsequent interim analysis cutpoints */
@@ -97,6 +88,8 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
     rtIk = sqrt(I[i]);
     mu = rtIk * theta;
     rtdeltak = sqrt(I[i] - I[i - 1]);
+    drift = theta * (I[i] - I[i - 1]);
+    scale = gs_inv_sqrt_2pi * rtIk / rtdeltak;
     hi_active = probhi[i] > 0.;
     btem2 = hi_active ? qnorm(probhi[i], mu, 1., 0, 0) : R_PosInf;
     btem = btem2;
@@ -105,29 +98,17 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
     while ((bdelta > tol) && j++ < GS_MAXITER) {
       phi = 0.;
       dphi = 0.;
-      plo = 0.;
       btem = btem2;
-      if (DEBUG)
-        Rprintf("i=%d m1=%d\n", i, m1);
-      /* compute probability of crossing boundaries & their derivatives */
+      /* compute probability of crossing the upper boundary & its derivative */
       for (ii = 0; ii <= m1; ii++) {
-        xhi = (z1[ii] * rtIkm1 - btem * rtIk + theta * (I[i] - I[i - 1])) /
-              rtdeltak;
-        phi += pnorm(xhi, 0., 1., 1, 0) * h[ii];
-        xlo = (z1[ii] * rtIkm1 - a[i] * rtIk + theta * (I[i] - I[i - 1])) /
-              rtdeltak;
-        plo += pnorm(xlo, 0., 1., 0, 0) * h[ii];
-        dphi -= h[ii] * exp(-xhi * xhi / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
-        if (DEBUG)
-          Rprintf("m1=%d ii=%d xhi=%lf phi=%lf xlo=%lf plo=%lf dphi=%lf\n", m1,
-                  ii, xhi, phi, xlo, plo, dphi);
+        xhi = (z1[ii] * rtIkm1 - btem * rtIk + drift) / rtdeltak;
+        phi += GS_PNORM_LOWER(xhi) * h[ii];
+        dphi -= h[ii] * exp(-xhi * xhi / 2);
       }
+      dphi *= scale;
       /* use 1st order Taylor's series to update boundaries */
       /* maximum allowed change is 1 */
       /* an exact hit (or a vanishing derivative) leaves the iterate unchanged */
-      if (DEBUG)
-        Rprintf("i=%2d j=%2d plo=%lf btem=%lf phi=%lf dphi=%lf\n", i, j, plo,
-                btem, phi, dphi);
       bdelta = probhi[i] - phi;
       if (bdelta < dphi)
         btem2 = btem + 1.;
@@ -143,15 +124,11 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
         btem2 = -GS_ZCLAMP;
       bdelta = fabs(btem2 - btem);
     }
-    if (!hi_active) {
-      /* no upper bound at this analysis: only the lower-tail probability is
-         needed */
-      plo = 0.;
-      for (ii = 0; ii <= m1; ii++) {
-        xlo = (z1[ii] * rtIkm1 - a[i] * rtIk + theta * (I[i] - I[i - 1])) /
-              rtdeltak;
-        plo += pnorm(xlo, 0., 1., 0, 0) * h[ii];
-      }
+    /* lower-tail crossing probability for the fixed lower bound */
+    plo = 0.;
+    for (ii = 0; ii <= m1; ii++) {
+      xlo = (z1[ii] * rtIkm1 - a[i] * rtIk + drift) / rtdeltak;
+      plo += GS_PNORM_UPPER(xlo) * h[ii];
     }
     b[i] = btem;
     problo[i] = plo;

--- a/src/gsdensity.c
+++ b/src/gsdensity.c
@@ -4,19 +4,16 @@
 
 /**
  * @brief Compute the sub-density of the Z statistic under group sequential
- * boundaries.
+ * boundaries (Jennison & Turnbull, 2000, Section 19.2, `g_k`).
  *
- * Returns the density of the standardized statistic evaluated at @p xz for each
- * drift value in @p xtheta. For multi-analysis designs (`xnanal[0] > 1`), this
- * is a sub-density (it integrates to less than 1) because probability mass is
- * removed by boundary crossing at earlier analyses.
+ * Returns the density of the standardized statistic evaluated at @p xz for
+ * each drift value in @p xtheta. For multi-analysis designs (`xnanal[0] > 1`)
+ * this is a sub-density because probability mass is removed by boundary
+ * crossing at earlier analyses. Bounds may be infinite. Written with pointer
+ * arguments for R's `.C()` interface (call with `NAOK = TRUE`).
  *
- * This routine is written with pointer arguments to support calling via R's
- * `.C()` interface.
- *
- * @param[out] den Output densities of length `ntheta[0] * zlen[0]`. Results are
- *   stored in `ntheta[0]` contiguous blocks of length `zlen[0]`, one block per
- *   drift value.
+ * @param[out] den Output densities of length `ntheta[0] * zlen[0]`, stored
+ *   in `ntheta[0]` contiguous blocks of length `zlen[0]`.
  * @param[in] xnanal Number of analyses (`nanal = xnanal[0]`).
  * @param[in] ntheta Number of drift values (`ntheta = ntheta[0]`).
  * @param[in] xtheta Drift values (length `ntheta`).
@@ -25,8 +22,7 @@
  * @param[in] b Upper Z cutoffs at each analysis (length `nanal`).
  * @param[in] xz Z values where the density is evaluated (length `zlen[0]`).
  * @param[in] zlen Length of @p xz (`nz = zlen[0]`).
- * @param[in] xr Grid parameter controlling the number of integration points
- *   (`r = xr[0]`).
+ * @param[in] xr Grid parameter (`r = xr[0]`).
  * @return Nothing.
  */
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
@@ -35,14 +31,10 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
   double z, mu, theta;
   double *zwk, *wwk, *hwk, *zwk2, *wwk2, *hwk2;
   double *z1, *z2, *w1, *w2, *h, *h2, *tem;
-  void h1(double, int, double *, double, double *, double *);
-  void hupdate(double, double *, int, double, double *, double *, int, double,
-               double *, double *);
-  int gridpts(int, double, double, double, double *, double *);
   r = xr[0];
   nanal = xnanal[0];
   nz = zlen[0];
-  wklen = r * 12 - 3;
+  wklen = 1000; /* work storage matching the other entry points */
   if (wklen < nz)
     wklen = nz;
   /* if density is at 1st analysis, just return normal density */
@@ -81,9 +73,9 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
     /* update h and compute rejection probabilities at each interim */
     for (i = 1; i < nanal; i++) {
       mu = theta * sqrt(I[i]);
-      if (i < nanal - 1)
+      if (i < nanal - 1) {
         m2 = gridpts(r, mu, a[i], b[i], z2, w2);
-      else {
+      } else {
         m2 = nz - 1;
         z2 = xz;
         h2 = den + k * nz;

--- a/src/hupdate.c
+++ b/src/hupdate.c
@@ -1,43 +1,47 @@
 #include "gsDesign.h"
 #include <math.h>
-#include <stdio.h>
 
 /**
  * @brief Propagate weighted densities from one analysis to the next.
  *
  * Updates the weighted density vector @p hk on a new grid @p zk at information
  * time @p Ik, given the previous grid @p zkm1 and weighted densities @p hkm1 at
- * information time @p Ikm1. The update performs the normal transition integral
- * used in the Jennison & Turnbull group sequential computations.
+ * information time @p Ikm1 (Jennison & Turnbull, 2000, equation 19.4 and the
+ * recursion for `h_k` on p. 347). Per-point constants are computed once so
+ * that the inner loop consists of one subtraction, one multiplication, one
+ * exponential and one fused multiply-add per pair of grid points.
  *
  * @param[in] theta Drift parameter.
  * @param[in] wgt Integration weights for the new grid @p zk (length `m2 + 1`).
  * @param[in] m1 Last valid index in @p zkm1 and @p hkm1.
  * @param[in] Ikm1 Statistical information at the previous analysis.
  * @param[in] zkm1 Grid points at the previous analysis (length `m1 + 1`).
- * @param[in] hkm1 Weighted densities at the previous analysis (length `m1 +
- * 1`).
+ * @param[in] hkm1 Weighted densities at the previous analysis.
  * @param[in] m2 Last valid index in @p zk and @p hk.
  * @param[in] Ik Statistical information at the new analysis.
  * @param[in] zk Grid points at the new analysis (length `m2 + 1`).
- * @param[out] hk Output weighted densities at the new analysis (length `m2 +
- * 1`).
+ * @param[out] hk Output weighted densities at the new analysis.
  * @return Nothing.
  */
 void hupdate(double theta, double *wgt, int m1, double Ikm1, double *zkm1,
              double *hkm1, int m2, double Ik, double *zk, double *hk) {
-  double deltak, x, rtIk, rtIkm1, rtdeltak;
+  double deltak, rtIk, rtIkm1, rtdeltak, scale, u, x, s;
+  double c[1000]; /* scaled previous grid, fixed-size work storage */
   int i, ii;
   deltak = Ik - Ikm1; /* incremental information */
   rtdeltak = sqrt(deltak);
   rtIk = sqrt(Ik);
   rtIkm1 = sqrt(Ikm1);
+  scale = gs_inv_sqrt_2pi * rtIk / rtdeltak;
+  for (ii = 0; ii <= m1; ii++)
+    c[ii] = (zkm1[ii] * rtIkm1 + theta * deltak) / rtdeltak;
   for (i = 0; i <= m2; i++) {
-    hk[i] = 0.;
+    u = zk[i] * rtIk / rtdeltak;
+    s = 0.;
     for (ii = 0; ii <= m1; ii++) {
-      x = (zk[i] * rtIk - zkm1[ii] * rtIkm1 - theta * deltak) / rtdeltak;
-      hk[i] += hkm1[ii] * exp(-x * x / 2) * gs_inv_sqrt_2pi * rtIk / rtdeltak;
+      x = u - c[ii];
+      s += hkm1[ii] * exp(-0.5 * x * x);
     }
-    hk[i] *= wgt[i];
+    hk[i] = wgt[i] * scale * s;
   }
 }

--- a/src/probpos.c
+++ b/src/probpos.c
@@ -1,23 +1,19 @@
 #include "R.h"
 #include "Rmath.h"
+#include "gsDesign.h"
 
 /**
  * @brief Compute probability of crossing the lower boundary at the next
- * analysis.
- *
- * Given a weighted density representation on the previous analysis grid, this
- * computes the (approximate) probability of crossing a lower Z boundary at the
- * next information time.
+ * analysis (Jennison & Turnbull, 2000, equation 19.8 with `1 - e_{k-1}`).
  *
  * @param[in] theta Drift parameter.
  * @param[in] m Last valid index in @p z and @p h.
- * @param[in] ak Lower Z boundary at the next analysis.
+ * @param[in] ak Lower Z boundary at the next analysis (may be `-Inf`).
  * @param[in] z Grid points at the previous analysis (length `m + 1`).
  * @param[in] h Weighted densities at the previous analysis (length `m + 1`).
  * @param[in] Ikm1 Statistical information at the previous analysis.
  * @param[in] Ik Statistical information at the next analysis.
- * @return Approximate probability of crossing the lower boundary at the next
- * analysis.
+ * @return Approximate probability of crossing the lower boundary.
  */
 double probneg(double theta, int m, double ak, double *z, double *h,
                double Ikm1, double Ik) {
@@ -30,28 +26,23 @@ double probneg(double theta, int m, double ak, double *z, double *h,
   prob = 0.;
   for (i = 0; i <= m; i++) {
     x = (z[i] * rtIkm1 + mu - ak * rtIk) / rtdeltak;
-    prob += pnorm(x, 0., 1., 0, 0) * h[i];
+    prob += GS_PNORM_UPPER(x) * h[i];
   }
   return (prob);
 }
 
 /**
  * @brief Compute probability of crossing the upper boundary at the next
- * analysis.
- *
- * Given a weighted density representation on the previous analysis grid, this
- * computes the (approximate) probability of crossing an upper Z boundary at the
- * next information time.
+ * analysis (Jennison & Turnbull, 2000, equation 19.8).
  *
  * @param[in] theta Drift parameter.
  * @param[in] m Last valid index in @p z and @p h.
- * @param[in] bk Upper Z boundary at the next analysis.
+ * @param[in] bk Upper Z boundary at the next analysis (may be `Inf`).
  * @param[in] z Grid points at the previous analysis (length `m + 1`).
  * @param[in] h Weighted densities at the previous analysis (length `m + 1`).
  * @param[in] Ikm1 Statistical information at the previous analysis.
  * @param[in] Ik Statistical information at the next analysis.
- * @return Approximate probability of crossing the upper boundary at the next
- * analysis.
+ * @return Approximate probability of crossing the upper boundary.
  */
 double probpos(double theta, int m, double bk, double *z, double *h,
                double Ikm1, double Ik) {
@@ -64,7 +55,7 @@ double probpos(double theta, int m, double bk, double *z, double *h,
   prob = 0.;
   for (i = 0; i <= m; i++) {
     x = (z[i] * rtIkm1 + mu - bk * rtIk) / rtdeltak;
-    prob += pnorm(x, 0., 1., 1, 0) * h[i];
+    prob += GS_PNORM_LOWER(x) * h[i];
   }
   return (prob);
 }

--- a/src/rprobrej.c
+++ b/src/rprobrej.c
@@ -6,10 +6,10 @@
  * @brief Compute group sequential boundary crossing probabilities.
  *
  * For each drift value in @p xtheta, computes the probability of crossing the
- * lower boundary @p a and the upper boundary @p b at each analysis time. The
- * implementation follows the Jennison & Turnbull numerical integration scheme
- * and is written with pointer arguments to support calling via R's `.C()`
- * interface.
+ * lower boundary @p a and the upper boundary @p b at each analysis time,
+ * following the recursive integration of Jennison & Turnbull (2000, Section
+ * 19.2). Bounds may be infinite (no bound at that analysis). Written with
+ * pointer arguments for R's `.C()` interface (call with `NAOK = TRUE`).
  *
  * @param[in] xnanal Number of analyses (`nanal = xnanal[0]`).
  * @param[in] ntheta Number of drift values (`ntheta = ntheta[0]`).
@@ -17,14 +17,10 @@
  * @param[in] I Statistical information at each analysis (length `nanal`).
  * @param[in] a Lower Z cutoffs at each analysis (length `nanal`).
  * @param[in] b Upper Z cutoffs at each analysis (length `nanal`).
- * @param[out] xproblo Output probabilities of crossing the lower boundary.
- *   Array length is `ntheta * nanal`, stored as contiguous blocks of length
- *   `nanal` for each drift value.
- * @param[out] xprobhi Output probabilities of crossing the upper boundary.
- *   Array length is `ntheta * nanal`, stored as contiguous blocks of length
- *   `nanal` for each drift value.
- * @param[in] xr Grid parameter controlling the number of integration points
- *   (`r = xr[0]`).
+ * @param[out] xproblo Lower boundary crossing probabilities, `ntheta`
+ *   contiguous blocks of length `nanal`.
+ * @param[out] xprobhi Upper boundary crossing probabilities, same layout.
+ * @param[in] xr Grid parameter (`r = xr[0]`).
  * @return Nothing.
  */
 void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
@@ -32,27 +28,23 @@ void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
   int r, i, m1, m2, nanal, k;
   double theta;
   double *problo, *probhi;
-  double probneg(double, int, double, double *, double *, double, double);
-  double probpos(double, int, double, double *, double *, double, double);
   /* note: should allocate zwk & wwk dynamically...*/
   double mu, zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000],
       hwk2[1000], *z1, *z2, *w1, *w2, *h, *h2, *tem;
-  void h1(double, int, double *, double, double *, double *);
-  void hupdate(double, double *, int, double, double *, double *, int, double,
-               double *, double *);
-  int gridpts(int, double, double, double, double *, double *);
   r = xr[0];
   nanal = xnanal[0];
+  if (nanal < 1)
+    return;
   for (k = 0; k < ntheta[0]; k++) {
     theta = xtheta[k];
     problo = xproblo + k * nanal;
     probhi = xprobhi + k * nanal;
     /* compute probability of rejecting at 1st interim analysis */
-    if (nanal < 1)
-      return;
     mu = theta * sqrt(I[0]);
-    problo[0] = pnorm(mu - a[0], 0., 1., 0, 0);
-    probhi[0] = pnorm(b[0] - mu, 0., 1., 0, 0);
+    problo[0] = GS_PNORM_UPPER(mu - a[0]);
+    probhi[0] = GS_PNORM_UPPER(b[0] - mu);
+    if (nanal == 1)
+      continue;
     /* compute h1 */
     z1 = zwk;
     w1 = wwk;


### PR DESCRIPTION
Reduce repeated work in the recursive integration routines while retaining the existing Jennison-Turnbull grid and Simpson weights.

- Precompute scaled grid points and normalizing constants in `hupdate()`.
- Evaluate the fixed lower-tail probability once per analysis in `gsbound1()`, and move constant factors outside boundary-search loops.
- Return early for single-analysis probability calculations and consolidate shared prototypes in `gsDesign.h`.
- Keep R's normal-tail functions as the default; allow `-DGS_USE_ERFC` as an opt-in build configuration.

The original Apple M4 / clang `-O2` research measured roughly 20% to 35% gains for the core routines, with probability/boundary differences around `1e-16`. These are C-level measurements; end-to-end gains depend on the share of time spent in R. See the [benchmark methodology and results](https://github.com/nanxstats/gsdesign-research).

Layer 3 of 4; depends on `numint-02-infinite-bounds`.

Validation on macOS with R 4.6.1: integration regression, exact-reference, and print snapshot tests passed for both the default build and an isolated `-DGS_USE_ERFC` build. The full suite passed with the default build and `NOT_CRAN=true` (four tests restricted to older R versions skipped). Ran `devtools::document()` and `git diff --check`.