### PR TITLE
Add opt-in Gauss-Legendre quadrature for numerical integration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,8 @@
   continuation region and neighboring information increments, with `r`
   controlling resolution. Research benchmarks show faster calculations and
   smaller integration errors. The default Jennison and Turnbull grid
-  (`"jt"`) is unchanged; see the numerical integration section of `?gsDesign`.
+  (`"jt"`) is unchanged; see the numerical integration section of `?gsDesign`
+  (#323).
 
 ## Performance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,15 @@
   and skipped analyses. Use `is.finite()` to identify active bounds.
   `gsBoundCP()` returns `NA` at an absent bound (#242, #321).
 
+## New features
+
+- Added opt-in Gauss-Legendre quadrature for boundary crossing calculations
+  via `options(gsDesign.quadrature = "gl")`. The node count adapts to the
+  continuation region and neighboring information increments, with `r`
+  controlling resolution. Research benchmarks show faster calculations and
+  smaller integration errors. The default Jennison and Turnbull grid
+  (`"jt"`) is unchanged; see the numerical integration section of `?gsDesign`.
+
 ## Performance
 
 - Reduced repeated work in the C density update and boundary searches while

--- a/R/gsDesign.R
+++ b/R/gsDesign.R
@@ -1,3 +1,14 @@
+# gsQuadratureMethod: integer code of the quadrature scheme selected by the
+# option "gsDesign.quadrature" ("jt", the default, or "gl"); passed to the C
+# entry points. See ?gsDesign, section "Numerical integration".
+gsQuadratureMethod <- function() {
+  method <- getOption("gsDesign.quadrature", "jt")
+  if (!is.character(method) || length(method) != 1 || !(method %in% c("jt", "gl"))) {
+    stop("option gsDesign.quadrature must be \"jt\" (Jennison and Turnbull grid) or \"gl\" (Gauss-Legendre)")
+  }
+  if (method == "gl") 1L else 0L
+}
+
 # gsBound roxy [sinew] ----
 #' @title Boundary derivation - low level
 #' @description  \code{gsBound()} and \code{gsBound1()} are lower-level functions used to
@@ -139,7 +150,7 @@ gsBound <- function(I, trueneg, falsepos, tol = 0.000001, r = 18, printerr = 0) 
   a <- falsepos
   b <- falsepos
   retval <- as.integer(0)
-  xx <- .C("gsbound", k, I, a, b, trueneg, falsepos, tol, r, retval, printerr, NAOK = TRUE)
+  xx <- .C("gsbound", k, I, a, b, trueneg, falsepos, tol, r, retval, printerr, gsQuadratureMethod(), NAOK = TRUE)
   rates <- list(falsepos = xx[[6]], trueneg = xx[[5]])
 
   ## DSB question: do we need to do something here in case of an error? (similarly as in gsBound1)
@@ -184,7 +195,7 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
   b <- a
   retval <- as.integer(0)
 
-  xx <- .C("gsbound1", k, theta, I, a, b, problo, probhi, tol, r, retval, printerr, NAOK = TRUE)
+  xx <- .C("gsbound1", k, theta, I, a, b, problo, probhi, tol, r, retval, printerr, gsQuadratureMethod(), NAOK = TRUE)
 
   y <- list(
     k = xx[[1]], theta = xx[[2]], I = xx[[3]], a = xx[[4]], b = xx[[5]],
@@ -328,7 +339,9 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #' probability calculations. Larger values provide more grid points and greater
 #' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
 #' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
-#' not changed by users.
+#' not changed by users. With \code{options(gsDesign.quadrature = "gl")}
+#' (see the section on numerical integration below) \code{r} scales the
+#' number of Gauss-Legendre nodes relative to its default.
 #' @param n.I Used for re-setting bounds when timing of analyses changes from
 #' initial design; see examples.
 #' @param maxn.IPlan Used for re-setting bounds when timing of analyses changes
@@ -393,6 +406,24 @@ gsBound1 <- function(theta, I, a, probhi, tol = 0.000001, r = 18, printerr = 0) 
 #' \code{-Inf} and the bound is displayed as
 #' \code{NA} in output. Cumulative harm crossing probability from earlier
 #' analyses is still displayed.
+#' @section Numerical integration:
+#' Boundary crossing probabilities are computed by the recursive numerical
+#' integration of Jennison and Turnbull (2000, Chapter 19). By default the
+#' integration grid of that chapter is used (Simpson's rule on \code{12 r - 3}
+#' points concentrated around the mean of the test statistic), which gives
+#' probabilities accurate to about \eqn{10^{-7}} with the default
+#' \code{r = 18}. Setting \code{options(gsDesign.quadrature = "gl")} switches
+#' all computations (\code{gsDesign()}, \code{gsProbability()},
+#' \code{gsBound()}, \code{gsBound1()}, \code{gsDensity()} and everything
+#' built on them) to Gauss-Legendre quadrature on the continuation region of
+#' each analysis, with a number of nodes that adapts to the width of the
+#' region relative to the neighboring information increments. In benchmarked
+#' designs this is several times faster and accurate to about \eqn{10^{-12}},
+#' with differences from the default grid within the accuracy of that grid.
+#' The rule uses at most 992 nodes, so extremely small information increments
+#' can reduce accuracy. \code{normalGrid()} always returns the Jennison and
+#' Turnbull grid.
+#'
 #' @return An object of the class \code{gsDesign}. This class has the following
 #' elements and upon return from \code{gsDesign()} contains: \item{k}{As
 #' input.} \item{test.type}{As input.} \item{alpha}{As input.} \item{beta}{As
@@ -814,7 +845,7 @@ gsProbability <- function(k = 0, theta, n.I, a, b, r = 18, d = NULL, overrun = 0
   plo <- as.double(c(1:(k * ntheta)))
   xx <- .C(
     "probrej", k, ntheta, as.double(theta), as.double(n.I),
-    as.double(a), as.double(b), plo, phi, r, NAOK = TRUE
+    as.double(a), as.double(b), plo, phi, r, gsQuadratureMethod(), NAOK = TRUE
   )
   plo <- matrix(xx[[7]], k, ntheta)
   phi <- matrix(xx[[8]], k, ntheta)
@@ -952,7 +983,7 @@ gsDensity <- function(x, theta = 0, i = 1, zi = 0, r = 18) {
     "gsdensity", den, as.integer(i), length(theta),
     as.double(theta), as.double(x$n.I),
     as.double(if (is.null(x$lower)) rep(-Inf, x$k) else x$lower$bound), as.double(x$upper$bound),
-    as.double(zi), length(zi), as.integer(r), NAOK = TRUE
+    as.double(zi), length(zi), as.integer(r), gsQuadratureMethod(), NAOK = TRUE
   )
   list(zi = zi, theta = theta, density = matrix(xx[[1]], nrow = length(zi), ncol = length(theta)))
 }
@@ -1642,7 +1673,7 @@ gsprob <- function(theta, I, a, b, r = 18, overrun = 0) {
   plo <- as.double(c(1:(nanal * ntheta)))
   xx <- .C(
     "probrej", nanal, ntheta, as.double(theta), as.double(I),
-    as.double(a), as.double(b), plo, phi, as.integer(r), NAOK = TRUE
+    as.double(a), as.double(b), plo, phi, as.integer(r), gsQuadratureMethod(), NAOK = TRUE
   )
 
   plo <- matrix(xx[[7]], nanal, ntheta)
@@ -1856,7 +1887,7 @@ gsDProb <- function(theta, d) {
   plo <- as.double(c(1:(k * ntheta)))
   xx <- .C(
     "probrej", k, ntheta, as.double(theta), as.double(n.I),
-    as.double(a), as.double(b), plo, phi, r, NAOK = TRUE
+    as.double(a), as.double(b), plo, phi, r, gsQuadratureMethod(), NAOK = TRUE
   )
   plo <- matrix(xx[[7]], k, ntheta)
   phi <- matrix(xx[[8]], k, ntheta)
@@ -1884,7 +1915,7 @@ gsDProb <- function(theta, d) {
     harm_phi <- as.double(c(1:(k * ntheta)))
     xx2 <- .C(
       "probrej", k, ntheta, as.double(theta), as.double(n.I),
-      as.double(d$harm$bound), as.double(b), harm_plo, harm_phi, r, NAOK = TRUE
+      as.double(d$harm$bound), as.double(b), harm_plo, harm_phi, r, gsQuadratureMethod(), NAOK = TRUE
     )
     d$harm$prob <- matrix(xx2[[7]], k, ntheta)
   }

--- a/man/gsDesign.Rd
+++ b/man/gsDesign.Rd
@@ -134,7 +134,9 @@ Turnbull (2000). Grid points are spread out in the tails for accurate
 probability calculations. Larger values provide more grid points and greater
 accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
 accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
-not changed by users.}
+not changed by users. With \code{options(gsDesign.quadrature = "gl")}
+(see the section on numerical integration below) \code{r} scales the
+number of Gauss-Legendre nodes relative to its default.}
 
 \item{n.I}{Used for re-setting bounds when timing of analyses changes from
 initial design; see examples.}
@@ -393,6 +395,26 @@ functions.
 The gsDesign technical manual is available at
   \url{https://keaven.github.io/gsd-tech-manual/}.
 }
+\section{Numerical integration}{
+
+Boundary crossing probabilities are computed by the recursive numerical
+integration of Jennison and Turnbull (2000, Chapter 19). By default the
+integration grid of that chapter is used (Simpson's rule on \code{12 r - 3}
+points concentrated around the mean of the test statistic), which gives
+probabilities accurate to about \eqn{10^{-7}} with the default
+\code{r = 18}. Setting \code{options(gsDesign.quadrature = "gl")} switches
+all computations (\code{gsDesign()}, \code{gsProbability()},
+\code{gsBound()}, \code{gsBound1()}, \code{gsDensity()} and everything
+built on them) to Gauss-Legendre quadrature on the continuation region of
+each analysis, with a number of nodes that adapts to the width of the
+region relative to the neighboring information increments. In benchmarked
+designs this is several times faster and accurate to about \eqn{10^{-12}},
+with differences from the default grid within the accuracy of that grid.
+The rule uses at most 992 nodes, so extremely small information increments
+can reduce accuracy. \code{normalGrid()} always returns the Jennison and
+Turnbull grid.
+}
+
 \examples{
 library(ggplot2)
 #  symmetric, 2-sided design with O'Brien-Fleming-like boundaries

--- a/man/gsSurvCalendar.Rd
+++ b/man/gsSurvCalendar.Rd
@@ -161,7 +161,9 @@ Turnbull (2000). Grid points are spread out in the tails for accurate
 probability calculations. Larger values provide more grid points and greater
 accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
 accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
-not changed by users.}
+not changed by users. With \code{options(gsDesign.quadrature = "gl")}
+(see the section on numerical integration below) \code{r} scales the
+number of Gauss-Legendre nodes relative to its default.}
 
 \item{tol}{Tolerance for error passed to the \code{\link{gsDesign}} function.}
 

--- a/man/nSurv.Rd
+++ b/man/nSurv.Rd
@@ -269,7 +269,9 @@ Turnbull (2000). Grid points are spread out in the tails for accurate
 probability calculations. Larger values provide more grid points and greater
 accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
 accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
-not changed by users.}
+not changed by users. With \code{options(gsDesign.quadrature = "gl")}
+(see the section on numerical integration below) \code{r} scales the
+number of Gauss-Legendre nodes relative to its default.}
 
 \item{usTime}{Default is NULL in which case upper bound spending time is 
 determined by \code{timing}. Otherwise, this should be a vector of length 

--- a/src/gsDesign.h
+++ b/src/gsDesign.h
@@ -4,6 +4,10 @@
 /* 1 / sqrt(2 * pi): shared scale factor for standard normal density. */
 static const double gs_inv_sqrt_2pi = 0.3989422804014327;
 
+/* Quadrature methods for the recursive integration (see gsquad.c). */
+#define GS_QUAD_JT 0 /* Jennison & Turnbull grid with Simpson's rule */
+#define GS_QUAD_GL 1 /* Gauss-Legendre on the continuation region */
+
 /* Standard normal lower/upper tail probability used in the boundary search
    and the crossing probabilities. R's pnorm() is the reference; erfc() from
    the C library is a faster alternative with equivalent accuracy on
@@ -18,16 +22,22 @@ static const double gs_inv_sqrt_2pi = 0.3989422804014327;
 #endif
 
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
-             double *probhi, double *xtol, int *xr, int *retval, int *printerr);
+             double *probhi, double *xtol, int *xr, int *retval, int *printerr,
+             int *method);
 void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
               double *problo, double *probhi, double *xtol, int *xr,
-              int *retval, int *printerr);
+              int *retval, int *printerr, int *method);
 void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
-             double *b, double *xproblo, double *xprobhi, int *xr);
+             double *b, double *xproblo, double *xprobhi, int *xr,
+             int *method);
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
-               double *a, double *b, double *xz, int *zlen, int *xr);
+               double *a, double *b, double *xz, int *zlen, int *xr,
+               int *method);
 void stdnorpts(int *r, double *bounds, double *z, double *w);
 int gridpts(int r, double mu, double a, double b, double *z, double *w);
+int gsgrid(int method, int r, double mu, double a, double b, double sig,
+           double *z, double *w);
+double gs_kernel_width(const double *I, int i, int nanal);
 void h1(double theta, int m, double *wgt, double I, double *z, double *h);
 void hupdate(double theta, double *wgt, int m1, double Ikm1, double *zkm1,
              double *hkm1, int m2, double Ik, double *zk, double *hk);

--- a/src/gsbound.c
+++ b/src/gsbound.c
@@ -36,14 +36,15 @@
  * @param[out] retval Error flag: 0 on success, 1 on illegal arguments or
  *   failure to converge.
  * @param[in] printerr If non-zero, print diagnostics via `Rprintf()`.
+ * @param[in] method Quadrature method (`GS_QUAD_JT` or `GS_QUAD_GL`).
  * @return Nothing.
  */
 void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
              double *probhi, double *xtol, int *xr, int *retval,
-             int *printerr) {
-  int i, ii, j, m1, m2, r, nanal, lo_active, hi_active;
+             int *printerr, int *method) {
+  int i, ii, j, m1, m2, r, nanal, lo_active, hi_active, meth;
   double plo, phi, dplo, dphi, btem = 0., atem = 0., atem2, btem2, rtdeltak,
-                               rtIk, rtIkm1, xlo, xhi, scale;
+                               rtIk, rtIkm1, xlo, xhi, scale, sig;
   double adelta, bdelta, tol;
   /* note: should allocate zwk & wwk dynamically...*/
   double zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000], hwk2[1000],
@@ -51,6 +52,7 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
   r = xr[0];
   nanal = xnanal[0];
   tol = xtol[0];
+  meth = method[0];
   /* compute bounds at 1st interim analysis using inverse normal */
   if (nanal < 1 || r < 1 || r > MAXR) {
     retval[0] = 1;
@@ -83,7 +85,8 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
   z2 = zwk2;
   w2 = wwk2;
   h2 = hwk2;
-  m1 = gridpts(r, 0., a[0], b[0], z1, w1);
+  sig = gs_kernel_width(I, 0, nanal);
+  m1 = gsgrid(meth, r, 0., a[0], b[0], sig, z1, w1);
   h1(0., m1, w1, I[0], z1, h);
   rtIk = sqrt(I[0]);
   /* use Newton-Raphson to find subsequent interim analysis cutpoints */
@@ -180,7 +183,8 @@ void gsbound(int *xnanal, double *I, double *a, double *b, double *problo,
       return;
     }
     if (i < nanal - 1) {
-      m2 = gridpts(r, 0., a[i], b[i], z2, w2);
+      sig = gs_kernel_width(I, i, nanal);
+      m2 = gsgrid(meth, r, 0., a[i], b[i], sig, z2, w2);
       hupdate(0., w2, m1, I[i - 1], z1, h, m2, I[i], z2, h2);
       m1 = m2;
       tem = z1;

--- a/src/gsbound1.c
+++ b/src/gsbound1.c
@@ -34,14 +34,15 @@
  * @param[out] retval Error flag: 0 on success, 1 on illegal arguments or
  *   failure to converge.
  * @param[in] printerr If non-zero, print diagnostics via `Rprintf()`.
+ * @param[in] method Quadrature method (`GS_QUAD_JT` or `GS_QUAD_GL`).
  * @return Nothing.
  */
 void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
               double *problo, double *probhi, double *xtol, int *xr,
-              int *retval, int *printerr) {
-  int i, ii, j, m1, m2, r, nanal, hi_active;
+              int *retval, int *printerr, int *method) {
+  int i, ii, j, m1, m2, r, nanal, hi_active, meth;
   double plo, phi, dphi, btem = 0., btem2, rtdeltak, rtIk, rtIkm1, xlo, xhi,
-                             theta, mu, tol, bdelta, drift, scale;
+                             theta, mu, tol, bdelta, drift, scale, sig;
   /* note: should allocate zwk & wwk dynamically...*/
   double zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000], hwk2[1000],
       *z1, *z2, *w1, *w2, *h, *h2, *tem;
@@ -49,6 +50,7 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
   nanal = xnanal[0];
   theta = xtheta[0];
   tol = xtol[0];
+  meth = method[0];
   if (nanal < 1 || r < 1 || r > MAXR) {
     retval[0] = 1;
     if (*printerr) {
@@ -79,7 +81,8 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
   z2 = zwk2;
   w2 = wwk2;
   h2 = hwk2;
-  m1 = gridpts(r, mu, a[0], b[0], z1, w1);
+  sig = gs_kernel_width(I, 0, nanal);
+  m1 = gsgrid(meth, r, mu, a[0], b[0], sig, z1, w1);
   h1(theta, m1, w1, I[0], z1, h);
   /* use Newton-Raphson to find subsequent interim analysis cutpoints */
   retval[0] = 0;
@@ -141,7 +144,8 @@ void gsbound1(int *xnanal, double *xtheta, double *I, double *a, double *b,
       retval[0] = 1;
     }
     if (i < nanal - 1) {
-      m2 = gridpts(r, mu, a[i], b[i], z2, w2);
+      sig = gs_kernel_width(I, i, nanal);
+      m2 = gsgrid(meth, r, mu, a[i], b[i], sig, z2, w2);
       hupdate(theta, w2, m1, I[i - 1], z1, h, m2, I[i], z2, h2);
       m1 = m2;
       tem = z1;

--- a/src/gsdensity.c
+++ b/src/gsdensity.c
@@ -23,17 +23,20 @@
  * @param[in] xz Z values where the density is evaluated (length `zlen[0]`).
  * @param[in] zlen Length of @p xz (`nz = zlen[0]`).
  * @param[in] xr Grid parameter (`r = xr[0]`).
+ * @param[in] method Quadrature method (`GS_QUAD_JT` or `GS_QUAD_GL`).
  * @return Nothing.
  */
 void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
-               double *a, double *b, double *xz, int *zlen, int *xr) {
-  int r, i, j, k, m1, m2, nanal, nz, wklen;
-  double z, mu, theta;
+               double *a, double *b, double *xz, int *zlen, int *xr,
+               int *method) {
+  int r, i, j, k, m1, m2, nanal, nz, wklen, meth;
+  double z, mu, theta, sig;
   double *zwk, *wwk, *hwk, *zwk2, *wwk2, *hwk2;
   double *z1, *z2, *w1, *w2, *h, *h2, *tem;
   r = xr[0];
   nanal = xnanal[0];
   nz = zlen[0];
+  meth = method[0];
   wklen = 1000; /* work storage matching the other entry points */
   if (wklen < nz)
     wklen = nz;
@@ -65,7 +68,8 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
     z1 = zwk;
     w1 = wwk;
     h = hwk;
-    m1 = gridpts(r, mu, a[0], b[0], z1, w1);
+    sig = gs_kernel_width(I, 0, nanal);
+    m1 = gsgrid(meth, r, mu, a[0], b[0], sig, z1, w1);
     h1(theta, m1, w1, I[0], z1, h);
     z2 = zwk2;
     w2 = wwk2;
@@ -74,7 +78,8 @@ void gsdensity(double *den, int *xnanal, int *ntheta, double *xtheta, double *I,
     for (i = 1; i < nanal; i++) {
       mu = theta * sqrt(I[i]);
       if (i < nanal - 1) {
-        m2 = gridpts(r, mu, a[i], b[i], z2, w2);
+        sig = gs_kernel_width(I, i, nanal);
+        m2 = gsgrid(meth, r, mu, a[i], b[i], sig, z2, w2);
       } else {
         m2 = nz - 1;
         z2 = xz;

--- a/src/gsquad.c
+++ b/src/gsquad.c
@@ -1,0 +1,189 @@
+/**
+ * @file
+ * @brief Integration grids for the group sequential recursion.
+ *
+ * Two quadrature schemes are available for the recursive integration of
+ * Jennison & Turnbull (2000, Chapter 19):
+ *
+ * - `GS_QUAD_JT`: the original grid of p. 349 (points concentrated within
+ *   three standard deviations of the mean, logarithmically spaced tails,
+ *   Simpson's rule; `12 r - 3` points before truncation).
+ * - `GS_QUAD_GL`: Gauss-Legendre quadrature on the continuation region
+ *   `(a, b)` of each analysis, truncated to `mu +/- GS_GL_L` when a bound is
+ *   absent. The integrands (sub-densities times normal kernels) are analytic
+ *   on the continuation region, so Gauss-Legendre converges much faster than
+ *   Simpson's rule. The number of nodes adapts to the width of the region
+ *   relative to the width `sig = sqrt(dI / I)` of the normal kernel linking
+ *   the analysis to the next one; the grid parameter `r` acts as a
+ *   multiplier relative to its default of 18. The sub-density at an analysis
+ *   inherits features as sharp as the kernel that produced it, and the next
+ *   integrand oscillates on the scale of the kernel to the following analysis,
+ *   so the relevant width is the smaller of the two (`gs_kernel_width()`).
+ *
+ * Gauss-Legendre nodes and weights are computed once (Newton iteration on
+ * Legendre polynomials) for a fixed menu of sizes and kept in static storage;
+ * no memory is allocated per call.
+ */
+#include <math.h>
+#include "R.h"
+#include "gsDesign.h"
+
+#define GS_GL_L 8.0    /* half-width (in standard deviations) replacing an infinite bound */
+#define GS_GL_C0 8.0   /* nodes = ceil((C0 + C1 * width / sig) * r / 18) */
+#define GS_GL_C1 3.0
+#define GS_GL_NMENU 21
+static const int gs_gl_menu[GS_GL_NMENU] = {8,   12,  16,  20,  24,  32,  40,
+                                            48,  64,  80,  96,  128, 160, 192,
+                                            256, 320, 384, 512, 640, 768, 992};
+#define GS_GL_TABLE 4792 /* sum of the menu; every rule fits the 1000-long work arrays */
+static double gs_gl_x[GS_GL_TABLE];
+static double gs_gl_w[GS_GL_TABLE];
+static int gs_gl_offset[GS_GL_NMENU];
+static int gs_gl_ready = 0;
+
+/**
+ * @brief Gauss-Legendre rule with @p n nodes on (-1, 1).
+ *
+ * Roots of the Legendre polynomial `P_n` are found by Newton's method from
+ * the classical asymptotic starting values; weights follow from the
+ * derivative. Accuracy is at the level of double precision rounding.
+ *
+ * @param[in] n Number of nodes (even, >= 2).
+ * @param[out] x Nodes in increasing order (length `n`).
+ * @param[out] w Weights (length `n`).
+ */
+static void gs_gl_rule(int n, double *x, double *w) {
+  int i, j, it, m = (n + 1) / 2;
+  double z, z1, p1, p2, p3, pp;
+  for (i = 0; i < m; i++) {
+    z = cos(M_PI * (i + 0.75) / (n + 0.5));
+    for (it = 0; it < 100; it++) {
+      p1 = 1.;
+      p2 = 0.;
+      for (j = 1; j <= n; j++) {
+        p3 = p2;
+        p2 = p1;
+        p1 = ((2. * j - 1.) * z * p2 - (j - 1.) * p3) / j;
+      }
+      pp = n * (z * p1 - p2) / (z * z - 1.);
+      z1 = z;
+      z = z1 - p1 / pp;
+      if (fabs(z - z1) < 1e-15)
+        break;
+    }
+    p1 = 1.;
+    p2 = 0.;
+    for (j = 1; j <= n; j++) {
+      p3 = p2;
+      p2 = p1;
+      p1 = ((2. * j - 1.) * z * p2 - (j - 1.) * p3) / j;
+    }
+    pp = n * (z * p1 - p2) / (z * z - 1.);
+    x[i] = -z;
+    x[n - 1 - i] = z;
+    w[i] = w[n - 1 - i] = 2. / ((1. - z * z) * pp * pp);
+  }
+}
+
+/**
+ * @brief Fill the static Gauss-Legendre tables (first use only).
+ */
+static void gs_gl_init(void) {
+  int i, off = 0;
+  if (gs_gl_ready)
+    return;
+  for (i = 0; i < GS_GL_NMENU; i++) {
+    gs_gl_offset[i] = off;
+    gs_gl_rule(gs_gl_menu[i], gs_gl_x + off, gs_gl_w + off);
+    off += gs_gl_menu[i];
+  }
+  gs_gl_ready = 1;
+}
+
+/**
+ * @brief Gauss-Legendre grid on the continuation region of an analysis.
+ *
+ * @param[in] r Grid parameter; the node count scales with `r / 18`.
+ * @param[in] mu Mean of the standardized statistic at the analysis.
+ * @param[in] a Lower bound (may be `-Inf`).
+ * @param[in] b Upper bound (may be `Inf`).
+ * @param[in] sig Width `sqrt(dI / I)` of the kernel to the next analysis.
+ * @param[out] z Nodes (length at least the largest menu size, 992).
+ * @param[out] w Weights.
+ * @return Last valid index (number of nodes minus one); 0 with a zero weight
+ *   when the region is empty.
+ */
+static int glpts(int r, double mu, double a, double b, double sig, double *z,
+                 double *w) {
+  int i, k, n;
+  double lo = a, hi = b, c, hw, nreq;
+  const double *gx, *gw;
+  gs_gl_init();
+  if (!(lo > mu - GS_GL_L))
+    lo = mu - GS_GL_L;
+  if (!(hi < mu + GS_GL_L))
+    hi = mu + GS_GL_L;
+  if (!(hi > lo)) {
+    z[0] = lo;
+    w[0] = 0.;
+    return 0;
+  }
+  nreq = (GS_GL_C0 + GS_GL_C1 * (hi - lo) / sig) * (r / 18.);
+  k = GS_GL_NMENU - 1;
+  for (i = 0; i < GS_GL_NMENU; i++)
+    if (gs_gl_menu[i] >= nreq) {
+      k = i;
+      break;
+    }
+  n = gs_gl_menu[k];
+  gx = gs_gl_x + gs_gl_offset[k];
+  gw = gs_gl_w + gs_gl_offset[k];
+  c = 0.5 * (hi + lo);
+  hw = 0.5 * (hi - lo);
+  for (i = 0; i < n; i++) {
+    z[i] = c + hw * gx[i];
+    w[i] = hw * gw[i];
+  }
+  return n - 1;
+}
+
+/**
+ * @brief Kernel width governing the resolution needed at an analysis.
+ *
+ * Returns the smaller of `sqrt(dI / I)` for the information increment into
+ * analysis @p i (which sets how sharp the sub-density is there) and for the
+ * increment out of it (which sets how fast the next integrand varies).
+ *
+ * @param[in] I Statistical information at each analysis (length @p nanal).
+ * @param[in] i Analysis index (0-based) at which the grid is built.
+ * @param[in] nanal Number of analyses.
+ * @return The kernel width (`Inf` if the analysis has no neighbours).
+ */
+double gs_kernel_width(const double *I, int i, int nanal) {
+  double in = R_PosInf, out = R_PosInf;
+  if (i > 0)
+    in = sqrt((I[i] - I[i - 1]) / I[i - 1]);
+  if (i + 1 < nanal)
+    out = sqrt((I[i + 1] - I[i]) / I[i]);
+  return in < out ? in : out;
+}
+
+/**
+ * @brief Integration grid for one analysis under the selected method.
+ *
+ * @param[in] method `GS_QUAD_JT` or `GS_QUAD_GL`.
+ * @param[in] r Grid parameter.
+ * @param[in] mu Mean of the standardized statistic at the analysis.
+ * @param[in] a Lower bound (may be `-Inf`).
+ * @param[in] b Upper bound (may be `Inf`).
+ * @param[in] sig Kernel width to the next analysis (used by `GS_QUAD_GL`).
+ * @param[out] z Grid points.
+ * @param[out] w Integration weights.
+ * @return Last valid index of @p z and @p w.
+ */
+int gsgrid(int method, int r, double mu, double a, double b, double sig,
+           double *z, double *w) {
+  if (method == GS_QUAD_GL)
+    return glpts(r, mu, a, b, sig, z, w);
+  return gridpts(r, mu, a, b, z, w);
+}

--- a/src/init.c
+++ b/src/init.c
@@ -11,23 +11,23 @@
 
 /* Argument types for `.C("gsbound")`. */
 static R_NativePrimitiveArgType gsbound_t[] = {
-    INTSXP,  REALSXP, REALSXP, REALSXP, REALSXP,
-    REALSXP, REALSXP, INTSXP,  INTSXP,  INTSXP};
+    INTSXP,  REALSXP, REALSXP, REALSXP, REALSXP, REALSXP,
+    REALSXP, INTSXP,  INTSXP,  INTSXP,  INTSXP};
 
 /* Argument types for `.C("gsbound1")`. */
 static R_NativePrimitiveArgType gsbound1_t[] = {
     INTSXP,  REALSXP, REALSXP, REALSXP, REALSXP, REALSXP,
-    REALSXP, REALSXP, INTSXP,  INTSXP,  INTSXP};
+    REALSXP, REALSXP, INTSXP,  INTSXP,  INTSXP,  INTSXP};
 
 /* Argument types for `.C("probrej")`. */
-static R_NativePrimitiveArgType probrej_t[] = {INTSXP,  INTSXP,  REALSXP,
-                                               REALSXP, REALSXP, REALSXP,
-                                               REALSXP, REALSXP, INTSXP};
+static R_NativePrimitiveArgType probrej_t[] = {
+    INTSXP,  INTSXP,  REALSXP, REALSXP, REALSXP,
+    REALSXP, REALSXP, REALSXP, INTSXP,  INTSXP};
 
 /* Argument types for `.C("gsdensity")`. */
 static R_NativePrimitiveArgType gsdensity_t[] = {
-    REALSXP, INTSXP,  INTSXP,  REALSXP, REALSXP,
-    REALSXP, REALSXP, REALSXP, INTSXP,  INTSXP};
+    REALSXP, INTSXP,  INTSXP,  REALSXP, REALSXP, REALSXP,
+    REALSXP, REALSXP, INTSXP,  INTSXP,  INTSXP};
 
 /* Argument types for `.C("stdnorpts")`. */
 static R_NativePrimitiveArgType stdnorpts_t[] = {INTSXP, REALSXP, REALSXP,
@@ -35,10 +35,10 @@ static R_NativePrimitiveArgType stdnorpts_t[] = {INTSXP, REALSXP, REALSXP,
 
 /* define array of all C entry points */
 static const R_CMethodDef CEntries[] = {
-    {"gsbound", (DL_FUNC)&gsbound, 10, gsbound_t},
-    {"gsbound1", (DL_FUNC)&gsbound1, 11, gsbound1_t},
-    {"probrej", (DL_FUNC)&probrej, 9, probrej_t},
-    {"gsdensity", (DL_FUNC)&gsdensity, 10, gsdensity_t},
+    {"gsbound", (DL_FUNC)&gsbound, 11, gsbound_t},
+    {"gsbound1", (DL_FUNC)&gsbound1, 12, gsbound1_t},
+    {"probrej", (DL_FUNC)&probrej, 10, probrej_t},
+    {"gsdensity", (DL_FUNC)&gsdensity, 11, gsdensity_t},
     {"stdnorpts", (DL_FUNC)&stdnorpts, 4, stdnorpts_t},
     {NULL, NULL, 0, NULL}};
 

--- a/src/rprobrej.c
+++ b/src/rprobrej.c
@@ -21,18 +21,21 @@
  *   contiguous blocks of length `nanal`.
  * @param[out] xprobhi Upper boundary crossing probabilities, same layout.
  * @param[in] xr Grid parameter (`r = xr[0]`).
+ * @param[in] method Quadrature method (`GS_QUAD_JT` or `GS_QUAD_GL`).
  * @return Nothing.
  */
 void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
-             double *b, double *xproblo, double *xprobhi, int *xr) {
-  int r, i, m1, m2, nanal, k;
+             double *b, double *xproblo, double *xprobhi, int *xr,
+             int *method) {
+  int r, i, m1, m2, nanal, k, meth;
   double theta;
   double *problo, *probhi;
   /* note: should allocate zwk & wwk dynamically...*/
-  double mu, zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000],
+  double mu, sig, zwk[1000], wwk[1000], hwk[1000], zwk2[1000], wwk2[1000],
       hwk2[1000], *z1, *z2, *w1, *w2, *h, *h2, *tem;
   r = xr[0];
   nanal = xnanal[0];
+  meth = method[0];
   if (nanal < 1)
     return;
   for (k = 0; k < ntheta[0]; k++) {
@@ -49,7 +52,8 @@ void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
     z1 = zwk;
     w1 = wwk;
     h = hwk;
-    m1 = gridpts(r, mu, a[0], b[0], z1, w1);
+    sig = gs_kernel_width(I, 0, nanal);
+    m1 = gsgrid(meth, r, mu, a[0], b[0], sig, z1, w1);
     h1(theta, m1, w1, I[0], z1, h);
     z2 = zwk2;
     w2 = wwk2;
@@ -60,7 +64,8 @@ void probrej(int *xnanal, int *ntheta, double *xtheta, double *I, double *a,
       problo[i] = probneg(theta, m1, a[i], z1, h, I[i - 1], I[i]);
       if (i < nanal - 1) {
         mu = theta * sqrt(I[i]);
-        m2 = gridpts(r, mu, a[i], b[i], z2, w2);
+        sig = gs_kernel_width(I, i, nanal);
+        m2 = gsgrid(meth, r, mu, a[i], b[i], sig, z2, w2);
         hupdate(theta, w2, m1, I[i - 1], z1, h, m2, I[i], z2, h2);
         m1 = m2;
         tem = z1;

--- a/tests/testthat/test-numint-gl.R
+++ b/tests/testthat/test-numint-gl.R
@@ -1,0 +1,117 @@
+# Tests for the Gauss-Legendre quadrature option
+# (options(gsDesign.quadrature = "gl")) of the recursive integration.
+
+fx <- local({
+  source(testthat::test_path("fixtures", "numint-fixtures.R"), local = TRUE)
+  numint_fixtures
+})
+
+with_gl <- function(expr) {
+  old <- options(gsDesign.quadrature = "gl")
+  on.exit(options(old), add = TRUE)
+  force(expr)
+}
+
+testthat::test_that("the quadrature option is validated", {
+  testthat::expect_equal(gsQuadratureMethod(), 0L)
+  testthat::expect_equal(with_gl(gsQuadratureMethod()), 1L)
+  old <- options(gsDesign.quadrature = "simpson")
+  on.exit(options(old), add = TRUE)
+  testthat::expect_error(gsQuadratureMethod(), "gsDesign.quadrature")
+})
+
+testthat::test_that("Gauss-Legendre quadrature matches exact multivariate normal probabilities", {
+  for (nm in names(fx$exact)) {
+    p <- fx$exact[[nm]]$args
+    z <- with_gl(gsProbability(k = p$k, theta = p$theta, n.I = p$n.I, a = p$a, b = p$b))
+    # reference accuracy is about 1e-10; the JT grid with r = 18 is about 1e-7
+    testthat::expect_lt(max(abs(z$upper$prob - fx$exact[[nm]]$upper)), 2e-9, label = paste(nm, "upper"))
+    testthat::expect_lt(max(abs(z$lower$prob - fx$exact[[nm]]$lower)), 2e-9, label = paste(nm, "lower"))
+  }
+})
+
+testthat::test_that("Gauss-Legendre results agree with the default grid within its accuracy", {
+  # Excluded: "r6" (the default grid with r = 6 is only accurate to about 1e-5)
+  # and "crossed" (bounds with a > b at an analysis: the default grid then
+  # carries negative Simpson weights, whereas Gauss-Legendre treats the empty
+  # continuation region as having no mass, so later probabilities are 0).
+  for (nm in setdiff(names(fx$gsProbability), c("r6", "crossed"))) {
+    case <- fx$gsProbability[[nm]]
+    z <- with_gl(do.call(gsProbability, case$args))
+    testthat::expect_lt(max(abs(z$upper$prob - case$upper)), 5e-7, label = paste(nm, "upper"))
+    testthat::expect_lt(max(abs(z$lower$prob - case$lower)), 5e-7, label = paste(nm, "lower"))
+  }
+  for (nm in names(fx$gsDesign)) {
+    case <- fx$gsDesign[[nm]]
+    x <- with_gl(eval(parse(text = case$call)))
+    testthat::expect_equal(x$n.I, case$n.I, tolerance = 1e-5, info = nm)
+    testthat::expect_equal(x$upper$bound, case$upper, tolerance = 1e-5, info = nm)
+    if (!is.null(case$lower)) testthat::expect_equal(x$lower$bound, case$lower, tolerance = 1e-5, info = nm)
+  }
+})
+
+testthat::test_that("Gauss-Legendre is self-consistent and stable for demanding designs", {
+  designs <- list(
+    list(k = 20, test.type = 4),
+    list(k = 20, test.type = 1, sfu = sfLDPocock),
+    list(k = 4, test.type = 4, timing = c(0.1, 0.2, 0.9)),
+    list(k = 3, test.type = 4, timing = c(0.5, 0.98))
+  )
+  for (d in designs) {
+    x <- with_gl(do.call(gsDesign, d))
+    a <- if (x$test.type == 1) rep(-Inf, x$k) else x$lower$bound
+    theta <- x$delta * c(0, 1, 2, 5, -1)
+    p18 <- with_gl(gsProbability(k = x$k, theta = theta, n.I = x$n.I, a = a, b = x$upper$bound, r = 18))
+    p60 <- with_gl(gsProbability(k = x$k, theta = theta, n.I = x$n.I, a = a, b = x$upper$bound, r = 60))
+    testthat::expect_lt(max(abs(p18$upper$prob - p60$upper$prob)), 1e-9)
+    testthat::expect_lt(max(abs(p18$lower$prob - p60$lower$prob)), 1e-9)
+    # the design attains its error rates under its own bounds
+    testthat::expect_lt(abs(sum(x$upper$prob[, 2]) - (1 - x$beta)), 2 * x$tol)
+    if (x$test.type == 4) testthat::expect_lt(abs(sum(x$falseposnb) - x$alpha), 2 * x$tol)
+  }
+})
+
+testthat::test_that("Gauss-Legendre resolves a narrow information increment followed by a wide one", {
+  # An analysis with (almost) no new information and no bound must not change
+  # the design: the final bound equals that of the two-analysis design.
+  ref <- with_gl(gsBound1(theta = 0, I = c(1, 3), a = rep(-Inf, 2), probhi = c(0.001, 0.024)))$b[2]
+  # (resolution is capped at 992 nodes, so accuracy degrades gradually below
+  # an information increment of 1e-3 relative to the previous analysis)
+  for (eps in c(1e-2, 1e-3, 1e-4)) {
+    y <- with_gl(gsBound1(theta = 0, I = c(1, 1 + eps, 3), a = rep(-Inf, 3), probhi = c(0.001, 0, 0.024)))
+    testthat::expect_equal(y$b[3], ref, tolerance = if (eps < 1e-3) 1e-5 else 1e-6, info = paste("eps", eps))
+  }
+  x <- gsDesign(k = 3, test.type = 4, timing = c(0.5, 0.9))
+  I <- x$n.I[3] * c(0.5, 0.505, 1)
+  p18 <- with_gl(gsProbability(k = 3, theta = c(0, x$delta), n.I = I, a = x$lower$bound, b = x$upper$bound, r = 18))
+  p60 <- with_gl(gsProbability(k = 3, theta = c(0, x$delta), n.I = I, a = x$lower$bound, b = x$upper$bound, r = 60))
+  testthat::expect_lt(max(abs(p18$upper$prob - p60$upper$prob), abs(p18$lower$prob - p60$lower$prob)), 1e-9)
+})
+
+testthat::test_that("Gauss-Legendre handles infinite bounds and empty continuation regions", {
+  # crossed bounds at analysis 2: no continuation, so nothing can cross later
+  cr <- with_gl(gsProbability(k = 3, theta = c(0, 1), n.I = 1:3, a = c(0, 2.5, 1.9), b = c(2.5, 2.2, 1.9)))
+  testthat::expect_equal(unname(cr$upper$prob[3, ]), c(0, 0))
+  testthat::expect_equal(unname(cr$lower$prob[3, ]), c(0, 0))
+  p <- with_gl(gsProbability(k = 3, theta = c(0, 1, 5), n.I = 1:3, a = rep(-Inf, 3), b = c(Inf, Inf, 1.96)))
+  testthat::expect_equal(p$upper$prob[1:2, ], matrix(0, 2, 3))
+  testthat::expect_equal(p$upper$prob[3, ], pnorm(1.96 - c(0, 1, 5) * sqrt(3), lower.tail = FALSE), tolerance = 1e-9)
+  # bounds crossed at analysis 1: nothing continues
+  q <- with_gl(gsProbability(k = 3, theta = 0, n.I = 1:3, a = c(1, 0, 0), b = c(1, 2, 2)))
+  testthat::expect_equal(sum(q$upper$prob) + sum(q$lower$prob), 1, tolerance = 1e-12)
+  testthat::expect_equal(q$upper$prob[2:3, 1], c(0, 0))
+  # zero spending at an interim gives an infinite bound with either method
+  y <- with_gl(gsBound1(theta = 0, I = c(1, 2, 3), a = rep(-Inf, 3), probhi = c(0.001, 0, 0.024)))
+  testthat::expect_equal(y$b[2], Inf)
+  testthat::expect_equal(y$b, gsBound1(theta = 0, I = c(1, 2, 3), a = rep(-Inf, 3), probhi = c(0.001, 0, 0.024))$b, tolerance = 1e-6)
+})
+
+testthat::test_that("gsDensity() integrates to the continuation probability under Gauss-Legendre", {
+  x <- with_gl(gsDesign(k = 3, test.type = 4))
+  g <- normalGrid(r = 40, bounds = c(-8, 8))
+  for (i in 2:3) {
+    d <- with_gl(gsDensity(x, theta = c(0, x$delta), i = i, zi = g$z))
+    cont <- 1 - colSums(x$upper$prob[1:(i - 1), , drop = FALSE]) - colSums(x$lower$prob[1:(i - 1), , drop = FALSE])
+    testthat::expect_equal(as.numeric(g$gridwgts %*% d$density), cont, tolerance = 1e-6)
+  }
+})


### PR DESCRIPTION
Add opt-in Gauss-Legendre quadrature for the recursive boundary-crossing calculations:

```r
options(gsDesign.quadrature = "gl")
```

The default remains `"jt"`. The option applies to `gsDesign()`, `gsProbability()`, `gsBound()`, `gsBound1()`, `gsDensity()`, and calculations built on them; `normalGrid()` continues to return the Jennison-Turnbull grid.

- Cache Gauss-Legendre rules for 8 to 992 nodes and adapt the node count to the continuation region and neighboring information increments; `r` scales the resolution.
- Clip integration to 8 standard deviations around the current mean and treat empty continuation regions as having zero mass.
- Add a method argument to the four registered native entry points and pass it from the R wrappers.
- Document the option and test exact references, agreement with the default, resolution stability, closely spaced analyses, infinite bounds, empty regions, and density integration.

The [research report](https://github.com/nanxstats/gsdesign-research) measured 4x to 9x faster C-level calculations than v3.11.0, with substantially smaller integration errors in the studied designs. End-to-end gains vary, and the finite node cap limits accuracy for extremely small information increments. The option intentionally changes results within the accuracy of the default grid in the tested cases.

Layer 4 of 4; depends on `numint-03-faster-recursion`.

Validation on macOS with R 4.6.1: focused Gauss-Legendre, regression, exact-reference, and print snapshot tests passed. The full suite passed with `NOT_CRAN=true` (four tests restricted to older R versions skipped). A separate `R CMD INSTALL` with clang `-O2` succeeded, and all four numerical integration test files passed against that installed build. Ran `devtools::document()` and `git diff --check`.