### PR TITLE
Fix conditional power at absent harm bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,9 +36,9 @@
 
 - Fixed `gsBoundCP()` to return `NA` at absent harm bounds, including bounds
   with zero spending. This also fixes `gsBoundSummary()` when conditional
-  power is requested for selective harm-bound designs (#321).
+  power is requested for selective harm-bound designs (#335).
 - `gsBoundSummary()` now skips conditional-power calculations separately for
-  excluded `CP` and `CP H1` rows.
+  excluded `CP` and `CP H1` rows (#335).
 - Guarded the Newton boundary search against `0/0` updates and separated its
   iteration limit and finite iterate clamp from the absent-bound values
   (#242, #321).

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
 
 ## Bug fixes
 
+- Fixed `gsBoundCP()` to return `NA` at absent harm bounds, including bounds
+  with zero spending. This also fixes `gsBoundSummary()` when conditional
+  power is requested for selective harm-bound designs (#321).
+- `gsBoundSummary()` now skips conditional-power calculations separately for
+  excluded `CP` and `CP H1` rows.
 - Guarded the Newton boundary search against `0/0` updates and separated its
   iteration limit and finite iterate clamp from the absent-bound values
   (#242, #321).

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,16 +34,16 @@
 
 ## Bug fixes
 
-- Fixed `gsBoundCP()` to return `NA` at absent harm bounds, including bounds
-  with zero spending. This also fixes `gsBoundSummary()` when conditional
-  power is requested for selective harm-bound designs (#335).
-- `gsBoundSummary()` now skips conditional-power calculations separately for
-  excluded `CP` and `CP H1` rows (#335).
 - Guarded the Newton boundary search against `0/0` updates and separated its
   iteration limit and finite iterate clamp from the absent-bound values
   (#242, #321).
 - Updated the R interfaces and convergence checks to handle infinite bounds,
   and fixed `gsDensity()` for one-sided designs (#242, #321).
+- Fixed `gsBoundCP()` to return `NA` at absent harm bounds, including bounds
+  with zero spending. This also fixes `gsBoundSummary()` when conditional
+  power is requested for selective harm bound designs (#335).
+- `gsBoundSummary()` now skips conditional power calculations separately for
+  excluded `CP` and `CP H1` rows (#335).
 
 ## Major changes
 

--- a/R/gsCP.R
+++ b/R/gsCP.R
@@ -344,11 +344,12 @@ gsPI <- function(x, i = 1, zi = 0, j = 2, level = .95, theta = c(0, 3), wgts = c
 #' accuracy but slow down computation. Jennison and Turnbull (p. 350) note an
 #' accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
 #' not changed by users.
-#' @return A list containing two vectors, \code{CPlo} and \code{CPhi}.
-#' \item{CPlo}{A vector of length \code{x$k-1} with conditional powers of
-#' crossing upper bounds given interim test statistics at each lower bound}
-#' \item{CPhi}{A vector of length \code{x$k-1} with conditional powers of
-#' crossing upper bounds given interim test statistics at each upper bound.}
+#' @return For one-sided designs, a vector of length \code{x$k-1} containing
+#' conditional power at each interim upper bound. For two-sided designs, a
+#' matrix with \code{x$k-1} rows and columns \code{CPlo} and \code{CPhi},
+#' containing conditional power at the lower and upper bounds, respectively.
+#' Designs with harm bounds (\code{test.type} 7 or 8) also have a
+#' \code{CPharm} column. An absent bound has conditional power \code{NA}.
 #' @examples
 #' 
 #' # set up a group sequential design
@@ -429,8 +430,11 @@ gsBoundCP <- function(x, theta = "thetahat", r = 18) {
       thetaharm <- x$harm$bound[1:len] / sqrt(x$n.I[1:len])
     }
     for (i in 1:len) {
-      xharm <- gsCP(x, thetaharm[i], i, x$harm$bound[i])
-      CPharm[i] <- sum(xharm$upper$prob)
+      CPharm[i] <- if (is.finite(x$harm$bound[i])) {
+        sum(gsCP(x, thetaharm[i], i, x$harm$bound[i])$upper$prob)
+      } else {
+        NA_real_ # no harm bound at this analysis
+      }
     }
     result <- cbind(result, CPharm)
   }

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -485,26 +485,26 @@ gsBoundSummary0 <- function(
     for (i in 1:length(x$theta)) pframe3 <- rbind(pframe3, data.frame("Harm" = cumsum(x$harm$prob[, i])))
     pframe <- data.frame(pframe, pframe3)
   }
-  if (x$k > 1) {
-    # conditional power at bound, theta=hat(theta)
-    cp <- data.frame(gsBoundCP(x, r = r))
-    # conditional power at bound, theta=theta[1]
-    cp1 <- data.frame(gsBoundCP(x, theta = x$delta, r = r))
+  cp_at <- function(theta, label) {
+    cp <- data.frame(gsBoundCP(x, theta = theta, r = r))
     if (x$test.type %in% c(7, 8)) {
       colnames(cp) <- c("Futility", "Efficacy", "Harm")
-      colnames(cp1) <- c("Futility", "Efficacy", "Harm")
     } else if (x$test.type > 1) {
       colnames(cp) <- c("Futility", "Efficacy")
-      colnames(cp1) <- c("Futility", "Efficacy")
     } else {
       colnames(cp) <- "Efficacy"
-      colnames(cp1) <- "Efficacy"
     }
-    cp <- data.frame(cp, "Value" = "CP", i = seq_len(x$k - 1))
-    cp1 <- data.frame(cp1, "Value" = "CP H1", i = seq_len(x$k - 1))
-  } else {
+    data.frame(cp, "Value" = label, i = seq_len(x$k - 1))
+  }
+  if ("CP" %in% exclude || x$k == 1) {
     cp <- NULL
+  } else {
+    cp <- cp_at("thetahat", "CP")
+  }
+  if ("CP H1" %in% exclude || x$k == 1) {
     cp1 <- NULL
+  } else {
+    cp1 <- cp_at(x$delta, "CP H1")
   }
   if ("PP" %in% exclude || x$k == 1) {
     pp <- NULL
@@ -803,6 +803,7 @@ gsBoundSummary0 <- function(
 #' @param exclude A list of test statistics to be excluded from design boundary
 #' summary produced; see details or examples for a list of all possible output
 #' values. A value of \code{NULL} produces all available summaries.
+#' Excluded conditional and predictive power quantities are not computed.
 #' @param POS This is an indicator of whether or not probability of success
 #' (POS) should be estimated at baseline or at each interim based on the prior
 #' distribution input in \code{prior}. The prior probability of success before

--- a/man/gsBoundCP.Rd
+++ b/man/gsBoundCP.Rd
@@ -26,11 +26,12 @@ accuracy of \eqn{10^{-6}} with \code{r = 16}. This parameter is normally
 not changed by users.}
 }
 \value{
-A list containing two vectors, \code{CPlo} and \code{CPhi}.
-\item{CPlo}{A vector of length \code{x$k-1} with conditional powers of
-crossing upper bounds given interim test statistics at each lower bound}
-\item{CPhi}{A vector of length \code{x$k-1} with conditional powers of
-crossing upper bounds given interim test statistics at each upper bound.}
+For one-sided designs, a vector of length \code{x$k-1} containing
+conditional power at each interim upper bound. For two-sided designs, a
+matrix with \code{x$k-1} rows and columns \code{CPlo} and \code{CPhi},
+containing conditional power at the lower and upper bounds, respectively.
+Designs with harm bounds (\code{test.type} 7 or 8) also have a
+\code{CPharm} column. An absent bound has conditional power \code{NA}.
 }
 \description{
 \code{gsBoundCP()} computes the total probability of crossing future upper

--- a/man/gsBoundSummary.Rd
+++ b/man/gsBoundSummary.Rd
@@ -126,7 +126,8 @@ bound.}
 
 \item{exclude}{A list of test statistics to be excluded from design boundary
 summary produced; see details or examples for a list of all possible output
-values. A value of \code{NULL} produces all available summaries.}
+values. A value of \code{NULL} produces all available summaries.
+Excluded conditional and predictive power quantities are not computed.}
 
 \item{r}{See \code{\link{gsDesign}}. This is an integer used to control the
 degree of accuracy of group sequential calculations which will normally not

--- a/tests/testthat/test-gsBoundCP-absent.R
+++ b/tests/testthat/test-gsBoundCP-absent.R
@@ -1,0 +1,107 @@
+test_that("gsBoundCP returns NA at absent harm bounds", {
+  for (test_type in c(7, 8)) {
+    for (zero_spend in c(FALSE, TRUE)) {
+      args <- list(
+        k = 3, test.type = test_type, astar = 0.025,
+        testUpper = c(FALSE, TRUE, TRUE),
+        testLower = c(TRUE, TRUE, FALSE)
+      )
+      if (zero_spend) {
+        args$sfharm <- sfPoints
+        args$sfharmparam <- c(0, 0.5, 1)
+      } else {
+        args$testHarm <- c(FALSE, TRUE, TRUE)
+      }
+      x <- do.call(gsDesign, args)
+      expect_identical(x$harm$bound[1], -Inf)
+
+      for (theta in list("thetahat", 0, x$delta)) {
+        cp <- gsBoundCP(x, theta = theta)
+        expect_identical(unname(cp[1, "CPharm"]), NA_real_)
+        expect_true(is.finite(cp[2, "CPharm"]))
+        effect <- if (is.character(theta)) x$harm$bound[2] / sqrt(x$n.I[2]) else theta
+        expected <- sum(gsCP(x, theta = effect, i = 2, zi = x$harm$bound[2])$upper$prob)
+        expect_equal(unname(cp[2, "CPharm"]), expected)
+      }
+    }
+  }
+})
+
+test_that("gsBoundSummary includes conditional power for selective harm designs", {
+  for (test_type in c(7, 8)) {
+    x <- gsDesign(
+      k = 3, test.type = test_type, astar = 0.025,
+      testUpper = c(FALSE, TRUE, TRUE),
+      testLower = c(TRUE, TRUE, FALSE),
+      testHarm = c(FALSE, TRUE, TRUE)
+    )
+    summary <- gsBoundSummary(x, exclude = NULL)
+    expect_s3_class(summary, "gsBoundSummary")
+    for (label in c("CP", "CP H1")) {
+      theta <- if (label == "CP") "thetahat" else x$delta
+      cp <- gsBoundCP(x, theta = theta)
+      rows <- summary$Value == label
+      expect_equal(sum(rows), x$k - 1)
+      expect_equal(summary$Harm[rows], round(cp[, "CPharm"], 4))
+      expect_equal(summary$Futility[rows], round(cp[, "CPlo"], 4))
+      expect_equal(summary$Efficacy[rows], round(cp[, "CPhi"], 4))
+    }
+    expect_true(is.na(summary$Harm[summary$Value == "CP"][1]))
+    expect_true(is.finite(summary$Harm[summary$Value == "CP"][2]))
+  }
+})
+
+test_that("gsBoundSummary only calculates requested conditional power", {
+  original <- gsBoundCP
+  calls <- list()
+  local_mocked_bindings(
+    gsBoundCP = function(x, theta = "thetahat", r = 18) {
+      calls[[length(calls) + 1L]] <<- theta
+      original(x, theta = theta, r = r)
+    },
+    .package = "gsDesign"
+  )
+
+  for (test_type in c(1, 4, 7, 8)) {
+    x <- gsDesign(k = 3, test.type = test_type, astar = 0.025)
+    calls <- list()
+    default <- gsBoundSummary(x)
+    expect_length(calls, 0)
+    expect_false(any(default$Value %in% c("CP", "CP H1")))
+
+    calls <- list()
+    cp_only <- gsBoundSummary(x, exclude = c("CP H1", "PP"))
+    expect_identical(calls, list("thetahat"))
+    expect_true("CP" %in% cp_only$Value)
+    expect_false("CP H1" %in% cp_only$Value)
+
+    calls <- list()
+    h1_only <- gsBoundSummary(x, exclude = c("CP", "PP"))
+    expect_identical(calls, list(x$delta))
+    expect_true("CP H1" %in% h1_only$Value)
+    expect_false("CP" %in% h1_only$Value)
+
+    calls <- list()
+    both <- gsBoundSummary(x, exclude = "PP")
+    expect_identical(calls, list("thetahat", x$delta))
+    columns <- c("Value", "Efficacy", if (test_type > 1) "Futility", if (test_type > 6) "Harm")
+    expect_equal(
+      unname(as.matrix(both[both$Value == "CP", columns])),
+      unname(as.matrix(cp_only[cp_only$Value == "CP", columns]))
+    )
+    expect_equal(
+      unname(as.matrix(both[both$Value == "CP H1", columns])),
+      unname(as.matrix(h1_only[h1_only$Value == "CP H1", columns]))
+    )
+  }
+})
+
+test_that("gsBoundSummary does not calculate conditional power for fixed designs", {
+  local_mocked_bindings(
+    gsBoundCP = function(...) stop("No future analysis for conditional power"),
+    .package = "gsDesign"
+  )
+  summary <- gsBoundSummary(gsSurv(k = 1), exclude = NULL)
+  expect_s3_class(summary, "gsBoundSummary")
+  expect_false(any(summary$Value %in% c("CP", "CP H1")))
+})


### PR DESCRIPTION
After #321, an absent harm bound is `-Inf`. `gsBoundCP()` still evaluates conditional power there, so selective harm designs can produce missing values and fail in `gsProbability()`. `gsBoundSummary()` also performs these calculations before removing excluded rows, which caused gsDesignNB checks to fail, and that also causes gsDesign reverse dependency checks to fail.

This PR:

- Update the implementation to return `NA` at absent harm bounds, matching the existing upper bound and lower bound behavior.
- Calculate `CP` and `CP H1` independently only when requested.
- Add regression tests for skipped and zero-spending harm bounds, requested conditional power rows, independent exclusions, and fixed designs.
- Update documentation.

Validation:

- Focused conditional power and selective bound tests passed.
- Full gsDesign test suite passed with four expected skips for tests restricted to older R versions.
- The updated gsDesignNB passed `R CMD check --as-cran` with CRAN gsDesign 3.11.0 and with this fix.

Companion gsDesignNB PR: https://github.com/keaven/gsDesignNB/pull/47

**Note**: Release gsDesignNB on CRAN before the next gsDesign release, so the gsDesign reverse dependency check will pass.