### PR TITLE
Fix survival summary reporting and POS table layout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.1.9011
+Version: 3.11.1.9012
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,9 @@
 
 ## Bug fixes
 
+- Survival calculation methods are reported in `summary()`, not boundary
+  tables. `gsBoundSummary()` keeps all analysis annotations when POS or
+  excluded statistics require unequal block sizes (#332).
 - Guarded the Newton boundary search against `0/0` updates and separated its
   iteration limit and finite iterate clamp from the absent-bound values
   (#242, #321).

--- a/R/as_rtf.R
+++ b/R/as_rtf.R
@@ -179,7 +179,7 @@ as_rtf.gsBoundSummary <- function(
   
   
   # Add a for first instance of "p (1-sided)" in Value column
-  if(!is.null(which(x$Value == "p (1-sided)")[1])) {
+  if(any(x$Value == "p (1-sided)")) {
     first_instance <- which(x$Value == "p (1-sided)")[1]
     x[first_instance, "Value"] <- paste0(x[first_instance, "Value"], "{^", letters[letter_order], "}")
     footnote <- c(footnote, paste0("{^", letters[letter_order], "}", footnote_p_onesided))
@@ -187,7 +187,7 @@ as_rtf.gsBoundSummary <- function(
   }
   
   # Add b for first instance of "~HR at bound" in Value column
-  if(!is.null(which(x$Value == "~HR at bound")[1])) {
+  if(any(x$Value == "~HR at bound")) {
     first_instance <- which(x$Value == "~HR at bound")[1]
     x[first_instance, "Value"] <- paste0(x[first_instance, "Value"], "{^", letters[letter_order], "}")
     footnote <- c(footnote, paste0("{^", letters[letter_order], "}", footnote_appx_effect_at_bound))
@@ -195,7 +195,7 @@ as_rtf.gsBoundSummary <- function(
   }
 
   # Add c for first instance of "P(Cross) if HR=1" in Value column
-  if(!is.null(which(x$Value == "P(Cross) if HR=1")[1])) {
+  if(any(x$Value == "P(Cross) if HR=1")) {
     first_instance <- which(x$Value == "P(Cross) if HR=1")[1]
     x[first_instance, "Value"] <- paste0(x[first_instance, "Value"], "{^", letters[letter_order], "}")
     footnote <- c(footnote, paste0("{^", letters[letter_order], "}", footnote_p_cross_h0))
@@ -203,7 +203,7 @@ as_rtf.gsBoundSummary <- function(
   }
 
   # Add d for first instance of "P(Cross) if HR=0.5" in Value column
-  if(!is.null(which(x$Value == "P(Cross) if HR=0.5")[1])) {
+  if(any(x$Value == "P(Cross) if HR=0.5")) {
     first_instance <- which(x$Value == "P(Cross) if HR=0.5")[1]
     x[first_instance, "Value"] <- paste0(x[first_instance, "Value"], "{^", letters[letter_order], "}")
     footnote <- c(footnote, paste0("{^", letters[letter_order], "}", footnote_p_cross_h1))
@@ -223,13 +223,13 @@ as_rtf.gsBoundSummary <- function(
   }
   
   # Insert blank row when Analysis column is null
-  idx <- which(x$Value == "Z")
+  idx <- which(grepl("^(IA [0-9]+:|Final$)", x$Analysis))
   blank_row <- data.frame(matrix(ncol = ncol(x), nrow = 1))
   colnames(blank_row) <- colnames(x)
 
-  x_sub <- x[1:(idx[2] - 1), ]
-  for (i in 2:length(idx)) {
-    row_end <- ifelse(i == length(idx), length(x$Value), (idx[i + 1] - 1))
+  x_sub <- x[seq_len(if (length(idx) > 1L) idx[2] - 1L else nrow(x)), ]
+  if (length(idx) > 1L) for (i in seq.int(2L, length(idx))) {
+    row_end <- ifelse(i == length(idx), nrow(x), (idx[i + 1] - 1))
     x_sub <- rbind(x_sub, blank_row, x[idx[i]:row_end, ])
   }
 
@@ -237,12 +237,12 @@ as_rtf.gsBoundSummary <- function(
   x |>
     rtf_title(title = title) |>
     rtf_colheader(
-      paste0("Analysis", " | ", "Value", " | ", "Efficacy", " | ", "Futility"),
-      col_rel_width = c(1, 1.5, 1, 1)
+      paste(names(x), collapse = " | "),
+      col_rel_width = c(1, 1.5, rep(1, ncol(x) - 2))
     ) |>
     rtf_body(
-      text_justification = c("l", rep("c", 3)),
-      col_rel_width = c(1, 1.5, 1, 1)
+      text_justification = c("l", rep("c", ncol(x) - 1)),
+      col_rel_width = c(1, 1.5, rep(1, ncol(x) - 2))
     ) |>
     rtf_footnote(footnote) |>
     rtf_encode() |>

--- a/R/gsMethods.R
+++ b/R/gsMethods.R
@@ -120,6 +120,14 @@ summary.gsDesign <- function(object, information = FALSE, timeunit = "months", .
   }
   out <- paste(out, 100 * (1 - object$beta), " percent power, ", 100 * object$alpha, " percent (1-sided) Type I error", sep = "")
   if ("gsSurv" %in% class(object)) {
+    if (is.character(object$method) && length(object$method) == 1L &&
+        !is.na(object$method) && nzchar(object$method)) {
+      method_name <- switch(object$method,
+        LachinFoulkes = "Lachin-Foulkes", BernsteinLagakos = "Bernstein-Lagakos",
+        object$method
+      )
+      out <- paste0(out, " (sample size/power method: ", method_name, ")")
+    }
     out <- paste(out, " to detect a hazard ratio of ", round(object$hr, 2), sep = "")
     if (object$hr0 != 1) out <- paste(out, " with a null hypothesis hazard ratio of ", round(object$hr0, 2), sep = "")
     out <- paste(out, ". Enrollment and total study durations are assumed to be ", round(sum(object$R), 1),
@@ -565,34 +573,35 @@ gsBoundSummary0 <- function(
   statframe <- statframe[!(statframe$Value %in% exclude), ]
   # sort by analysis
   statframe <- statframe[order(statframe$i), ]
-  # add analysis and timing
-  statframe$Analysis <- ""
+  # Build annotations independently of the selected boundary statistics.
+  # A block must accommodate the longer of the two columns of information.
   aname <- paste("IA ", 1:x$k, ": ", round(100 * x$timing, 0), "%", sep = "")
   aname[x$k] <- "Final"
-  statframe[statframe$Value == statframe$Value[1], ]$Analysis <- aname
+  annotations <- as.list(aname)
   # sample size, events or information at analyses
   if (!("gsSurv" %in% class(x))) {
     if (x$n.fix > 1) N <- ceiling(x$n.I) else N <- round(x$n.I, 2)
     if (Nname == "Information") N <- round(x$n.I, 2)
     # Check if calendar time T is provided (for non-gsSurv objects like gsNB)
     if (inherits(x, "gsNB") && !is.null(x$T)) {
-      nstat <- 3
       Time <- round(x$T, tdigits)
-      statframe[statframe$Value == statframe$Value[3], ]$Analysis <- paste(timename, ": ", as.character(Time), sep = "")
-    } else {
-      nstat <- 2
     }
   } else {
-    nstat <- 4
     event_counts <- gsRoundNearInteger(x$n.I)
-    statframe[statframe$Value == statframe$Value[3], ]$Analysis <- paste("Events:", ceiling(event_counts))
     experimental_n <- gsRoundNearInteger(rowSums(x$eNE))
     control_n <- gsRoundNearInteger(rowSums(x$eNC))
     if (x$ratio == 1) N <- 2 * ceiling(experimental_n) else N <- ceiling(experimental_n) + ceiling(control_n)
     Time <- round(x$T, tdigits)
-    statframe[statframe$Value == statframe$Value[4], ]$Analysis <- paste(timename, ": ", as.character(Time), sep = "")
   }
-  statframe[statframe$Value == statframe$Value[2], ]$Analysis <- paste(Nname, ": ", N, sep = "")
+  for (i in seq_len(k)) {
+    annotations[[i]] <- c(annotations[[i]], paste0(Nname, ": ", N[i]))
+    if (inherits(x, "gsSurv")) {
+      annotations[[i]] <- c(annotations[[i]], paste("Events:", ceiling(event_counts[i])))
+    }
+    if (inherits(x, "gsSurv") || (inherits(x, "gsNB") && !is.null(x$T))) {
+      annotations[[i]] <- c(annotations[[i]], paste0(timename, ": ", Time[i]))
+    }
+  }
   # add POS and predictive POS, if requested
   if (POS) {
     if (x$k == 1) {
@@ -601,9 +610,9 @@ gsBoundSummary0 <- function(
           prior$z * sqrt(x$n.I[1]) - x$upper$bound[1]
         )
       )
-      statframe$Analysis[nrow(statframe)] <- paste0(
+      annotations[[1]] <- c(annotations[[1]], paste0(
         "Trial POS: ", round(100 * trial_pos, 1), "%"
-      )
+      ))
     } else {
       ppos <- rep("", x$k)
       for (i in seq_len(x$k - 1)) {
@@ -616,18 +625,31 @@ gsBoundSummary0 <- function(
           sep = ""
         )
       }
-      statframe[statframe$Value == statframe$Value[nstat + 1], ]$Analysis <- ppos
-      statframe[nstat + 2, ]$Analysis <- ppos[1]
-      statframe[nstat + 1, ]$Analysis <- paste(
+      annotations[[1]] <- c(annotations[[1]], paste(
         "Trial POS: ",
         as.character(round(100 * gsPOS(
           x = x, theta = prior$z, wgts = prior$wgts
         ), 1)),
         "%",
         sep = ""
-      )
+      ))
+      for (i in seq_len(k - 1L)) annotations[[i]] <- c(annotations[[i]], ppos[i])
     }
   }
+  blocks <- lapply(seq_len(k), function(i) {
+    block <- statframe[statframe$i == i, , drop = FALSE]
+    n <- max(nrow(block), length(annotations[[i]]))
+    if (n > nrow(block)) {
+      pad <- statframe[rep(NA_integer_, n - nrow(block)), , drop = FALSE]
+      pad$Value <- ""
+      pad$i <- i
+      block <- rbind(block, pad)
+    }
+    block$Analysis <- c(annotations[[i]], rep("", n - length(annotations[[i]])))
+    block
+  })
+  statframe <- do.call(rbind, blocks)
+  rownames(statframe) <- NULL
   # add futility and harm columns to data frame
   if (x$test.type %in% c(7, 8)) {
     # Order: Harm, Futility, Efficacy
@@ -673,6 +695,12 @@ gsBoundSummary0 <- function(
 }
 # gsBoundSummary roxy [sinew] ----
 #' @title Bound Summary and Z-transformations
+#' @details For survival designs, \code{summary()} identifies the stored
+#' sample size/power calculation method, when available. The method is not
+#' displayed by \code{gsBoundSummary()}. Each analysis block accommodates
+#' both its annotations and the selected boundary statistics, padding the
+#' shorter side. Padding has an empty \code{Value} and missing numeric values;
+#' the print method displays these cells as blanks.
 #' @description  A tabular summary of a group sequential design's bounds and their properties
 #' are often useful. The 'vintage' \code{print.gsDesign()} function provides a
 #' complete but minimally formatted summary of a group sequential design
@@ -1051,7 +1079,11 @@ gsBoundSummary <- function(
       # POS is only computed for original alpha level
       exclude = exclude, POS = FALSE, ratio = ratio, r = r, prior = prior
     )
-    out <- cbind(out, yout$Efficacy)
+    # POS annotations can require extra rows only in the original table.
+    # Match statistical rows within analyses instead of recycling columns.
+    row_match <- match(paste(analysis_i, out$Value),
+                       paste(attr(yout, "analysis_i"), yout$Value))
+    out <- cbind(out, yout$Efficacy[row_match])
     names(out)[ncol(out)] <- sprintf(efficacy_format, a)
 
     # now if test.type is not 1, we need to add futility bounds
@@ -1178,11 +1210,14 @@ xprint <- function(x, include.rownames = FALSE,
 #' @rdname gsBoundSummary
 # print.gsBoundSummary function [sinew] ----
 print.gsBoundSummary <- function(x, row.names = FALSE, digits = 4, ...) {
-  method <- attr(x, "method", exact = TRUE)
-  if (!is.null(method)) {
-    cat("Method:", method, "\n")
+  if (any(x$Value == "")) {
+    display <- format.data.frame(x, digits = digits)
+    display[x$Value == "", setdiff(names(x), "Analysis")] <- ""
+    print.data.frame(display, row.names = row.names, ...)
+  } else {
+    print.data.frame(x, row.names = row.names, digits = digits, ...)
   }
-  print.data.frame(x, row.names = row.names, digits = digits, ...)
+  invisible(x)
 }
 
 # gsLegendText function [sinew] ----

--- a/man/gsBoundSummary.Rd
+++ b/man/gsBoundSummary.Rd
@@ -277,6 +277,14 @@ including its cumulative crossing probability, is shown as \code{NA} at an
 analysis where that bound is inactive. The underlying probability arrays on
 \code{x} retain the cumulative crossing information.
 }
+\details{
+For survival designs, \code{summary()} identifies the stored
+sample size/power calculation method, when available. The method is not
+displayed by \code{gsBoundSummary()}. Each analysis block accommodates
+both its annotations and the selected boundary statistics, padding the
+shorter side. Padding has an empty \code{Value} and missing numeric values;
+the print method displays these cells as blanks.
+}
 \note{
 The gsDesign technical manual is available at
   \url{https://keaven.github.io/gsd-tech-manual/}.

--- a/tests/testthat/_snaps/independent-test-as_rtf/gsBoundSummary-footnote.rtf
+++ b/tests/testthat/_snaps/independent-test-as_rtf/gsBoundSummary-footnote.rtf
@@ -85,6 +85,16 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 IA 2: 67%}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Z}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2.5465}\cell

--- a/tests/testthat/_snaps/independent-test-gsBoundSummary.md
+++ b/tests/testthat/_snaps/independent-test-gsBoundSummary.md
@@ -58,7 +58,6 @@
 
 # Test gsBoundSummary for gsSurv Object
 
-    Method: LachinFoulkes 
        Analysis              Value Efficacy Futility
       IA 1: 33%                  Z   3.0107  -0.2388
          N: 460        p (1-sided)   0.0013   0.5944

--- a/tests/testthat/_snaps/independent-test-print.gsSurv.md
+++ b/tests/testthat/_snaps/independent-test-print.gsSurv.md
@@ -9,7 +9,6 @@
       Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2.
     
     Analysis summary:
-    Method: LachinFoulkes 
        Analysis              Value Efficacy Futility
       IA 1: 33%                  Z   3.0107  -0.2388
           N: 44        p (1-sided)   0.0013   0.5944
@@ -47,7 +46,6 @@
       Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2.
     
     Analysis summary:
-    Method: LachinFoulkes 
        Analysis              Value Efficacy Futility
       IA 1: 33%                  Z   3.0107  -0.2388
           N: 24        p (1-sided)   0.0013   0.5944
@@ -85,7 +83,6 @@
       Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.
     
     Analysis summary:
-    Method: LachinFoulkes 
         Analysis              Value Efficacy Futility
        IA 1: 25%                  Z   3.1554   0.1555
            N: 76        p (1-sided)   0.0008   0.4382
@@ -127,7 +124,6 @@
       Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4.
     
     Analysis summary:
-    Method: LachinFoulkes 
        Analysis              Value Efficacy
       IA 1: 25%                  Z   3.1554
           N: 64        p (1-sided)   0.0008
@@ -170,7 +166,6 @@
       Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.
     
     Analysis summary:
-    Method: LachinFoulkes 
         Analysis              Value Efficacy Futility
        IA 1: 25%                  Z   3.1554   0.1555
            N: 80        p (1-sided)   0.0008   0.4382

--- a/tests/testthat/_snaps/independent-test-summary.gsDesign.md
+++ b/tests/testthat/_snaps/independent-test-summary.gsDesign.md
@@ -1,26 +1,26 @@
 # Test - gsSurv
 
-    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 314 and 57 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
+    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 314 and 57 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
 
 # Test - gsSurv change in snapshot
 
-    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 628 and 137 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.56. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
+    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 628 and 137 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.56. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
 
 # Test - gsSurv - test.type = 1
 
-    [1] "One-sided group sequential design with 3 analyses, time-to-event outcome with sample size 298 and 54 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4."
+    [1] "One-sided group sequential design with 3 analyses, time-to-event outcome with sample size 298 and 54 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4."
 
 # Test - gsSurv - test.type = 2
 
-    [1] "Symmetric two-sided group sequential design with 3 analyses, time-to-event outcome with sample size 298 and 54 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Bounds derived using a  Hwang-Shih-DeCani spending function with gamma = -4."
+    [1] "Symmetric two-sided group sequential design with 3 analyses, time-to-event outcome with sample size 298 and 54 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Bounds derived using a  Hwang-Shih-DeCani spending function with gamma = -4."
 
 # Test - gsSurv - test.type = 3
 
-    [1] "Asymmetric two-sided group sequential design with binding futility bound, 3 analyses, time-to-event outcome with sample size 308 and 56 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
+    [1] "Asymmetric two-sided group sequential design with binding futility bound, 3 analyses, time-to-event outcome with sample size 308 and 56 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
 
 # Test for gsSurv - hr0 < 1
 
-    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 1506 and 311 events required, 90 percent power, 2.5 percent (1-sided) Type I error to detect a hazard ratio of 0.6 with a null hypothesis hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
+    [1] "Asymmetric two-sided group sequential design with non-binding futility bound, 3 analyses, time-to-event outcome with sample size 1506 and 311 events required, 90 percent power, 2.5 percent (1-sided) Type I error (sample size/power method: Lachin-Foulkes) to detect a hazard ratio of 0.6 with a null hypothesis hazard ratio of 0.4. Enrollment and total study durations are assumed to be 0.5 and 2 months, respectively. Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4. Futility bounds derived using a Hwang-Shih-DeCani spending function with gamma = -2."
 
 # Test:  nSurvival object
 

--- a/tests/testthat/test-summary-reporting.R
+++ b/tests/testthat/test-summary-reporting.R
@@ -1,0 +1,84 @@
+test_that("survival methods belong in overall summaries only", {
+  methods <- c(LachinFoulkes = "Lachin-Foulkes", Schoenfeld = "Schoenfeld",
+               Freedman = "Freedman", BernsteinLagakos = "Bernstein-Lagakos")
+  for (method in names(methods)) {
+    for (make in list(
+      function() gsSurv(method = method),
+      function() gsSurv(k = 1, test.type = 1, method = method),
+      function() gsSurvCalendar(method = method)
+    )) {
+      x <- make()
+      expect_match(summary(x), paste0("sample size/power method: ", methods[[method]]), fixed = TRUE)
+      out <- gsBoundSummary(x)
+      expect_false(any(grepl("Method:|method:", capture.output(print(out)))))
+      old <- x
+      old$method <- NULL
+      expect_false(grepl("method:", summary(old), fixed = TRUE))
+      expect_equal(out[, -1], gsBoundSummary(old)[, -1], ignore_attr = TRUE)
+    }
+  }
+  x <- gsDesign()
+  text <- summary(x)
+  x$method <- "Schoenfeld"
+  expect_identical(summary(x), text)
+})
+
+summary_blocks <- function(x) {
+  starts <- which(grepl("^(IA [0-9]+:|Final$)", x$Analysis))
+  split(x, findInterval(seq_len(nrow(x)), starts))
+}
+
+test_that("POS annotations are kept within each analysis regardless of exclusions", {
+  x <- gsSurv()
+  all <- gsBoundSummary(x, exclude = NULL)
+  all_blocks <- summary_blocks(all)
+  defaults <- c("B-value", "Spending", "CP", "CP H1", "PP")
+  for (pos in c(FALSE, TRUE)) {
+    for (excluded in list(NULL, defaults, c(defaults, "p (1-sided)"), unique(all$Value))) {
+      out <- gsBoundSummary(x, POS = pos, exclude = excluded)
+      blocks <- summary_blocks(out)
+      expect_length(blocks, x$k)
+      for (i in seq_len(x$k)) {
+        b <- blocks[[i]]
+        nnotes <- 4L + as.integer(pos && i == 1L) + as.integer(pos && i < x$k)
+        original <- all_blocks[[i]]
+        original <- original[!original$Value %in% excluded, , drop = FALSE]
+        expect_equal(nrow(b), max(nnotes, nrow(original)))
+        expect_match(b$Analysis[2], "N:", fixed = TRUE)
+        expect_match(b$Analysis[3], "Events:", fixed = TRUE)
+        expect_match(b$Analysis[4], "Month:", fixed = TRUE)
+        expect_equal(sum(grepl("Trial POS:", b$Analysis, fixed = TRUE)), as.integer(pos && i == 1L))
+        expect_equal(sum(grepl("Post IA POS:", b$Analysis, fixed = TRUE)), as.integer(pos && i < x$k))
+        expect_equal(lapply(b[b$Value != "", -1], identity), lapply(original[, -1], identity))
+        expect_true(all(is.na(as.matrix(b[b$Value == "", -(1:2), drop = FALSE]))))
+      }
+      expect_false(any(grepl("NA", capture.output(print(out)), fixed = TRUE)))
+    }
+  }
+})
+
+test_that("alternate alpha columns align despite POS padding", {
+  x <- gsSurv()
+  out <- gsBoundSummary(x, POS = TRUE, alpha = c(.025, .01))
+  ref <- gsBoundSummary(x, POS = FALSE, alpha = c(.025, .01))
+  expect_equal(lapply(out[out$Value != "", -1], identity), lapply(ref[ref$Value != "", -1], identity))
+  expect_true(all(is.na(out[out$Value == "", 3:ncol(out)])))
+})
+
+test_that("fixed designs and rendered tables retain annotations", {
+  for (x in list(gsSurv(), gsSurv(k = 1, test.type = 1))) {
+    out <- gsBoundSummary(x, POS = TRUE,
+      exclude = c("Z", "B-value", "Spending", "CP", "CP H1", "PP", "p (1-sided)"))
+    expect_length(summary_blocks(out), x$k)
+    html <- capture.output(print(xtable::xtable(out), type = "html", include.rownames = FALSE))
+    expect_true(any(grepl("Trial POS:", html, fixed = TRUE)))
+    expect_false(any(grepl("LachinFoulkes", html, fixed = TRUE)))
+    if (requireNamespace("r2rtf", quietly = TRUE)) {
+      path <- tempfile(fileext = ".rtf")
+      expect_no_error(as_rtf(out, file = path))
+      rtf <- readLines(path, warn = FALSE)
+      expect_true(any(grepl("Trial POS:", rtf, fixed = TRUE)))
+      expect_false(any(grepl("LachinFoulkes", rtf, fixed = TRUE)))
+    }
+  }
+})


### PR DESCRIPTION
Closes #332.

Report the stored survival calculation method in summary(), not gsBoundSummary(). Size every analysis block independently so all POS annotations and requested statistics remain visible, including with exclusions. Align alternate-alpha columns and support padded RTF output.

Validation: new regression tests and all focused reporting/RTF tests pass. Full unit suite completed; after updating intended reporting snapshots, only two power-plot SVG legend-order differences remain. Those plotting paths are unchanged by this PR; checking the master baseline separately. Statistical calculations are unchanged.