### PR TITLE
Label information-based plots with fractional information

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.1.9012
+Version: 3.11.1.9013
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 ## Bug fixes
 
+- Information-based boundary plots label actual information as `I=` with
+  two decimal places, rather than rounding it to a sample size (#315).
 - Survival calculation methods are reported in `summary()`, not boundary
   tables. `gsBoundSummary()` keeps all analysis annotations when POS or
   excluded statistics require unequal block sizes (#332).

--- a/R/gsqplot.R
+++ b/R/gsqplot.R
@@ -18,6 +18,9 @@ globalVariables(c("y", "N", "Z", "Bound", "thetaidx", "Probability", "delta", "A
 #' values of \code{plottype}; one exception is that \code{type="l"} cannot be
 #' overridden when \code{plottype=2}. Default values for labels depend on
 #' \code{plottype} and the class of \code{x}.
+#' For \code{endpoint = "info"}, information annotations on boundary,
+#' treatment-effect, B-value, and conditional-power plots use \code{I=}
+#' and round information to two decimal places (without integer rounding).
 #'
 #' For test types 7 and 8, harm and futility probabilities stored on the
 #' design are mutually exclusive stopping outcomes. In a type 2 plot, the
@@ -359,17 +362,22 @@ qplotit <- function(x, xlim = NULL, ylim = NULL, main = NULL, geom = c("line", "
     if (length(dgt) < 3) dgt <- c(dgt, dgt[1])
   }
   is_surv <- inherits(x, "gsSurv")
-  if (x$n.fix == 1) {
+  is_info <- isTRUE(tolower(x$endpoint) == "info")
+  if (is_info) {
+    nround <- 2
+    ntx <- "I="
+    if (is.null(xlab)) xlab <- "Information"
+  } else if (x$n.fix == 1) {
     nround <- 3
     ntx <- "r="
     if (is.null(xlab)) xlab <- "Information relative to fixed sample design"
   } else if (is_surv || x$nFixSurv > 0) {
-    ntx <- "d="
+    ntx <- "N="
     nround <- 0
     if (is.null(xlab)) xlab <- "Events"
   } else {
     nround <- 0
-    ntx <- "n="
+    ntx <- "N="
     if (is.null(xlab)) xlab <- "Sample size"
   }
   if (x$test.type > 1) {
@@ -486,7 +494,7 @@ qplotit <- function(x, xlim = NULL, ylim = NULL, main = NULL, geom = c("line", "
     if (base) {
       graphics::text(x = y2$N, y = y$Z, y$Ztxt, cex = cex)
     }
-    if (x$n.fix == 1) {
+    if (x$n.fix == 1 && !is_info) {
       if (base) {
         graphics::text(x = y2$N, y = y2$Z, paste(rep("r=", x$k), y2$Ztxt, sep = ""), cex = cex)
       } else {
@@ -495,9 +503,9 @@ qplotit <- function(x, xlim = NULL, ylim = NULL, main = NULL, geom = c("line", "
       }
     } else {
       if (base) {
-        graphics::text(x = y2$N, y = y2$Z, paste(rep("N=", x$k), y2$Ztxt, sep = ""), cex = cex)
+        graphics::text(x = y2$N, y = y2$Z, paste0(ntx, y2$Ztxt), cex = cex)
       } else {
-        y2$Ztxt <- paste(rep("N=", x$k), y2$Ztxt, sep = "")
+        y2$Ztxt <- paste0(ntx, y2$Ztxt)
         p <- p + ggplot2::geom_text(data = y2, ggplot2::aes(group = factor(.data$Bound), label = Ztxt), size = cex * 5, show.legend = F, colour = getColor(1))
       }
     }
@@ -558,17 +566,22 @@ plotgsCP <- function(x, theta = "thetahat", main = "Conditional power at interim
     xlim <- xlim + c(-.05, .05) * (xlim[2] - xlim[1])
     if (x$k == 2) xlim <- xlim + c(-1, 1)
   }
-  if (x$n.fix == 1) {
+  is_info <- isTRUE(tolower(x$endpoint) == "info")
+  if (is_info) {
+    nround <- 2
+    ntx <- "I="
+    if (is.null(xlab)) xlab <- "Information"
+  } else if (x$n.fix == 1) {
     nround <- 3
     ntx <- "r="
     if (is.null(xlab)) xlab <- "Information relative to fixed sample design"
   } else if (inherits(x, "gsSurv")) {
     nround <- 0
-    ntx <- "d="
+    ntx <- "N="
     if (is.null(xlab)) xlab <- "Events"
   } else {
     nround <- 0
-    ntx <- "n="
+    ntx <- "N="
     if (is.null(xlab)) xlab <- "N"
   }
   test.type <- ifelse(inherits(x, "gsProbability"), 3, x$test.type)
@@ -688,7 +701,7 @@ plotgsCP <- function(x, theta = "thetahat", main = "Conditional power at interim
       Bound = rep("Lower", x$k - 1),
       Ztxt = as.character(round(x$n.I[1:(x$k - 1)], nround))
     )
-    if (x$n.fix == 1) {
+    if (x$n.fix == 1 && !is_info) {
       if (base) {
         graphics::text(x = y2$N, y = y2$CP, paste(rep("r=", length(y2$Ztxt)), y2$Ztxt, sep = ""), cex = cex)
       } else {
@@ -697,9 +710,9 @@ plotgsCP <- function(x, theta = "thetahat", main = "Conditional power at interim
       }
     } else {
       if (base) {
-        graphics::text(x = y2$N, y = y2$CP, paste(rep("N=", length(y2$Ztxt)), y2$Ztxt, sep = ""), cex = cex)
+        graphics::text(x = y2$N, y = y2$CP, paste0(ntx, y2$Ztxt), cex = cex)
       } else {
-        y2$Ztxt <- paste(rep("N=", x$k - 1), y2$Ztxt, sep = "")
+        y2$Ztxt <- paste0(ntx, y2$Ztxt)
         p <- p + geom_text(data = y2, aes(N, CP, group = factor(Bound), label = Ztxt), size = cex * 5, colour = getColor(1))
       }
     }

--- a/man/plot.gsDesign.Rd
+++ b/man/plot.gsDesign.Rd
@@ -77,6 +77,9 @@ ylab, lty, col, lwd, type, pch, cex} have been tested and work for most
 values of \code{plottype}; one exception is that \code{type="l"} cannot be
 overridden when \code{plottype=2}. Default values for labels depend on
 \code{plottype} and the class of \code{x}.
+For \code{endpoint = "info"}, information annotations on boundary,
+treatment-effect, B-value, and conditional-power plots use \code{I=}
+and round information to two decimal places (without integer rounding).
 
 For test types 7 and 8, harm and futility probabilities stored on the
 design are mutually exclusive stopping outcomes. In a type 2 plot, the

--- a/tests/testthat/test-plot-information-labels.R
+++ b/tests/testthat/test-plot-information-labels.R
@@ -1,0 +1,38 @@
+test_that("information annotations retain fractional values in every bound plot", {
+  x <- gsDesign(n.fix = 10, endpoint = "info")
+  for (type in c(1, 3, 4, 7)) {
+    indices <- seq_len(if (type == 4) x$k - 1L else x$k)
+    expected <- paste0("I=", round(x$n.I[indices], 2))
+    p <- plot(x, plottype = type)
+    labels <- unlist(lapply(ggplot2::ggplot_build(p)$data, function(d) d$label))
+    expect_true(all(expected %in% labels))
+    expect_false(any(grepl("^N=", labels)))
+    expect_identical(p$scales$get_scales("x")$name, "Information")
+    expect_identical(plot(x, plottype = type, xlab = "Custom")$scales$get_scales("x")$name, "Custom")
+    svg <- svglite::stringSVG(plot(x, plottype = type, base = TRUE))
+    for (label in expected) expect_match(svg, paste0(">", label, "</text>"), fixed = TRUE)
+    expect_false(grepl(">N=", svg, fixed = TRUE))
+    unlabeled <- plot(x, plottype = type, nlabel = FALSE)
+    labels <- unlist(lapply(ggplot2::ggplot_build(unlabeled)$data, function(d) d$label))
+    expect_false(any(grepl("^I=", labels)))
+  }
+})
+
+test_that("relative information, sample sizes and events keep existing labels", {
+  for (x in list(gsDesign(), gsDesign(n.fix = 100), gsSurv())) {
+    for (type in c(1, 3, 4, 7)) {
+      p <- plot(x, plottype = type)
+      labels <- unlist(lapply(ggplot2::ggplot_build(p)$data, function(d) d$label))
+      indices <- seq_len(if (type == 4) x$k - 1L else x$k)
+      values <- if (x$n.fix == 1) round(x$n.I[indices], 3) else if (type == 4) {
+        round(x$n.I[indices])
+      } else ceiling(x$n.I[indices])
+      expected <- paste0(if (x$n.fix == 1) "r=" else "N=", values)
+      expect_true(all(expected %in% labels))
+    }
+  }
+  x <- gsDesign(n.fix = 1, endpoint = "info")
+  p <- plot(x)
+  labels <- unlist(lapply(ggplot2::ggplot_build(p)$data, function(d) d$label))
+  expect_true(all(paste0("I=", round(x$n.I, 2)) %in% labels))
+})


### PR DESCRIPTION
Closes #315. Stacked after #336; retarget to master after that PR merges.

Use I= and two-decimal information annotations for Z, approximate effect, B-value and conditional-power plots, in both base graphics and ggplot2. Preserve existing sample/event/relative-information labels and custom axis labels.

Validation: 48 new label checks and 8 plot-input checks pass. Existing plot snapshots pass except the same two power-plot legend-order differences reproduced on untouched master with this local environment. No unrelated snapshots changed.