### PR TITLE
Preserve skipped futility looks in exact binomial conversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.1.9013
+Version: 3.11.1.9014
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 ## Bug fixes
 
+- Exact binomial conversion preserves skipped futility looks without invalid
+  provisional boundaries during beta-spending calibration (#333).
 - Information-based boundary plots label actual information as `I=` with
   two decimal places, rather than rounding it to a sample size (#315).
 - Survival calculation methods are reported in `summary()`, not boundary

--- a/R/toBinomialExact.R
+++ b/R/toBinomialExact.R
@@ -52,6 +52,11 @@
 #' If \code{x$testLower} is present (for example from \code{gsSurv()} with
 #' selective lower-bound looks), lower-bound spending is flattened at analyses
 #' where \code{testLower = FALSE}.
+#' For Type 4, the exact futility bound at a skipped look carries forward
+#' \code{n.I - b} from the preceding look (or uses \code{b = n.I + 1}
+#' at a skipped first look). It cannot be crossed by a continuing path and
+#' spends no additional beta. Efficacy calibration ignores these non-binding
+#' futility bounds.
 #' 
 #' @return An object with primary class \code{gsBinomialExactSpending},
 #'   inheriting from \code{gsBinomialExact} and \code{gsProbability}. In
@@ -320,32 +325,44 @@ toBinomialExact <- function(x, observedEvents = NULL, alpha = NULL, usTime = NUL
       bmax <- counts[j] + 1
       bmax <- ifelse(j == 1, bmax, min(bmax, counts[j] - counts[j - 1] + b[j - 1]))
       if (bmin > bmax) stop(paste("bmin > bmax: bmin =", bmin, "bmax =", bmax, "j =", j))
+      # Carry the gap counts - b forward at inactive looks. No path that
+      # continued at the preceding look can cross this bound, even if every
+      # additional event is on treatment.
+      if (!isTRUE(active_lower[j])) {
+        b[j] <- bmax
+        next
+      }
+      # Only evaluate calibrated looks. In particular, a provisional bound
+      # at look 2 can be invalid after updating look 1. Its value is irrelevant
+      # to the first-look probability, which is a simple binomial tail.
+      upper_probability <- function(candidate) {
+        if (j == 1L) {
+          return(stats::pbinom(candidate - 1, counts[j], p1, lower.tail = FALSE))
+        }
+        b_candidate <- b[seq_len(j)]
+        b_candidate[j] <- candidate
+        sum(gsBinomialExact(
+          k = j, theta = p1, n.I = counts[seq_len(j)],
+          a = a[seq_len(j)], b = b_candidate
+        )$upper$prob[, 1])
+      }
       b[j] <- ifelse(b[j] > bmax, bmax, b[j])
       b[j] <- ifelse(b[j] < bmin, bmin, b[j])
       btem[j] <- b[j]
-      upperprob <- sum(gsBinomialExact(
-        k = max(j, 2), theta = p1, n.I = counts[1:max(j, 2)],
-        a = a[1:max(j, 2)], b = b[1:max(j, 2)]
-      )$upper$prob[1:j])
+      upperprob <- upper_probability(b[j])
       if (upperprob < lower_spend[j]) {
         while (upperprob < lower_spend[j]) {
           b[j] <- btem[j]
           if (btem[j] == bmin) break # only lower if range allows
           btem[j] <- btem[j] - 1
-          upperprob <- sum(gsBinomialExact(
-            k = max(j, 2), theta = p1, n.I = counts[1:max(j, 2)],
-            a = a[1:max(j, 2)], b = btem[1:max(j, 2)]
-          )$upper$prob[1:j])
+          upperprob <- upper_probability(btem[j])
         }
         
       } else if (upperprob > lower_spend[j]) {
         while (upperprob > lower_spend[j] &&
                b[j] < bmax) {
           b[j] <- b[j] + 1
-          upperprob <- sum(gsBinomialExact(
-            k = max(j, 2), theta = p1, n.I = counts[1:max(j, 2)],
-            a = a[1:max(j, 2)], b = b[1:max(j, 2)]
-          )$upper$prob[1:j])
+          upperprob <- upper_probability(b[j])
         }
       }
     } else if (x$test.type == 6) {

--- a/man/toBinomialExact.Rd
+++ b/man/toBinomialExact.Rd
@@ -88,6 +88,11 @@ spending time is set to 1 so all remaining spending is used at the last look.
 If \code{x$testLower} is present (for example from \code{gsSurv()} with
 selective lower-bound looks), lower-bound spending is flattened at analyses
 where \code{testLower = FALSE}.
+For Type 4, the exact futility bound at a skipped look carries forward
+\code{n.I - b} from the preceding look (or uses \code{b = n.I + 1}
+at a skipped first look). It cannot be crossed by a continuing path and
+spends no additional beta. Efficacy calibration ignores these non-binding
+futility bounds.
 }
 \examples{
 # The following code derives the group sequential design using the method

--- a/tests/testthat/test-exact-skipped-futility.R
+++ b/tests/testthat/test-exact-skipped-futility.R
@@ -1,0 +1,73 @@
+skipped_futility_design <- function(testLower = c(TRUE, FALSE, FALSE)) {
+  gsSurv(
+    k = 3, test.type = 4, alpha = .025, beta = .1251133,
+    timing = c(.46, .76), sfu = sfHSD, sfupar = 3.25,
+    sfl = sfHSD, sflpar = -2.8, lambdaC = c(.002, 0), S = 12,
+    eta = 0, hr = .3, hr0 = .8, R = 12, T = 24, minfup = 12,
+    ratio = 1, testLower = testLower
+  )
+}
+
+check_exact_skipped_futility <- function(x, out) {
+  expect_true(all(diff(out$upper$bound) >= 0))
+  expect_true(all(diff(out$n.I - out$upper$bound) >= 0))
+  expect_true(all(out$upper$bound > out$lower$bound))
+  expect_identical(out$testLower, x$testLower)
+  inactive <- which(!out$testLower)
+  expect_true(all(abs(out$upper$prob[inactive, , drop = FALSE]) < 1e-12))
+  for (j in inactive) {
+    expected <- if (j == 1) out$n.I[j] + 1 else {
+      out$n.I[j] - out$n.I[j - 1] + out$upper$bound[j - 1]
+    }
+    expect_equal(out$upper$bound[j], expected)
+  }
+  nb <- gsBinomialExact(
+    k = out$k, theta = out$theta[1], n.I = out$n.I,
+    a = out$lower$bound, b = out$n.I + 1
+  )
+  alpha_target <- x$upper$sf(out$alpha, out$usTime, x$upper$param)$spend
+  expect_true(all(cumsum(nb$lower$prob[, 1]) <= alpha_target + 1e-10))
+  beta_target <- x$lower$sf(x$beta, out$lsTime, x$lower$param)$spend
+  for (j in seq_len(out$k)) if (!out$testLower[j]) {
+    beta_target[j] <- if (j == 1) 0 else beta_target[j - 1]
+  }
+  expect_true(all(cumsum(out$upper$prob[, 2]) <= beta_target + 1e-10))
+}
+
+test_that("the reported Type 4 skipped-futility example converts successfully", {
+  x <- skipped_futility_design()
+  out <- toBinomialExact(x)
+  check_exact_skipped_futility(x, out)
+  expect_equal(out$n.I, c(29, 47, 62))
+  expect_equal(out$upper$bound, c(12, 30, 45))
+  target <- x$lower$sf(x$beta, out$lsTime[1], x$lower$param)$spend
+  expect_gt(pbinom(10, 29, out$theta[2], lower.tail = FALSE), target)
+})
+
+test_that("all patterns of skipped Type 4 looks preserve exact spending", {
+  patterns <- expand.grid(rep(list(c(FALSE, TRUE)), 3))
+  for (i in seq_len(nrow(patterns))) {
+    flags <- as.logical(patterns[i, ])
+    if (!any(flags)) next # Type 4 requires at least one lower-bound test.
+    x <- skipped_futility_design(flags)
+    out <- toBinomialExact(x)
+    check_exact_skipped_futility(x, out)
+    # Same information and efficacy spending, with futility enabled everywhere.
+    all_active <- x
+    all_active$testLower <- rep(TRUE, x$k)
+    ref <- toBinomialExact(all_active)
+    expect_equal(out$lower$bound, ref$lower$bound)
+  }
+})
+
+test_that("skipped futility is retained with actual-event and spending overrides", {
+  x <- skipped_futility_design()
+  for (alpha in c(.025, .01)) {
+    out <- toBinomialExact(x, observedEvents = c(25, 45, 60), alpha = alpha,
+      usTime = c(.4, .7, .95), lsTime = c(.4, .7, .95), maxSpend = TRUE)
+    check_exact_skipped_futility(x, out)
+    expect_equal(out$n.I, c(25, 45, 60))
+    expect_equal(out$usTime, c(.4, .7, 1))
+    expect_equal(out$lsTime, c(.4, .7, 1))
+  }
+})


### PR DESCRIPTION
Closes #333. Stacked after #337; retarget to master after that PR merges.

At inactive Type 4 futility looks, carry the n.I - b gap forward to make crossing impossible. Evaluate beta spending only through the current calibrated look, using the direct binomial tail at IA1 instead of validating an unfinished IA2 boundary.

Validation:
- 101 new regression checks pass: reported example, all seven permitted three-look testing patterns, actual-event/spending/alpha overrides, monotone boundaries, zero skipped-look crossing probabilities, and exact non-binding alpha and beta-spending checks.
- Existing exact conversion, binomial recursion and integer-conversion tests pass.
- Representative all-active designs have identical boundaries and probabilities to master for types 1, 4, 6 and 8.
- Final full unit suite passes in standard CRAN mode; snapshot-enabled suite was also run, with intended reporting snapshots updated and only two pre-existing power-plot SVG legend-order differences remaining (confirmed on untouched master).
- Documentation regenerated and source package build succeeds. Unintended snapshot deletions from testthat were restored.