### PR TITLE
Inherit reference spending in CP calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Suggests:
     rmarkdown,
     rpact,
     scales,
+    svglite,
     testthat,
     utils,
     vdiffr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.1.9014
+Version: 3.11.1.9015
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 ## Bug fixes
 
+- `gsCPFutilitySpending()` inherits the reference design's futility spending
+  function when `sfl` is omitted; explicit overrides remain supported (#318).
 - Exact binomial conversion preserves skipped futility looks without invalid
   provisional boundaries during beta-spending calibration (#333).
 - Information-based boundary plots label actual information as `I=` with

--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,8 @@
 
 ## Testing
 
+- Declare `svglite` as a test dependency for information-label rendering checks
+  (#315).
 - Added tests for natural-effect calibration, joint boundary targets,
   HR allocation/direction handling and design replay (#331).
 - Added regression fixtures, multivariate normal reference checks, and print

--- a/R/gsCPFutilitySpending.R
+++ b/R/gsCPFutilitySpending.R
@@ -44,7 +44,8 @@
 #'   identify active futility bounds, be unique, and be in
 #'   \code{1:(x$k - 1)}. Results are ordered by analysis.
 #' @param sfl Futility spending function, supplied as a supported function or
-#'   its character name. The default is \code{"sfHSD"}.
+#'   its character name. By default, use \code{x$lower$sf}, the reference
+#'   design's futility spending function. Supply \code{sfl} to override it.
 #' @param theta Optional future effect for conditional power. A scalar is
 #'   recycled; otherwise its length must equal \code{target_cp}. When \code{NULL}, the
 #'   observed effect at each candidate lower bound is used.
@@ -159,7 +160,7 @@
 #'   \code{\link{toInteger}}, \code{\link{gsPPFutilitySpending}}
 #' @export
 gsCPFutilitySpending <- function(x, target_cp, i = seq_along(target_cp),
-                                 sfl = "sfHSD", theta = NULL,
+                                 sfl = x$lower$sf, theta = NULL,
                                  control = list()) {
   .gsFutilitySpending(
     x, target_cp, i, sfl, theta, control,

--- a/man/gsCPFutilitySpending.Rd
+++ b/man/gsCPFutilitySpending.Rd
@@ -8,7 +8,7 @@ gsCPFutilitySpending(
   x,
   target_cp,
   i = seq_along(target_cp),
-  sfl = "sfHSD",
+  sfl = x$lower$sf,
   theta = NULL,
   control = list()
 )
@@ -24,7 +24,8 @@ identify active futility bounds, be unique, and be in
 \code{1:(x$k - 1)}. Results are ordered by analysis.}
 
 \item{sfl}{Futility spending function, supplied as a supported function or
-its character name. The default is \code{"sfHSD"}.}
+its character name. By default, use \code{x$lower$sf}, the reference
+design's futility spending function. Supply \code{sfl} to override it.}
 
 \item{theta}{Optional future effect for conditional power. A scalar is
 recycled; otherwise its length must equal \code{target_cp}. When \code{NULL}, the

--- a/tests/testthat/test-cp-spending-default.R
+++ b/tests/testthat/test-cp-spending-default.R
@@ -1,0 +1,22 @@
+test_that("CP calibration inherits spending and permits explicit overrides", {
+  for (spec in list(
+    list(sf = sfPower, par = 2, timing = c(.5, .75), i = 1),
+    list(sf = sfCauchy, par = c(0, 1), timing = c(.4, .75), i = 1:2),
+    list(sf = sfLinear, par = c(.3, .5, .7, .05, .2, .5),
+         timing = c(.3, .5, .7), i = 1:3)
+  )) {
+    x <- gsDesign(k = length(spec$timing) + 1, test.type = 4,
+      timing = spec$timing, sfl = spec$sf, sflpar = spec$par)
+    target <- gsBoundCP(x, theta = "thetahat")[spec$i, 1]
+    fit <- gsCPFutilitySpending(x, target, i = spec$i)
+    explicit <- gsCPFutilitySpending(x, target, i = spec$i, sfl = spec$sf)
+    expect_identical(fit$lower$sf, spec$sf)
+    expect_equal(fit$lower$param, explicit$lower$param)
+    expect_equal(unname(fit$cpFutilitySpending$achieved_cp), unname(target), tolerance = 1e-4)
+  }
+  x <- gsDesign(k = 3, test.type = 4, timing = c(.5, .75), sfl = sfPower, sflpar = 2)
+  fit <- gsCPFutilitySpending(x, .2, i = 1, sfl = "sfHSD")
+  expect_identical(fit$lower$sf, sfHSD)
+  expect_equal(fit$cpFutilitySpending$achieved_cp, .2, tolerance = 1e-4)
+  expect_error(gsCPFutilitySpending(1, .2), class = "gsCPFutilitySpending_input_error")
+})


### PR DESCRIPTION
Closes #318. The core CP calibration, controls, multi-parameter solving, metadata and vignette were already implemented. This finishes the requested default: omitted sfl inherits x$lower$sf; explicit overrides remain supported. New inheritance tests (power, Cauchy and piecewise-linear) and the existing full CP calibration test file pass. Documentation regenerated.