### PR TITLE
Print full spending function parameters in print.gsSurv (#307)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gsDesign
-Version: 3.11.1.9017
+Version: 3.11.1.9018
 Title: Group Sequential Design
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,9 @@
 
 ## Bug fixes
 
+- `print.gsSurv()` no longer truncates spending function parameters with
+  decimal values, such as the t-distribution parameters printed as
+  `a = -1.63774, b = 2.96683, df = 3` (#307).
 - `gsCPFutilitySpending()` inherits the reference design's futility spending
   function when `sfl` is omitted; explicit overrides remain supported (#318).
 - Exact binomial conversion preserves skipped futility looks without invalid

--- a/R/gsSurv.R
+++ b/R/gsSurv.R
@@ -329,9 +329,14 @@ print.gsSurv <- function(x, digits = 3, show_gsDesign = FALSE, show_strata = TRU
 
   # Spending function summary (extracted from summary())
   summ_text <- summary(x)
-  # Extract spending function sentences
-  spending_parts <- unlist(strsplit(summ_text, "\\."))
+  # Extract spending function sentences. Split on sentence boundaries (a period
+  # followed by whitespace) rather than bare periods so that decimal values in
+  # spending function parameters (e.g. the t-distribution parameters printed as
+  # "a = -1.63774, b = 2.96683, df = 3") are not truncated (GitHub issue #307).
+  spending_parts <- unlist(strsplit(summ_text, "(?<=\\.)\\s+", perl = TRUE))
   spending_parts <- grep("spending function", spending_parts, ignore.case = TRUE, value = TRUE)
+  # Drop any trailing period left on the final sentence for consistent formatting
+  spending_parts <- sub("\\.$", "", spending_parts)
   if (length(spending_parts) > 0) {
     cat("\nSpending functions:\n")
     for (part in spending_parts) {

--- a/tests/testthat/_snaps/independent-test-print.gsSurv.md
+++ b/tests/testthat/_snaps/independent-test-print.gsSurv.md
@@ -80,7 +80,7 @@
     
     Spending functions:
       Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4.
-      Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.
+      Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.5.
     
     Analysis summary:
         Analysis              Value Efficacy Futility
@@ -163,7 +163,7 @@
     
     Spending functions:
       Efficacy bounds derived using a Hwang-Shih-DeCani spending function with gamma = -4.
-      Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.
+      Futility bounds derived using a Kim-DeMets (power) spending function with rho = 0.5.
     
     Analysis summary:
         Analysis              Value Efficacy Futility

--- a/tests/testthat/test-developer-test-print-gsSurv-tdist-307.R
+++ b/tests/testthat/test-developer-test-print-gsSurv-tdist-307.R
@@ -1,0 +1,22 @@
+test_that("print.gsSurv prints full t-distribution spending parameters (issue #307)", {
+  # The t-distribution spending function has parameters with decimal values.
+  # print.gsSurv previously split the summary on bare periods, truncating
+  # "a = -1.63774" to "a = -1". Verify all three parameters are printed.
+  x <- gsSurv(
+    k = 3, test.type = 4, alpha = 0.025, beta = 0.1, timing = 1,
+    sfu = sfTDist, sfupar = c(0.2, 0.5, 0.01, 0.1, 3),
+    sfl = sfLDOF, sflpar = 0,
+    lambdaC = log(2) / 6, hr = 0.6, hr0 = 1, eta = 0.01,
+    gamma = c(2.5, 5, 7.5, 10), R = c(2, 2, 2, 6), T = 18, minfup = 6, ratio = 1
+  )
+  out <- paste(capture.output(print(x)), collapse = "\n")
+
+  # The full t-distribution parameter sentence must appear intact.
+  expect_match(
+    out,
+    "t-distribution spending function with a = -1.63774, b = 2.96683, df = 3",
+    fixed = TRUE
+  )
+  # And it must not be truncated to just the first (integer) digit.
+  expect_false(grepl("spending function with a = -1\\.\\n", out))
+})


### PR DESCRIPTION
## Summary

Fixes #307. `print.gsSurv()` truncated spending-function parameters that contain decimal values. For the t-distribution spending function (`sfTDist`, "3 Parameters" in the Shiny app), the output showed only `a = -1.` instead of the full `a = -1.63774, b = 2.96683, df = 3`.

## Root cause

`print.gsSurv()` builds the "Spending functions:" block by extracting sentences from `summary(x)` via `strsplit(summ_text, "\\.")` — a split on **bare periods**. Decimal parameter values (`-1.63774`) contain periods, so the split shredded the number and the surviving fragment was the truncated `...a = -1`. `print.gsDesign()` (the binomial path) uses different code and was unaffected, which is why the bug only appeared for time-to-event designs.

## Fix

Split on sentence boundaries (a period followed by whitespace, `(?<=\\.)\\s+`) rather than bare periods, so decimals inside parameter values are preserved. A trailing period is stripped and re-added for consistent formatting.

## Verification

Before:
```
Spending functions:
  Efficacy bounds derived using a t-distribution spending function with a = -1.
```
After:
```
Spending functions:
  Efficacy bounds derived using a t-distribution spending function with a = -1.63774, b = 2.96683, df = 3.
```

- Added regression test `test-developer-test-print-gsSurv-tdist-307.R`.
- Updated the `independent-test-print.gsSurv` snapshot: the old snapshot itself encoded the bug (`rho = 0.` for a `sfPower` design with `sflpar = .5`); it now correctly reads `rho = 0.5`.
- Existing `print.gsSurv` tests pass; non-decimal spending functions (HSD `gamma = -4`, LDOF) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)